### PR TITLE
feat: v2.4 Phase 16 Plan Review 強化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Cycle docs: `docs/cycles/YYYYMMDD_HHMM_<topic>.md`
 
 ```
 dev-crew/
-├── agents/          # 37 agents (flat), 21 security agents
+├── agents/          # 40 agents (flat), 21 security agents
 ├── skills/          # Skills (each: SKILL.md + reference.md)
 ├── scripts/gates/   # Deterministic gate scripts (pre-red, pre-commit)
 ├── rules/           # Always-applied rules (git-safety, security, git-conventions)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@
 ## 現在地
 
 v2.3.0 リリース済み。v3 (Constitution-Driven Development) Phase 1-7 完了。
-v4 は Review Taxonomy 体系化。セキュリティの OWASP アプローチを Plan/Test/Code Review に適用する。
+v2.4 は Review Taxonomy 体系化。セキュリティの OWASP アプローチを Plan/Test/Code Review に適用する。
 
 ## v3: Constitution-Driven Development
 
@@ -53,7 +53,7 @@ migration 支援（philosophy.md スキャン、CLAUDE.md 肥大化検出）。
 
 ---
 
-## v4: Review Taxonomy 体系化
+## v2.4: Review Taxonomy 体系化
 
 セキュリティレビューが OWASP Top 10 / CWE Top 25 に基づく 19 attacker agent で体系化されているのに対し、Plan Review / Test Review / Code Review は汎用的な観点のみだった。権威ある参照元に基づき、専門 reviewer agent を体系的に追加する。
 
@@ -247,11 +247,11 @@ Risk-gated（risk-classifier.sh 判定時のみ）:
 
 Phase 13 のスキルマップに新 agent の位置を追加。
 
-#### 17.4 リリース (v4.0.0)
+#### 17.4 リリース (v2.4.0)
 
 ### 統廃合サマリ
 
-| Agent | 現状 | v4 後 | 変更 |
+| Agent | 現状 | v2.4 後 | 変更 |
 |-------|------|-------|------|
 | design-reviewer | Plan: スコープ + アーキ + リスク | Plan: スコープ + アーキ + リスク + 過剰設計 | risk 維持、過剰設計追加 |
 | product-reviewer | Plan: ビジネス判断 | 維持 | - |
@@ -293,7 +293,7 @@ Phase 17: 統合・リリース
   17.1 段階的統合テスト（全 agent 横断）
   17.2 review スキル統合
   17.3 スキルマップ更新
-  17.4 v4.0.0 リリース
+  17.4 v2.4.0 リリース
 ```
 
 ### 参照元一覧

--- a/agents/change-safety-reviewer.md
+++ b/agents/change-safety-reviewer.md
@@ -1,0 +1,29 @@
+---
+name: change-safety-reviewer
+description: ロールバック安全性・マイグレーション安全性レビュー。破壊的変更の検出と安全なデプロイ戦略を検証。
+model: sonnet
+memory: project
+---
+
+## Focus
+
+| 観点 | チェック内容 | 参照元 |
+|------|------------|--------|
+| Deploy Rollback | ロールバック手順の有無、前バージョンとの互換性 | Fowler Parallel Change |
+| Schema Migration | 破壊的スキーマ変更、expand-contract パターン準拠 | Fowler Evolutionary DB Design |
+| Feature Flag | 段階的ロールアウト戦略、フラグのライフサイクル | Fowler Feature Toggles |
+| Blast Radius | 影響範囲の限定、段階デプロイ可能性 | - |
+| Irreversible Steps | 元に戻せない操作の検出（データ削除、暗号化変更） | - |
+
+## design-reviewer との分担
+
+design-reviewer は risk フラグ（breaking changes の有無）を出す。change-safety-reviewer はその深掘り（どう安全にデプロイするか）を担当。
+
+## Output
+
+`{"blocking_score": 0-100, "issues": [{"severity": "critical|important|optional", "category": "rollback|migration|feature-flag|blast-radius|irreversible", "message", "suggestion"}]}`
+
+## ブロッキングスコア基準
+
+blocking_score: パイプラインをブロックすべき度合い（0 = 問題なし, 100 = ブロック必須）
+80-100→BLOCK | 50-79→WARN | 0-49→PASS

--- a/agents/design-reviewer.md
+++ b/agents/design-reviewer.md
@@ -5,10 +5,10 @@ model: sonnet
 ---
 
 ## Focus
-Scope validity (YAGNI, file count <=10) | Architecture consistency (patterns, layers) | Risk (impact, breaking changes, rollback) | Upstream consistency (requirements/ROADMAP alignment, term consistency)
+Scope validity (YAGNI, file count <=10) | Architecture consistency (patterns, layers) | Risk (impact, breaking changes, rollback) | Upstream consistency (requirements/ROADMAP alignment, term consistency) | Over-engineering (Speculative Generality, 1-caller interfaces, unused config params)
 
 ## Output
-`{"blocking_score": 0-100, "issues": [{"severity": "critical|important|optional", "category": "scope|architecture|risk|upstream", "message", "suggestion"}]}`
+`{"blocking_score": 0-100, "issues": [{"severity": "critical|important|optional", "category": "scope|architecture|risk|upstream|over-engineering", "message", "suggestion"}]}`
 
 ## ブロッキングスコア基準
 blocking_score: パイプラインをブロックすべき度合い（0 = 問題なし, 100 = ブロック必須）

--- a/agents/impact-reviewer.md
+++ b/agents/impact-reviewer.md
@@ -1,0 +1,24 @@
+---
+name: impact-reviewer
+description: 変更の連鎖影響と破壊範囲を分析。依存モジュール、公開API変更、SPOF生成、循環依存を検出。
+model: sonnet
+memory: project
+---
+
+## Focus
+
+| 観点 | チェック内容 | 参照元 |
+|------|------------|--------|
+| 依存分析 | 変更が影響する下流モジュールの列挙 | C4 Model |
+| 公開 API | 外部公開インターフェースの変更有無 | C4 Model |
+| SPOF | 単一障害点の生成・悪化 | SEI ATAM |
+| 循環依存 | 新たな循環依存の導入 | SEI ATAM |
+
+## Output
+
+`{"blocking_score": 0-100, "issues": [{"severity": "critical|important|optional", "category": "dependency|public-api|spof|circular-dep", "message", "suggestion"}]}`
+
+## ブロッキングスコア基準
+
+blocking_score: パイプラインをブロックすべき度合い（0 = 問題なし, 100 = ブロック必須）
+80-100→BLOCK | 50-79→WARN | 0-49→PASS

--- a/agents/resiliency-reviewer.md
+++ b/agents/resiliency-reviewer.md
@@ -1,0 +1,24 @@
+---
+name: resiliency-reviewer
+description: 耐障害性・カスケード障害防止レビュー。タイムアウト、リトライ戦略、サーキットブレーカーを検証。
+model: sonnet
+memory: project
+---
+
+## Focus
+
+| 観点 | チェック内容 | 参照元 |
+|------|------------|--------|
+| タイムアウト | 外部呼び出しのタイムアウト設定有無 | AWS Well-Architected Reliability |
+| リトライ戦略 | exponential backoff + jitter の採用 | Google SRE Book |
+| サーキットブレーカー | 障害伝播防止パターンの有無 | AWS Well-Architected Reliability |
+| カスケード障害 | 連鎖的な障害の防止策 | Google SRE Book |
+
+## Output
+
+`{"blocking_score": 0-100, "issues": [{"severity": "critical|important|optional", "category": "timeout|retry|circuit-breaker|cascade", "message", "suggestion"}]}`
+
+## ブロッキングスコア基準
+
+blocking_score: パイプラインをブロックすべき度合い（0 = 問題なし, 100 = ブロック必須）
+80-100→BLOCK | 50-79→WARN | 0-49→PASS

--- a/agents/test-reviewer.md
+++ b/agents/test-reviewer.md
@@ -37,6 +37,17 @@ blocking_score: パイプラインをブロックすべき度合い（0 = 問題
 | 例外処理の存在有無 | correctness | try/catch が必須だが未実装 |
 | エッジケース漏れ | correctness | 空配列、ゼロ除算 |
 
+## Plan Mode Focus
+
+| 観点 | チェック内容 | 参照元 |
+|------|------------|--------|
+| TC カバレッジ | Scope 項目あたりの TC 数が十分か | Google SWE Book Ch12 |
+| 異常系 TC | エラーケース・境界値の TC 有無 | xUnit Test Patterns |
+| テスト独立性 | TC 間の依存関係がないか | Google SWE Book Ch11 |
+| Given/When/Then | テスト設計形式の準拠 | - |
+
+起動条件: Always-on (Plan mode)
+
 ## Memory
 
 Record: プロジェクト固有のテストパターン、テストヘルパー/fixture の場所、既知のテストスメル。

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,10 +4,10 @@
 
 | Metric | Value |
 |--------|-------|
-| In-Progress Cycles | 1 |
-| Done (unarchived) | 20 |
+| In-Progress Cycles | 0 |
+| Done (unarchived) | 21 |
 | Archived Cycles | 37 |
-| Test Scripts | 86 |
+| Test Scripts | 87 |
 
 Last updated: 2026-03-17
 
@@ -15,11 +15,12 @@ Last updated: 2026-03-17
 
 | Date | Cycle | Type |
 |------|-------|------|
-| 2026-03-17 | v4 Phase 15.3: Socrates review pipeline 統合 | feat |
-| 2026-03-17 | v4 Phase 15.1: test-reviewer 新設 | feat |
-| 2026-03-16 | v4 Phase 14.4: performance-reviewer 強化 | feat |
-| 2026-03-16 | v4 Phase 14.3: observability-reviewer 新設 | feat |
-| 2026-03-16 | v4 Phase 14.2: api-contract-reviewer 新設 | feat |
+| 2026-03-17 | v2.4 Phase 16: Plan Review 強化 | feat |
+| 2026-03-17 | v2.4 Phase 15.3: Socrates review pipeline 統合 | feat |
+| 2026-03-17 | v2.4 Phase 15.1: test-reviewer 新設 | feat |
+| 2026-03-16 | v2.4 Phase 14.4: performance-reviewer 強化 | feat |
+| 2026-03-16 | v2.4 Phase 14.3: observability-reviewer 新設 | feat |
+| 2026-03-16 | v2.4 Phase 14.2: api-contract-reviewer 新設 | feat |
 | 2026-03-16 | v3 Phase 7: onboard CONSTITUTION 対応 (#75) | feat |
 | 2026-03-16 | v3 Phase 6: CONSTITUTION authority migration (#75) | feat |
 | 2026-03-15 | v2.1.0 決定論的ゲート強化 + Review品質改善 (#58-#66) | feat |
@@ -42,9 +43,7 @@ Last updated: 2026-03-17
 
 ## In Progress
 
-| Date | Cycle | Phase |
-|------|-------|-------|
-| 2026-03-17 | v4 Phase 15.3: Socrates review pipeline 統合 | COMMIT |
+(none)
 
 ## TODO
 

--- a/skills/review/reference.md
+++ b/skills/review/reference.md
@@ -26,6 +26,9 @@ SKILL.mdの詳細情報。必要時のみ参照。
 | 変更行数 > 200 | +20 | diff 行数 |
 | UI コンポーネント変更 | +10 | ファイルパスに component/view/page/.vue/.tsx 等 |
 | テストファイル変更 | +10 | ファイルパスに test/spec/__tests__ 等 |
+| スキーマ/migration 変更 | +20 | ファイルパスに migration/schema/model 等 |
+| 外部通信パターン | +15 | diff に fetch/axios/requests/HttpClient 等 |
+| 広範囲変更 (dir spread>=3) | +15 | 変更ファイルのディレクトリ分散度 >= 3 |
 
 ### Level 判定
 
@@ -56,11 +59,15 @@ SKILL.mdの詳細情報。必要時のみ参照。
 |-------|-------|-----------|
 | review-briefer | Haiku | Always |
 | design-reviewer | Sonnet | Always |
+| test-reviewer | Sonnet | Always (Plan mode) |
 | security-reviewer | Sonnet | If auth/security flags |
 | product-reviewer | Haiku | If API/user-facing flags |
 | performance-reviewer | Sonnet | If DB/perf flags |
 | usability-reviewer | Haiku | If UI flags |
 | designer | Sonnet | If UI + UI tech stack |
+| change-safety-reviewer | Sonnet | If migration/schema flags |
+| impact-reviewer | Sonnet | If wide-change flags |
+| resiliency-reviewer | Sonnet | If external-comm flags |
 
 ## Agent Roster (Code Mode)
 

--- a/skills/review/risk-classifier.sh
+++ b/skills/review/risk-classifier.sh
@@ -12,6 +12,9 @@
 #   line count > 200            +20
 #   UI component changes        +10
 #   test file changes            +10
+#   schema/migration changes     +20
+#   external communication       +15
+#   wide change (dir spread>=3)  +15
 #
 # Thresholds:
 #   0-29:  LOW
@@ -69,6 +72,17 @@ if [ -f "$FILES_LIST" ]; then
       score=$((score - 15))
     fi
   fi
+
+  # Schema/migration file changes (+20)
+  if grep -qiE 'migration|schema|\.migrate\.|model.*field|alter.table' "$FILES_LIST" 2>/dev/null; then
+    score=$((score + 20))
+  fi
+
+  # Wide change - directory spread >= 3 (+15)
+  dir_count=$(grep '/' "$FILES_LIST" 2>/dev/null | awk -F/ '{print $1}' | sort -u | wc -l | tr -d ' ')
+  if [ "$dir_count" -ge 3 ]; then
+    score=$((score + 15))
+  fi
 fi
 
 # --- Diff content based signals ---
@@ -82,6 +96,11 @@ if [ -f "$DIFF_CONTENT" ]; then
   # crypto/token/secret patterns (+30)
   if grep -qiE 'password|secret|token|hash|encrypt|decrypt|cipher|private.key|api.key|credential' "$DIFF_CONTENT" 2>/dev/null; then
     score=$((score + 30))
+  fi
+
+  # External communication patterns (+15)
+  if grep -qiE 'fetch\(|axios\.|requests\.|http\.client|HttpClient|new URL\(|curl_|guzzle|urllib|httpx' "$DIFF_CONTENT" 2>/dev/null; then
+    score=$((score + 15))
   fi
 
   # Line count > 200 (+20)

--- a/skills/review/steps-subagent.md
+++ b/skills/review/steps-subagent.md
@@ -89,6 +89,7 @@ Task(subagent_type: "dev-crew:test-reviewer", model: "sonnet", prompt: "Review B
 # Always-on
 Task(subagent_type: "dev-crew:review-briefer", model: "haiku", prompt: "...")  # Step 2 で実行済み
 Task(subagent_type: "dev-crew:design-reviewer", model: "sonnet", prompt: "Review Brief: [brief]. 設計をスコープ・アーキテクチャ・リスク観点でレビューせよ。")
+Task(subagent_type: "dev-crew:test-reviewer", model: "sonnet", prompt: "Review Brief: [brief]. Plan mode: TC カバレッジ、異常系、独立性、Given/When/Then を検証せよ。")
 
 # Risk-gated (MEDIUM/HIGH のみ)
 Task(subagent_type: "dev-crew:security-reviewer", model: "sonnet", prompt: "...")      # auth/security flags
@@ -96,6 +97,9 @@ Task(subagent_type: "dev-crew:product-reviewer", model: "haiku", prompt: "...") 
 Task(subagent_type: "dev-crew:performance-reviewer", model: "sonnet", prompt: "...")   # DB/perf flags
 Task(subagent_type: "dev-crew:usability-reviewer", model: "haiku", prompt: "...")      # UI flags
 Task(subagent_type: "dev-crew:designer", model: "sonnet", prompt: "...")               # UI + UI tech stack
+Task(subagent_type: "dev-crew:change-safety-reviewer", model: "sonnet", prompt: "Review Brief: [brief]. ロールバック安全性・マイグレーション安全性を検証せよ。")  # migration/schema flags
+Task(subagent_type: "dev-crew:impact-reviewer", model: "sonnet", prompt: "Review Brief: [brief]. 変更の連鎖影響と破壊範囲を分析せよ。")  # wide-change flags
+Task(subagent_type: "dev-crew:resiliency-reviewer", model: "sonnet", prompt: "Review Brief: [brief]. 耐障害性・カスケード障害防止を検証せよ。")  # external-comm flags
 ```
 
 ## Step 4.5: Devil's Advocate (Socrates)

--- a/tests/test-plan-review-phase16.sh
+++ b/tests/test-plan-review-phase16.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# test-plan-review-phase16.sh - Phase 16 Plan Review 強化テスト
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+passed=0
+failed=0
+errors=""
+
+assert() {
+  local tc="$1" desc="$2" result="$3"
+  if [ "$result" = "true" ]; then
+    echo "  PASS: $tc - $desc"
+    passed=$((passed + 1))
+  else
+    echo "  FAIL: $tc - $desc"
+    failed=$((failed + 1))
+    errors="${errors}\n  FAIL: $tc - $desc"
+  fi
+}
+
+echo "=== Phase 16: Plan Review 強化 Tests ==="
+
+# --- 新規 agent 存在・構造 ---
+
+# TC-01: agents/change-safety-reviewer.md が存在する
+assert "TC-01" "agents/change-safety-reviewer.md が存在する" \
+  "$([ -f "$BASE_DIR/agents/change-safety-reviewer.md" ] && echo true || echo false)"
+
+# TC-02: agents/impact-reviewer.md が存在する
+assert "TC-02" "agents/impact-reviewer.md が存在する" \
+  "$([ -f "$BASE_DIR/agents/impact-reviewer.md" ] && echo true || echo false)"
+
+# TC-03: agents/resiliency-reviewer.md が存在する
+assert "TC-03" "agents/resiliency-reviewer.md が存在する" \
+  "$([ -f "$BASE_DIR/agents/resiliency-reviewer.md" ] && echo true || echo false)"
+
+# TC-04: change-safety-reviewer の description にロールバックまたはマイグレーションを含む
+assert "TC-04" "change-safety-reviewer の description にロールバックまたはマイグレーションを含む" \
+  "$(grep -E '^description:' "$BASE_DIR/agents/change-safety-reviewer.md" 2>/dev/null | grep -qE 'ロールバック|マイグレーション' && echo true || echo false)"
+
+# TC-05: impact-reviewer の description に影響または依存を含む
+assert "TC-05" "impact-reviewer の description に影響または依存を含む" \
+  "$(grep -E '^description:' "$BASE_DIR/agents/impact-reviewer.md" 2>/dev/null | grep -qE '影響|依存' && echo true || echo false)"
+
+# TC-06: resiliency-reviewer の description に耐障害またはタイムアウトを含む
+assert "TC-06" "resiliency-reviewer の description に耐障害またはタイムアウトを含む" \
+  "$(grep -E '^description:' "$BASE_DIR/agents/resiliency-reviewer.md" 2>/dev/null | grep -qE '耐障害|タイムアウト' && echo true || echo false)"
+
+# TC-07: 3体とも model: sonnet である
+tc07_result=true
+for agent in change-safety-reviewer impact-reviewer resiliency-reviewer; do
+  if ! grep -q '^model: sonnet' "$BASE_DIR/agents/$agent.md" 2>/dev/null; then
+    tc07_result=false
+  fi
+done
+assert "TC-07" "3体とも model: sonnet である" "$tc07_result"
+
+# --- design-reviewer 強化 ---
+
+# TC-08: design-reviewer.md の Focus に過剰設計関連の記述がある
+assert "TC-08" "design-reviewer.md の Focus に過剰設計関連の記述がある" \
+  "$(grep -qiE 'Over-engineering|Speculative Generality|YAGNI' "$BASE_DIR/agents/design-reviewer.md" 2>/dev/null && echo true || echo false)"
+
+# --- test-reviewer Plan mode ---
+
+# TC-09: test-reviewer.md に Plan mode セクションが含まれる
+assert "TC-09" "test-reviewer.md に Plan mode セクションが含まれる" \
+  "$(grep -qi 'Plan mode\|Plan Mode' "$BASE_DIR/agents/test-reviewer.md" 2>/dev/null && echo true || echo false)"
+
+# TC-10: Plan mode に TC カバレッジ観点が含まれる
+assert "TC-10" "Plan mode に TC カバレッジ観点が含まれる" \
+  "$(grep -q 'TC カバレッジ\|TC coverage\|TCカバレッジ' "$BASE_DIR/agents/test-reviewer.md" 2>/dev/null && echo true || echo false)"
+
+# --- risk-classifier.sh 拡張 ---
+
+# TC-11: risk-classifier.sh にスキーマ/migration 検出シグナルが含まれる
+assert "TC-11" "risk-classifier.sh にスキーマ/migration 検出シグナルが含まれる" \
+  "$(grep -qiE 'migration|schema' "$BASE_DIR/skills/review/risk-classifier.sh" 2>/dev/null && echo true || echo false)"
+
+# TC-12: risk-classifier.sh に外部通信検出シグナルが含まれる
+assert "TC-12" "risk-classifier.sh に外部通信検出シグナルが含まれる" \
+  "$(grep -qiE 'fetch|axios|requests|http.client|external.*comm' "$BASE_DIR/skills/review/risk-classifier.sh" 2>/dev/null && echo true || echo false)"
+
+# TC-13: risk-classifier.sh に広範囲変更（ディレクトリ分散）検出シグナルが含まれる
+assert "TC-13" "risk-classifier.sh に広範囲変更検出シグナルが含まれる" \
+  "$(grep -qiE 'dir.*spread|directory.*dispers|wide.*change|dir_count' "$BASE_DIR/skills/review/risk-classifier.sh" 2>/dev/null && echo true || echo false)"
+
+# --- steps-subagent.md / reference.md 統合 ---
+
+# TC-14: steps-subagent.md の Plan Mode に change-safety-reviewer が含まれる
+assert "TC-14" "steps-subagent.md の Plan Mode に change-safety-reviewer が含まれる" \
+  "$(sed -n '/Plan Mode/,/Code Mode\|^## /p' "$BASE_DIR/skills/review/steps-subagent.md" 2>/dev/null | grep -q 'change-safety-reviewer' && echo true || echo false)"
+
+# TC-15: steps-subagent.md の Plan Mode に impact-reviewer が含まれる
+assert "TC-15" "steps-subagent.md の Plan Mode に impact-reviewer が含まれる" \
+  "$(sed -n '/Plan Mode/,/Code Mode\|^## /p' "$BASE_DIR/skills/review/steps-subagent.md" 2>/dev/null | grep -q 'impact-reviewer' && echo true || echo false)"
+
+# TC-16: steps-subagent.md の Plan Mode に resiliency-reviewer が含まれる
+assert "TC-16" "steps-subagent.md の Plan Mode に resiliency-reviewer が含まれる" \
+  "$(sed -n '/Plan Mode/,/Code Mode\|^## /p' "$BASE_DIR/skills/review/steps-subagent.md" 2>/dev/null | grep -q 'resiliency-reviewer' && echo true || echo false)"
+
+# TC-17: steps-subagent.md の Plan Mode に test-reviewer が含まれる
+assert "TC-17" "steps-subagent.md の Plan Mode に test-reviewer が含まれる" \
+  "$(sed -n '/Plan Mode/,/Code Mode\|^## /p' "$BASE_DIR/skills/review/steps-subagent.md" 2>/dev/null | grep -q 'test-reviewer' && echo true || echo false)"
+
+# TC-18: reference.md の Agent Roster (Plan Mode) に change-safety-reviewer が含まれる
+assert "TC-18" "reference.md の Agent Roster (Plan Mode) に change-safety-reviewer が含まれる" \
+  "$(sed -n '/Agent Roster (Plan Mode)/,/^##/p' "$BASE_DIR/skills/review/reference.md" 2>/dev/null | grep -q 'change-safety-reviewer' && echo true || echo false)"
+
+# --- リグレッション ---
+
+echo ""
+echo "  TC-19: リグレッション確認..."
+regression_pass=true
+for f in "$BASE_DIR"/tests/test-agents-structure.sh "$BASE_DIR"/tests/test-test-reviewer.sh "$BASE_DIR"/tests/test-socrates-review-integration.sh; do
+  if [ -f "$f" ]; then
+    if ! bash "$f" > /dev/null 2>&1; then
+      regression_pass=false
+      echo "    FAIL: $(basename "$f") failed"
+    fi
+  fi
+done
+assert "TC-19" "既存テスト全通過" "$regression_pass"
+
+echo ""
+echo "=== Results: $passed passed, $failed failed ==="
+if [ "$failed" -gt 0 ]; then
+  echo -e "\nFailures:$errors"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- change-safety-reviewer / impact-reviewer / resiliency-reviewer 3新agent追加（Plan mode Risk-gated）
- design-reviewer に Over-engineering 検出、test-reviewer に Plan Mode Focus 追加
- risk-classifier.sh に3新シグナル（schema/migration +20, external comm +15, wide change +15）
- 19 TC 全 PASS + リグレッション 0

## Test plan
- [x] `bash tests/test-plan-review-phase16.sh` (19 TC PASS)
- [x] `bash tests/test-agents-structure.sh` (18 TC PASS)
- [x] `bash tests/test-test-reviewer.sh` (17 TC PASS)
- [x] `bash tests/test-socrates-review-integration.sh` (8 TC PASS)

## DISCOVERED (Phase 17委譲)
- 閾値キャリブレーション（+50スコアインフレ）
- impact/change-safety dedup テーブル
- Plan mode ファイルリスト生成ロジック定義

🤖 Generated with [Claude Code](https://claude.com/claude-code)