### PR TITLE
feat: onboardテンプレートにno-verify-guard hook推奨追加

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,9 +5,9 @@
 | Metric | Value |
 |--------|-------|
 | In-Progress Cycles | 0 |
-| Done (unarchived) | 25 |
+| Done (unarchived) | 26 |
 | Archived Cycles | 37 |
-| Test Scripts | 92 |
+| Test Scripts | 93 |
 
 Last updated: 2026-03-23
 
@@ -15,6 +15,7 @@ Last updated: 2026-03-23
 
 | Date | Cycle | Type |
 |------|-------|------|
+| 2026-03-23 | #88: onboardテンプレートにno-verify-guard hook推奨追加 | feat |
 | 2026-03-23 | v2.7 Phase 25: 動的スキルコンテンツ注入 段階的適用 | feat |
 | 2026-03-23 | v2.7 Phase 24: 動的スキルコンテンツ注入 設計・PoC | feat |
 | 2026-03-23 | v2.8 Phase 26: --no-verify hook（決定論的ブロック） | feat |

--- a/docs/cycles/20260323_1651_onboard-no-verify-hook.md
+++ b/docs/cycles/20260323_1651_onboard-no-verify-hook.md
@@ -1,0 +1,136 @@
+---
+feature: onboard-no-verify-hook
+cycle: 20260323_1651
+phase: DONE
+complexity: trivial
+test_count: 3
+risk_level: low
+codex_session_id: ""
+created: 2026-03-23 16:51
+updated: 2026-03-23 17:00
+---
+
+# Issue #88: onboardテンプレートにno-verify-guard hook推奨追加
+
+## Scope Definition
+
+### In Scope
+- [ ] `.claude/hooks/recommended.md` を更新: PreToolUse/Bashにおいてインラインのcaseをno-verify-guard.shスクリプト参照に変更。インライン版はfallbackとして残す
+- [ ] Hook一覧テーブルにno-verify-guard.shの説明を追加
+- [ ] `skills/onboard/reference.md` Step 6の説明文を更新（決定論的ブロックの語句を追加）
+- [ ] `tests/test-onboard-no-verify-hook.sh` を新規作成
+
+### Out of Scope
+- no-verify-guard.sh スクリプト自体の変更（Phase 26実装済み）
+- recommended.md 以外のhookファイルの変更
+
+### Files to Change (target: 10 or less)
+- `.claude/hooks/recommended.md` (edit)
+- `skills/onboard/reference.md` (edit)
+- `tests/test-onboard-no-verify-hook.sh` (new)
+
+## Environment
+
+### Scope
+- Layer: Backend (shell script / markdown)
+- Plugin: N/A (Documentation + Template)
+- Risk: 15 (PASS)
+
+### Runtime
+- Language: bash (hook scripts)
+
+### Dependencies (key packages)
+- N/A (テンプレート・ドキュメント更新のみ)
+
+### Risk Interview (BLOCK only)
+- N/A (PASS判定)
+
+## Context & Dependencies
+
+### Reference Documents
+- `scripts/hooks/no-verify-guard.sh` - 参照対象スクリプト本体
+- `ROADMAP.md` Phase 26 - 「onboardテンプレートにも推奨hookとして追加」
+- `CONSTITUTION.md` 原則6 - 決定論的プロセス保証
+
+### Dependent Features
+- Phase 26: no-verify-guard.sh 実装（20260323_0031_no-verify-guard.md）
+
+### Related Issues/PRs
+- Issue #88: onboardテンプレートにno-verify-guard hookを推奨hookとして追加
+
+## Test List
+
+### TODO
+(none)
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+- [x] TC-01: Given recommended.md, When grepで "no-verify-guard" を検索, Then マッチすること
+- [x] TC-02: Given recommended.md, When JSONブロックを抽出, Then PreToolUse/Bash hookにno-verify関連エントリがあること
+- [x] TC-03: Given onboard reference.md Step 6, When hookの説明を確認, Then 決定論的ブロックの記述があること
+
+## Implementation Notes
+
+### Goal
+onboardスキルが新規プロジェクトに配布する推奨hookテンプレートに、Phase 26で実装済みの `no-verify-guard.sh` を反映する。
+
+### Background
+Phase 26で `scripts/hooks/no-verify-guard.sh` を実装済み。現状の `.claude/hooks/recommended.md` には既にインライン版のno-verifyガードがあるが、`no-verify-guard.sh` スクリプトの存在やdev-crewプラグインとしての利用方法が明記されていない。ROADMAP Phase 26の残タスクとして対応が必要。
+
+### Design Approach
+1. `recommended.md` のPreToolUse/Bash hookにスクリプト参照エントリを追加。インライン版はポータビリティのためfallbackとして残す（スクリプトがない環境向け）
+2. Hook一覧テーブルに `no-verify-guard.sh` の行を追加
+3. `onboard/reference.md` Step 6の説明文に「決定論的ブロック」の語句を追記
+4. `tests/test-onboard-no-verify-hook.sh` でドキュメント内容の存在を検証
+
+**WARN (Design Review Gate)**: `no-verify-guard.sh` は `--no-verify` のみを検出する。`rm -rf` と `--force` の検出はインライン版に依存するため、インライン版の完全削除は不可。実装時に注意すること。
+
+## Progress Log
+
+### 2026-03-23 16:51 - KICKOFF
+- Cycle doc created
+- Design Review Gate: WARN (スコア30)
+- WARN: `no-verify-guard.sh` は `--no-verify` のみ対象。`rm -rf`・`--force` はインラインcaseに残存させること
+- Scope definition ready
+
+### 2026-03-23 17:00 - RED
+- tests/test-onboard-no-verify-hook.sh 新規作成（TC-01〜TC-03）
+- 3件全FAIL確認（RED状態）
+
+### 2026-03-23 17:00 - GREEN
+- .claude/hooks/recommended.md: no-verify-guard.shスクリプト参照追加、Hook一覧テーブル更新
+- skills/onboard/reference.md: Step 6に「決定論的ブロック」の語句追加
+- 3件全PASS
+
+### 2026-03-23 17:00 - REFACTOR
+- チェックリスト7項目確認、リファクタリング不要
+- Verification Gate PASS（新規3件 + 既存12件 + plugin構造6件）
+- Phase completed
+
+### 2026-03-23 17:00 - REVIEW
+- Risk: LOW (score 0)
+- Security: PASS（Markdown/テストのみ）
+- Correctness: PASS（インライン版残存、スクリプト参照追加）
+- Score: PASS
+- DISCOVERED: .claude/ が .gitignore 対象のため recommended.md は git追跡外（プラグイン配布で管理、既知の構造）
+- Phase completed
+
+---
+
+## Next Steps
+
+1. [Done] KICKOFF
+2. [Done] RED
+3. [Done] GREEN
+4. [Done] REFACTOR
+5. [Done] REVIEW
+6. [Done] COMMIT
+
+### 2026-03-23 17:00 - COMMIT
+- Codex review: スキップ（ドキュメント変更のみ、ユーザー判断）
+- Phase completed

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -536,9 +536,9 @@ CLAUDE.md から `@docs/architecture.md` のように外部ファイルを参照
 
 ---
 
-## Step 6: .claude/ 構造
+## Step 6: .claude/ 構造（決定論的ブロック・hookテンプレート配布）
 
-core の `.claude/` から Read してコピー: `.claude/rules/security.md`, `.claude/rules/git-safety.md`, `.claude/rules/git-conventions.md`, `.claude/hooks/recommended.md` (--no-verify + rm -rf ブロック)。
+core の `.claude/` から Read してコピー: `.claude/rules/security.md`, `.claude/rules/git-safety.md`, `.claude/rules/git-conventions.md`, `.claude/hooks/recommended.md` (--no-verify + rm -rf ブロック、no-verify-guard.sh による決定論的ブロック)。
 
 ### ファイル単位の差分チェック
 

--- a/tests/test-onboard-no-verify-hook.sh
+++ b/tests/test-onboard-no-verify-hook.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# test-onboard-no-verify-hook.sh - Tests for onboard template no-verify-guard hook
+# TC-01〜TC-03: recommended.md と onboard reference.md の構造検証
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RECOMMENDED_MD="$SCRIPT_DIR/.claude/hooks/recommended.md"
+ONBOARD_REF_MD="$SCRIPT_DIR/skills/onboard/reference.md"
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (expected=$expected, actual=$actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== onboard no-verify-guard hook: structure tests ==="
+
+# TC-01
+# Given: .claude/hooks/recommended.md が存在する
+# When: grep で "no-verify-guard" を検索する
+# Then: マッチすること（no-verify-guard.sh への参照が存在する）
+if [ -f "$RECOMMENDED_MD" ]; then
+  if grep -q "no-verify-guard" "$RECOMMENDED_MD" 2>/dev/null; then
+    assert_eq "TC-01: recommended.md contains no-verify-guard" "true" "true"
+  else
+    assert_eq "TC-01: recommended.md contains no-verify-guard" "true" "false"
+  fi
+else
+  echo "FAIL: TC-01: recommended.md not found at $RECOMMENDED_MD"
+  FAIL=$((FAIL + 1))
+fi
+
+# TC-02
+# Given: .claude/hooks/recommended.md が存在する
+# When: JSONブロックを抽出し、PreToolUse/Bash hook エントリを確認する
+# Then: no-verify-guard に関連するエントリが存在すること
+if [ -f "$RECOMMENDED_MD" ]; then
+  # JSON ブロック内に no-verify-guard の記述があるか確認
+  # recommended.md 内の ``` ブロックから JSON 断片を抽出して検索
+  JSON_CONTENT=$(awk '/^```(json)?$/,/^```$/' "$RECOMMENDED_MD" | grep -v '^```')
+  if echo "$JSON_CONTENT" | grep -q "no-verify-guard"; then
+    assert_eq "TC-02: recommended.md JSON block has PreToolUse/Bash no-verify-guard entry" "true" "true"
+  else
+    assert_eq "TC-02: recommended.md JSON block has PreToolUse/Bash no-verify-guard entry" "true" "false"
+  fi
+else
+  echo "FAIL: TC-02: recommended.md not found at $RECOMMENDED_MD"
+  FAIL=$((FAIL + 1))
+fi
+
+# TC-03
+# Given: skills/onboard/reference.md が存在する
+# When: Step 6 の hookの説明を確認する
+# Then: 「決定論的ブロック」の記述があること
+if [ -f "$ONBOARD_REF_MD" ]; then
+  # Step 6 セクションを抽出して検索
+  STEP6_CONTENT=$(awk '/^## Step 6:/,/^## Step [0-9]/' "$ONBOARD_REF_MD")
+  if echo "$STEP6_CONTENT" | grep -q "決定論的ブロック"; then
+    assert_eq "TC-03: onboard reference.md Step 6 contains 決定論的ブロック" "true" "true"
+  else
+    assert_eq "TC-03: onboard reference.md Step 6 contains 決定論的ブロック" "true" "false"
+  fi
+else
+  echo "FAIL: TC-03: onboard reference.md not found at $ONBOARD_REF_MD"
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- recommended.mdにno-verify-guard.shスクリプト参照を追加（インライン版はfallbackとして残存）
- onboard reference.md Step 6に「決定論的ブロック」の語句を追記
- test-onboard-no-verify-hook.sh新設（TC-01〜TC-03）

Closes #88

## Test plan

- [x] `bash tests/test-onboard-no-verify-hook.sh` (3 passed)
- [x] `bash tests/test-no-verify-guard.sh` (12 passed)
- [x] `bash tests/test-plugin-structure.sh` (6 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)