### PR TITLE
feat: Phase 26 no-verify hook（決定論的ブロック）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Phase-boundary compaction:
 | PreToolUse | Edit\|Write | `scripts/hooks/post-approve-gate.sh` | Blocks Edit/Write until orchestrate clears the flag (exit 2) |
 | PostToolUse | Edit\|Write\|Bash | `scripts/hooks/observe.sh` | Logs tool usage patterns for learn skill |
 | PostToolUse | Skill\|Agent | `~/.claude/hooks/observe-skills.sh` | Logs Skill/Agent usage for prune planning (global hook) |
+| PreToolUse | Bash | `scripts/hooks/no-verify-guard.sh` | Blocks --no-verify commands (exit 2) |
 | PreCompact | manual | `scripts/hooks/pre-compact.sh` | Persists phase summary before /compact |
 
 ## Usage Patterns

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,7 +7,7 @@
 | In-Progress Cycles | 0 |
 | Done (unarchived) | 23 |
 | Archived Cycles | 37 |
-| Test Scripts | 90 |
+| Test Scripts | 91 |
 
 Last updated: 2026-03-22
 

--- a/docs/cycles/20260323_0031_no-verify-guard.md
+++ b/docs/cycles/20260323_0031_no-verify-guard.md
@@ -1,0 +1,144 @@
+---
+feature: no-verify-guard
+cycle: 20260323_0031
+phase: DONE
+complexity: trivial
+test_count: 12
+risk_level: low
+codex_session_id: ""
+created: 2026-03-23 00:31
+updated: 2026-03-23 00:31
+---
+
+# Phase 26: --no-verify hook（決定論的ブロック）
+
+## Scope Definition
+
+### In Scope
+- [ ] `scripts/hooks/no-verify-guard.sh` の新規作成（PreToolUse Bash hook）
+- [ ] `hooks/hooks.json` への PreToolUse Bash matcher エントリ追加
+- [ ] `tests/test-no-verify-guard.sh` の新規作成（8ケース）
+- [ ] `CLAUDE.md` Hooks テーブルへの no-verify-guard 行追加
+- [ ] `docs/STATUS.md` Phase 26 完了・Test Scripts カウント更新
+
+### Out of Scope
+- rules/git-safety.md の変更（既存ルールで十分）
+- git コマンド限定の絞り込み（安全側に倒して全ブロック）
+
+### Files to Change (target: 10 or less)
+- `scripts/hooks/no-verify-guard.sh` (new)
+- `hooks/hooks.json` (edit)
+- `tests/test-no-verify-guard.sh` (new)
+- `CLAUDE.md` (edit)
+- `docs/STATUS.md` (edit)
+
+## Environment
+
+### Scope
+- Layer: CLI（シェルスクリプト + hooks設定）
+- Plugin: N/A（シェルスクリプトのみ）
+- Risk: 15 (PASS)
+
+### Runtime
+- Language: bash (shell script)
+
+### Dependencies (key packages)
+- jq（observe.sh で既に使用中。jq不在時はINPUT全体をgrepするフォールバック）
+
+### Risk Interview (BLOCK only)
+- N/A（Risk Score 15 PASS のためインタビュー不要）
+
+## Context & Dependencies
+
+### Reference Documents
+- [ROADMAP.md] - v2.8 Phase 26 定義
+- [CONSTITUTION.md] - 原則6: 決定論的プロセス保証
+- [scripts/hooks/post-approve-gate.sh] - 実装パターン参照（PreToolUse exit 2 パターン）
+- [hooks/hooks.json] - 既存hook設定。PreToolUse セクションに追記する
+- [.claude/rules/git-safety.md] - --no-verify 禁止ルール（hook で決定論的に強制）
+
+### Dependent Features
+- post-approve-gate.sh: 同じ PreToolUse exit 2 パターンを先行実装
+
+### Related Issues/PRs
+- ROADMAP.md v2.8 Phase 26
+
+## Test List
+
+### TODO
+- [ ] TC-01: `git commit -m "msg"`（--no-verify なし）→ exit 0（許可）
+- [ ] TC-02: `git commit --no-verify -m "msg"` → exit 2（ブロック）
+- [ ] TC-03: `git push --no-verify` → exit 2（ブロック）
+- [ ] TC-04: `echo "--no-verify"`（git コマンドではない）→ exit 2（ブロック・安全側）
+- [ ] TC-05: `grep --no-verify file.txt`（誤検知候補）→ exit 2（ブロック・--no-verify 自体を全遮断）
+- [ ] TC-06: 空入力 → exit 0（許可）
+- [ ] TC-07: ネストされたJSON `{"tool_input":{"command":"git commit --no-verify"}}` → exit 2（jqパース検証）
+- [ ] TC-08: pretty-print JSON（改行・インデント付き）→ exit 2（フォーマット耐性）
+- [ ] TC-09: jq不在時にINPUT全体からfallback検出 → exit 2（フォールバック検証）
+- [ ] TC-10: hooks.json に no-verify-guard エントリが存在する → PASS
+- [ ] TC-11: hooks.json に post-approve-gate エントリも共存している → PASS（既存hook保護）
+- [ ] TC-12: CLAUDE.md Hooks テーブルに no-verify-guard が存在する → PASS
+
+### WIP
+(none)
+
+### DISCOVERED
+- onboard テンプレートへの推奨hook追加（ROADMAP記載あり、本サイクルではスコープ外）
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+`--no-verify` を含む Bash コマンドを PreToolUse hook で決定論的にブロックする。LLMがルールを無視するリスクをゼロにする。
+
+### Background
+`--no-verify` は rules/git-safety.md で禁止されているが、LLMがルールを無視するリスクがある。CONSTITUTION 原則6「決定論的プロセス保証」に従い、post-approve-gate.sh と同じパターンで PreToolUse hook による決定論的ブロックに昇格する。
+
+### Design Approach
+- `scripts/hooks/no-verify-guard.sh`: stdin から tool_input（JSON）を読み取り、`--no-verify` を検出したら exit 2 でブロック。post-approve-gate.sh のパターンを踏襲。
+- `hooks/hooks.json` の PreToolUse セクションに Bash マッチャーを追加。
+- テストは `test-post-approve-gate.sh` のパターンを流用し Given/When/Then 形式で実装。
+- stdin JSON のパース: jq 優先（`.tool_input.command // ""`）+ jq不在時はINPUT全体grep（安全側フォールバック）。observe.sh のパターンと一貫性を保つ。
+- `--no-verify-signatures` 等もブロック対象（over-blocking で安全側に倒す。CONSTITUTION原則6優先）。
+
+## Progress Log
+
+### 2026-03-23 00:31 - INIT
+- Cycle doc created
+- Scope definition ready
+
+### 2026-03-23 - RED
+- test-no-verify-guard.sh 作成（12ケース）
+- 全テスト失敗確認（RED状態）
+
+### 2026-03-23 - GREEN
+- no-verify-guard.sh 実装（jq優先 + grepフォールバック）
+- hooks.json にBash matcher追加
+- CLAUDE.md Hooksテーブル更新
+- 12/12 PASS + 回帰0 FAIL
+
+### 2026-03-23 - REFACTOR
+- チェックリスト全項目確認、改善不要（31行のシンプルなスクリプト）
+- Verification Gate PASS
+- Phase completed
+
+### 2026-03-23 - REVIEW
+- security-reviewer: PASS (score 10)
+- correctness-reviewer: PASS (score 42)
+- 修正: set -euo pipefail, jq失敗時fallback, TC-09環境変数フラグ方式
+- 全テスト12/12 PASS + 回帰0 FAIL
+- Phase completed
+
+---
+
+## Next Steps
+
+1. [Done] INIT <- Current
+2. [Done] PLAN (planファイルから転記済み)
+3. [Next] RED
+4. [ ] GREEN
+5. [ ] REFACTOR
+6. [ ] REVIEW
+7. [ ] COMMIT

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -30,6 +30,15 @@
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/hooks/post-approve-gate.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/hooks/no-verify-guard.sh"
+          }
+        ]
       }
     ],
     "PreCompact": [

--- a/scripts/hooks/no-verify-guard.sh
+++ b/scripts/hooks/no-verify-guard.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# no-verify-guard.sh - PreToolUse hook for Bash
+# Blocks any Bash command containing --no-verify.
+# Exit 2 = block the tool call.
+
+set -euo pipefail
+
+# Read all stdin
+INPUT=$(cat)
+
+# If stdin is empty or whitespace-only, allow
+if [ -z "$(echo "$INPUT" | tr -d '[:space:]')" ]; then
+  exit 0
+fi
+
+# Extract command: jq preferred, grep fallback
+# NO_VERIFY_GUARD_SKIP_JQ=1 forces fallback path (for testing)
+if [ "${NO_VERIFY_GUARD_SKIP_JQ:-}" != "1" ] && command -v jq >/dev/null 2>&1; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null) || COMMAND="$INPUT"
+else
+  # jq absent or skipped: check entire INPUT (safe side)
+  COMMAND="$INPUT"
+fi
+
+# Detect --no-verify → block
+if echo "$COMMAND" | grep -q -- '--no-verify'; then
+  echo "BLOCKED: --no-verify is prohibited by git-safety rules." >&2
+  echo "Remove --no-verify and let pre-commit hooks run." >&2
+  exit 2
+fi
+
+exit 0

--- a/tests/test-no-verify-guard.sh
+++ b/tests/test-no-verify-guard.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# test-no-verify-guard.sh - Tests for no-verify-guard.sh (PreToolUse Bash hook)
+# TC-01〜TC-12: --no-verify 検出・ブロックの決定論的テスト
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+GUARD="$SCRIPT_DIR/scripts/hooks/no-verify-guard.sh"
+HOOKS_JSON="$SCRIPT_DIR/hooks/hooks.json"
+CLAUDE_MD="$SCRIPT_DIR/CLAUDE.md"
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (expected=$expected, actual=$actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" expected="$2" actual="$3"
+  if echo "$actual" | grep -q "$expected"; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (expected to contain '$expected')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_guard() {
+  local input="$1"
+  echo "$input" | bash "$GUARD" 2>/dev/null
+  echo $?
+}
+
+# --- TC-01〜TC-06: exit code 検証 ---
+
+echo "=== no-verify-guard.sh: exit code tests ==="
+
+# TC-01
+# Given: --no-verify なしの git commit コマンド
+# When: no-verify-guard.sh に stdin でパイプ
+# Then: exit 0（許可）
+INPUT='{"tool_input":{"command":"git commit -m \"msg\""}}'
+EXIT=$(run_guard "$INPUT")
+assert_eq "TC-01: git commit without --no-verify → exit 0 (allow)" "0" "$EXIT"
+
+# TC-02
+# Given: --no-verify 付きの git commit コマンド
+# When: no-verify-guard.sh に stdin でパイプ
+# Then: exit 2（ブロック）
+INPUT='{"tool_input":{"command":"git commit --no-verify -m \"msg\""}}'
+EXIT=$(run_guard "$INPUT")
+assert_eq "TC-02: git commit --no-verify → exit 2 (block)" "2" "$EXIT"
+
+# TC-03
+# Given: --no-verify 付きの git push コマンド
+# When: no-verify-guard.sh に stdin でパイプ
+# Then: exit 2（ブロック）
+INPUT='{"tool_input":{"command":"git push --no-verify"}}'
+EXIT=$(run_guard "$INPUT")
+assert_eq "TC-03: git push --no-verify → exit 2 (block)" "2" "$EXIT"
+
+# TC-04
+# Given: --no-verify を含む echo コマンド（git 以外）
+# When: no-verify-guard.sh に stdin でパイプ
+# Then: exit 2（ブロック・安全側。--no-verify 自体を全遮断）
+INPUT='{"tool_input":{"command":"echo \"--no-verify\""}}'
+EXIT=$(run_guard "$INPUT")
+assert_eq "TC-04: echo --no-verify (non-git) → exit 2 (block, safe side)" "2" "$EXIT"
+
+# TC-05
+# Given: --no-verify を含む grep コマンド（誤検知候補）
+# When: no-verify-guard.sh に stdin でパイプ
+# Then: exit 2（ブロック・--no-verify 自体を全遮断）
+INPUT='{"tool_input":{"command":"grep --no-verify file.txt"}}'
+EXIT=$(run_guard "$INPUT")
+assert_eq "TC-05: grep --no-verify (false positive candidate) → exit 2 (block)" "2" "$EXIT"
+
+# TC-06
+# Given: 空の入力
+# When: no-verify-guard.sh に stdin でパイプ
+# Then: exit 0（許可）
+EXIT=$(echo "" | bash "$GUARD" 2>/dev/null; echo $?)
+assert_eq "TC-06: empty input → exit 0 (allow)" "0" "$EXIT"
+
+# --- TC-07〜TC-09: jq パース検証 ---
+
+echo ""
+echo "=== no-verify-guard.sh: JSON parse tests ==="
+
+# TC-07
+# Given: ネストされた JSON（tool_input.command に --no-verify）
+# When: no-verify-guard.sh に stdin でパイプ
+# Then: exit 2（jq パースで検出・ブロック）
+INPUT='{"session_id":"abc","tool_name":"Bash","tool_input":{"command":"git commit --no-verify"}}'
+EXIT=$(run_guard "$INPUT")
+assert_eq "TC-07: nested JSON with --no-verify → exit 2 (jq parse)" "2" "$EXIT"
+
+# TC-08
+# Given: pretty-print JSON（改行・インデント付き）で --no-verify を含む
+# When: no-verify-guard.sh に stdin でパイプ
+# Then: exit 2（フォーマット耐性）
+INPUT=$(printf '{\n  "tool_input": {\n    "command": "git commit --no-verify -m msg"\n  }\n}')
+EXIT=$(echo "$INPUT" | bash "$GUARD" 2>/dev/null; echo $?)
+assert_eq "TC-08: pretty-print JSON with --no-verify → exit 2 (format tolerance)" "2" "$EXIT"
+
+# TC-09
+# Given: jq が不在の状況を模擬（PATH から jq を除外）
+#        stdin には --no-verify を含む JSON
+# When: no-verify-guard.sh に stdin でパイプ（jq 不在の PATH で）
+# Then: exit 2（INPUT 全体への grep フォールバックで検出・ブロック）
+INPUT='{"tool_input":{"command":"git commit --no-verify -m msg"}}'
+EXIT=$(echo "$INPUT" | NO_VERIFY_GUARD_SKIP_JQ=1 bash "$GUARD" 2>/dev/null; echo $?)
+assert_eq "TC-09: jq absent → fallback grep detects --no-verify → exit 2" "2" "$EXIT"
+
+# --- TC-10〜TC-12: 構造チェック ---
+
+echo ""
+echo "=== Structure checks ==="
+
+# TC-10
+# Given: hooks/hooks.json が存在する
+# When: no-verify-guard エントリを検索
+# Then: no-verify-guard.sh への参照が存在する
+if [ -f "$HOOKS_JSON" ]; then
+  if grep -q "no-verify-guard" "$HOOKS_JSON" 2>/dev/null; then
+    assert_eq "TC-10: hooks.json has no-verify-guard entry" "true" "true"
+  else
+    assert_eq "TC-10: hooks.json has no-verify-guard entry" "true" "false"
+  fi
+else
+  echo "FAIL: TC-10: hooks.json not found at $HOOKS_JSON"
+  FAIL=$((FAIL + 1))
+fi
+
+# TC-11
+# Given: hooks/hooks.json が存在する
+# When: post-approve-gate と no-verify-guard の両エントリを検索
+# Then: 両方のエントリが共存している（既存 hook が保護されている）
+if [ -f "$HOOKS_JSON" ]; then
+  HAS_GATE=false
+  HAS_GUARD=false
+  grep -q "post-approve-gate" "$HOOKS_JSON" 2>/dev/null && HAS_GATE=true
+  grep -q "no-verify-guard" "$HOOKS_JSON" 2>/dev/null && HAS_GUARD=true
+  if [ "$HAS_GATE" = "true" ] && [ "$HAS_GUARD" = "true" ]; then
+    assert_eq "TC-11: hooks.json has both post-approve-gate and no-verify-guard entries" "true" "true"
+  else
+    assert_eq "TC-11: hooks.json has both post-approve-gate and no-verify-guard entries" "true" "false"
+  fi
+else
+  echo "FAIL: TC-11: hooks.json not found at $HOOKS_JSON"
+  FAIL=$((FAIL + 1))
+fi
+
+# TC-12
+# Given: CLAUDE.md が存在する
+# When: Hooks テーブルから no-verify-guard を検索
+# Then: no-verify-guard の行が存在する
+if [ -f "$CLAUDE_MD" ]; then
+  if grep -q "no-verify-guard" "$CLAUDE_MD" 2>/dev/null; then
+    assert_eq "TC-12: CLAUDE.md Hooks table has no-verify-guard entry" "true" "true"
+  else
+    assert_eq "TC-12: CLAUDE.md Hooks table has no-verify-guard entry" "true" "false"
+  fi
+else
+  echo "FAIL: TC-12: CLAUDE.md not found at $CLAUDE_MD"
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- `--no-verify` を含むBashコマンドをPreToolUse hookで決定論的にブロック（exit 2）
- jq優先パース + jq失敗/不在時はINPUT全体grepフォールバック（安全側）
- CONSTITUTION原則6: ルール禁止→決定論的強制への昇格

## Review
- Socrates + Codex plan review: jqパース方式・影響範囲・テストカバレッジの指摘を反映
- security-reviewer: PASS (score 10)
- correctness-reviewer: PASS (score 42)、important指摘3件を修正済み

## Test plan
- [x] 12テストケース全PASS（exit code, JSONパース, 構造チェック）
- [x] 全テストスクリプト回帰確認 FAIL 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)