### PR TITLE
docs: スキルマップ一元リファレンス追加 (Phase 13)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 |-------------|------|
 | [PHILOSOPHY.md](PHILOSOPHY.md) | 開発フロー哲学。Claude + Codex 統合、承認ゲート、Findings判断 |
 | [ROADMAP.md](ROADMAP.md) | Phase 11+。sync-plan移行、Codex委譲、ドキュメント整備 |
+| [skill-map.md](skill-map.md) | スキル/エージェント/ゲートの一元リファレンス。フロー上の位置と担当 |
 | [document-hierarchy.md](document-hierarchy.md) | 権威階層とファイル配置マップ |
 | [architecture.md](architecture.md) | システム設計。Phase-Boundary Compaction、Token最適化 |
 | [test-architecture-integration.md](test-architecture-integration.md) | テストアーキテクチャ統合の検討と採用方針 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -224,7 +224,7 @@ onboard がプロジェクトに生成するディレクトリ構成を、どこ
 - CLAUDE.md: REFACTOR主従明記、Usage Patterns整合
 - architecture.md: フロー図にゲート追加、ハードコード数値削除
 
-## Phase 13: スキルマップ
+## Phase 13: スキルマップ (完了)
 
 各スキルが開発フローのどこで、誰（Claude/Codex）が使うかを明示する。決定論的ゲートをフロー上の位置に含める。
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,9 +5,9 @@
 | Metric | Value |
 |--------|-------|
 | In-Progress Cycles | 0 |
-| Done (unarchived) | 17 |
+| Done (unarchived) | 18 |
 | Archived Cycles | 37 |
-| Test Scripts | 76 |
+| Test Scripts | 77 |
 
 Last updated: 2026-03-16
 
@@ -45,7 +45,7 @@ None
 - [x] 11.8 付属スキルの差し込み位置整理（P2）
 - [x] 11.9 ディレクトリ構成の AI-Driven 標準化（P3）
 - [ ] Phase 12 ドキュメント体系整備（P2）
-- [ ] Phase 13 スキルマップ確定（P2）
+- [x] Phase 13 スキルマップ確定（P2）
 
 詳細は [ROADMAP.md](ROADMAP.md) 参照。
 

--- a/docs/cycles/20260316_0053_phase13_skill_map.md
+++ b/docs/cycles/20260316_0053_phase13_skill_map.md
@@ -1,0 +1,64 @@
+# Phase 13: スキルマップ確定
+
+## Metadata
+
+| Key | Value |
+|-----|-------|
+| Status | DONE |
+| Phase | COMMIT |
+| Created | 2026-03-16 |
+| Branch | feat/phase-13-skill-map |
+| Risk | 10 (PASS) |
+
+## Context
+
+Phase 11 (実装) + Phase 12 (ドキュメント整備) 完了。スキル29個、エージェント34個、ゲート3個が全て実装済みだが、「どのスキルがフローのどこで、誰（Claude/Codex）が使うか」の一元的なリファレンスが存在しない。
+
+## Scope
+
+### In Scope
+
+- `docs/skill-map.md`: 新規作成。TDDフローに沿ったスキルマップ + フロー外スキル一覧
+- `docs/README.md`: skill-map.md へのリンク追加
+- `docs/ROADMAP.md`: Phase 13 完了マーク
+- `docs/STATUS.md`: テスト数・日付更新
+- `tests/test-skill-map.sh`: 新規テスト
+
+### Out of Scope
+
+- PHILOSOPHY.md の変更
+- architecture.md の変更
+- 各スキルの SKILL.md / reference.md 変更
+
+## Test List
+
+- [x] T-01: docs/skill-map.md が存在する
+- [x] T-02: skill-map.md に TDD Workflow Skills テーブルがある（`pre-red-gate` を含む）
+- [x] T-03: skill-map.md に TDD Workflow Skills テーブルがある（`pre-commit-gate` を含む）
+- [x] T-04: skill-map.md に Support Skills テーブルがある（`phase-compact` を含む）
+- [x] T-05: skill-map.md に PHILOSOPHY.md 参照がある
+- [x] T-06: skill-map.md にハードコード数値がない（`34 agents|29 skills` が存在しない）
+- [x] T-07: docs/README.md に skill-map への参照がある
+- [x] T-08: ROADMAP.md Phase 13 に完了マークがある
+
+## Design
+
+### docs/skill-map.md 構成
+
+1. ヘッダ: Authority 宣言（PHILOSOPHY.md）、Counts は STATUS.md 参照
+2. TDD Workflow Skills: フロー順テーブル（Phase / Skill|Gate / Primary / Fallback / Notes）
+3. Support Skills: カテゴリ別テーブル（Category / Skill / Purpose）
+
+## Phase Summary
+
+### RED
+tests/test-skill-map.sh 作成。8テスト、7 FAIL 確認。
+
+### GREEN
+docs/skill-map.md 新規作成、docs/README.md リンク追加、ROADMAP.md 完了マーク、STATUS.md 更新。8/8 PASS。
+
+### REFACTOR
+構造シンプル、追加改善不要。
+
+### REVIEW
+correctness-reviewer: blocking_score 28 (PASS)。Cycle doc 状態不整合を修正。

--- a/docs/skill-map.md
+++ b/docs/skill-map.md
@@ -1,0 +1,42 @@
+# Skill Map
+
+> Authority: [PHILOSOPHY.md](PHILOSOPHY.md) のフロー図が正。このドキュメントはスキル/エージェント/ゲートの実装リファレンス。
+> Counts: [STATUS.md](STATUS.md) 参照。
+
+## TDD Workflow Skills
+
+| Phase | Skill/Gate | Primary | Fallback | Notes |
+|-------|-----------|---------|----------|-------|
+| 企画 | strategy | Claude | - | |
+| 設計 | spec | Claude | - | 曖昧性検出内蔵 |
+| plan review | review --plan | Codex | Claude | competitive |
+| Cycle doc生成 | sync-plan | Claude | - | agent |
+| **pre-red-gate.sh** | **(決定論的)** | **script** | **-** | Cycle doc存在・sync-plan完了・Plan Review記録を検証 |
+| テスト作成 | red | Codex | Claude | codex_mode依存 |
+| テスト静的解析 | exspec | (tool) | skip | 未インストール時skip |
+| 実装 | green | Codex | Claude | codex_mode依存 |
+| 品質改善 | refactor | Claude | Codex | |
+| レビュー | review | Claude+Codex | Claude | competitive |
+| **pre-commit-gate.sh** | **(決定論的)** | **script** | **-** | REVIEW完了・Codex review記録・STATUS.md同期を検証 |
+| コミット | commit | Claude | - | |
+
+## Support Skills
+
+| Category | Skill | Purpose |
+|----------|-------|---------|
+| Context | phase-compact | Phase境界でCycle docに永続化 |
+| Context | reload | compact後のコンテキスト復元 |
+| Orchestration | orchestrate | TDDサイクル全体の自律管理 |
+| Diagnostic | diagnose | 複雑なバグの並列仮説調査 |
+| Diagnostic | parallel | クロスレイヤー並列開発 |
+| Setup | onboard | プロジェクトTDD初期化 |
+| Setup | skill-maker | スキル作成支援 |
+| Setup | sync-skills | Codex用symlinkセットアップ |
+| Security | security-scan | 脆弱性検出 |
+| Security | security-audit | スキャン+レポート一括 |
+| Security | attack-report | レポート生成 |
+| Security | context-review | 誤検知確認 |
+| Security | generate-e2e | E2Eテスト自動生成 |
+| Meta | learn | セッションパターン抽出 |
+| Meta | evolve | instinctからスキル自動進化 |
+| Language | *-quality | 言語別品質チェック (auto) |

--- a/tests/test-skill-map.sh
+++ b/tests/test-skill-map.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# test-skill-map.sh - docs/skill-map.md の構造検証テスト (Phase 13)
+# T-01 ~ T-08
+
+set -euo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf "  \033[32mPASS\033[0m %s\n" "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf "  \033[31mFAIL\033[0m %s\n" "$1"; }
+
+SKILL_MAP="$BASE_DIR/docs/skill-map.md"
+README="$BASE_DIR/docs/README.md"
+ROADMAP="$BASE_DIR/docs/ROADMAP.md"
+
+echo "=== Skill Map Tests ==="
+echo ""
+
+# T-01: Given docs/, Then skill-map.md が存在する
+echo "T-01: docs/skill-map.md exists"
+if [ -f "$SKILL_MAP" ]; then
+  pass "T-01: skill-map.md exists"
+else
+  fail "T-01: skill-map.md does not exist"
+fi
+
+# T-02: Given skill-map.md, Then TDD Workflow Skills テーブルに pre-red-gate がある
+echo ""
+echo "T-02: skill-map.md has pre-red-gate in TDD Workflow Skills"
+if grep -q 'pre-red-gate' "$SKILL_MAP" 2>/dev/null; then
+  pass "T-02: pre-red-gate found"
+else
+  fail "T-02: pre-red-gate not found"
+fi
+
+# T-03: Given skill-map.md, Then TDD Workflow Skills テーブルに pre-commit-gate がある
+echo ""
+echo "T-03: skill-map.md has pre-commit-gate in TDD Workflow Skills"
+if grep -q 'pre-commit-gate' "$SKILL_MAP" 2>/dev/null; then
+  pass "T-03: pre-commit-gate found"
+else
+  fail "T-03: pre-commit-gate not found"
+fi
+
+# T-04: Given skill-map.md, Then Support Skills テーブルに phase-compact がある
+echo ""
+echo "T-04: skill-map.md has phase-compact in Support Skills"
+if grep -q 'phase-compact' "$SKILL_MAP" 2>/dev/null; then
+  pass "T-04: phase-compact found"
+else
+  fail "T-04: phase-compact not found"
+fi
+
+# T-05: Given skill-map.md, Then PHILOSOPHY.md への参照がある
+echo ""
+echo "T-05: skill-map.md references PHILOSOPHY.md"
+if grep -q 'PHILOSOPHY.md' "$SKILL_MAP" 2>/dev/null; then
+  pass "T-05: PHILOSOPHY.md reference found"
+else
+  fail "T-05: PHILOSOPHY.md reference not found"
+fi
+
+# T-06: Given skill-map.md, Then ハードコード数値がない
+echo ""
+echo "T-06: skill-map.md has no hardcoded agent/skill counts"
+if grep -qE '34 agents|29 skills' "$SKILL_MAP" 2>/dev/null; then
+  fail "T-06: hardcoded counts found"
+else
+  pass "T-06: no hardcoded counts"
+fi
+
+# T-07: Given docs/README.md, Then skill-map への参照がある
+echo ""
+echo "T-07: docs/README.md references skill-map"
+if grep -q 'skill-map' "$README" 2>/dev/null; then
+  pass "T-07: skill-map reference found in README.md"
+else
+  fail "T-07: skill-map reference not found in README.md"
+fi
+
+# T-08: Given ROADMAP.md, Then Phase 13 に完了マークがある
+echo ""
+echo "T-08: ROADMAP.md Phase 13 has completion mark"
+if grep -qE 'Phase 13.*完了|スキルマップ.*完了|スキルマップ.*\(完了\)' "$ROADMAP" 2>/dev/null; then
+  pass "T-08: Phase 13 completion mark found"
+else
+  fail "T-08: Phase 13 completion mark not found"
+fi
+
+# Summary
+echo ""
+echo "=== Summary ==="
+echo "PASS: $PASS / FAIL: $FAIL / TOTAL: $((PASS + FAIL))"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- `docs/skill-map.md` 新規作成: TDD Workflow Skills + Support Skills の一元リファレンス
- PHILOSOPHY.md のフロー図と整合した2セクション構成（決定論的ゲート含む）
- `tests/test-skill-map.sh`: 8テストケース追加
- docs/README.md, ROADMAP.md, STATUS.md 更新

## Test plan

- [x] `bash tests/test-skill-map.sh` 8/8 PASS
- [x] 既存テスト回帰なし
- [x] correctness-reviewer: blocking_score 28 (PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)