### PR TITLE
feat: Phase 30 ディレクトリ構造厳格化

### DIFF
--- a/docs/cycles/20260316_0053_phase13_skill_map.md
+++ b/docs/cycles/20260316_0053_phase13_skill_map.md
@@ -1,3 +1,7 @@
+---
+phase: DONE
+---
+
 # Phase 13: スキルマップ確定
 
 ## Metadata

--- a/docs/cycles/20260316_1757_phase14_2_api_contract_reviewer.md
+++ b/docs/cycles/20260316_1757_phase14_2_api_contract_reviewer.md
@@ -1,3 +1,7 @@
+---
+phase: DONE
+---
+
 # Phase 14.2: api-contract-reviewer 新設
 
 ## Metadata

--- a/docs/cycles/20260316_2300_phase14_4_performance_reviewer.md
+++ b/docs/cycles/20260316_2300_phase14_4_performance_reviewer.md
@@ -1,3 +1,7 @@
+---
+phase: DONE
+---
+
 # Phase 14.4: performance-reviewer 強化
 
 ## Metadata

--- a/docs/cycles/20260317_0000_phase15_1_test_reviewer.md
+++ b/docs/cycles/20260317_0000_phase15_1_test_reviewer.md
@@ -1,3 +1,7 @@
+---
+phase: DONE
+---
+
 # Phase 15.1: test-reviewer 新設
 
 ## Metadata

--- a/docs/cycles/20260317_0200_phase15_3_socrates_review_integration.md
+++ b/docs/cycles/20260317_0200_phase15_3_socrates_review_integration.md
@@ -1,3 +1,7 @@
+---
+phase: DONE
+---
+
 # Phase 15.3: Socrates Devil's Advocate review pipeline 統合
 
 ## Metadata

--- a/docs/cycles/20260317_1031_v241_discovered_fix.md
+++ b/docs/cycles/20260317_1031_v241_discovered_fix.md
@@ -1,10 +1,12 @@
 ---
+phase: DONE
 id: 20260317_1031_v241_discovered_fix
 title: "v2.4.1: DISCOVERED 修正 + ROADMAP 次期フェーズ追記"
 status: DONE
 type: fix
 created: 2026-03-17
 ---
+phase: DONE
 
 # v2.4.1: DISCOVERED 修正 + ROADMAP 次期フェーズ追記
 

--- a/docs/cycles/20260317_1200_phase17_v24_integration_release.md
+++ b/docs/cycles/20260317_1200_phase17_v24_integration_release.md
@@ -1,8 +1,10 @@
 ---
+phase: DONE
 status: DONE
 type: feat
 created: 2026-03-17
 ---
+phase: DONE
 
 # Phase 17: v2.4 統合・リリース
 

--- a/docs/cycles/20260323_1352_phase29-plugin-data-migration.md
+++ b/docs/cycles/20260323_1352_phase29-plugin-data-migration.md
@@ -1,10 +1,12 @@
 ---
+phase: DONE
 title: "Phase 29: CLAUDE_PLUGIN_DATA Migration"
 date: 2026-03-23
 status: IN_PROGRESS
 plan_file: /Users/morodomi/.claude/plans/parsed-seeking-steele.md
 codex_session_id: ""
 ---
+phase: DONE
 
 # Phase 29: CLAUDE_PLUGIN_DATA 移行
 
@@ -159,5 +161,6 @@ Design Review Gate: **PASS** (score: 20/100)
 - Risk: 全体的にリスクは低い。フォールバック設計が安全ネットとして機能する。
 
 ---
+phase: DONE
 
 _RED phase: tests/test-plugin-data-paths.sh を作成し、全 T-01〜T-06 が FAIL することを確認する_

--- a/docs/cycles/20260323_2324_phase30-directory-structure.md
+++ b/docs/cycles/20260323_2324_phase30-directory-structure.md
@@ -1,0 +1,163 @@
+---
+feature: directory-structure
+cycle: phase30-directory-structure
+phase: DONE
+complexity: trivial
+test_count: 9
+risk_level: low
+codex_session_id: ""
+created: 2026-03-23 23:24
+updated: 2026-03-23 23:24
+---
+
+# Phase 30: ディレクトリ構造厳格化
+
+## Scope Definition
+
+### In Scope
+- [ ] `tests/test-directory-structure.sh` 新規作成 (TC-DS01〜DS09)
+- [ ] `scripts/validate-cycle-frontmatter.sh` 拡張 (feature/cycle/created/updated 存在チェック追加)
+- [ ] `skills/onboard/validation.md` 更新 (#8: docs/cycles/ 命名規約チェック追加)
+- [ ] `skills/onboard/reference.md` 更新 (Cycle doc命名規約の明示)
+
+### Out of Scope
+- 旧形式Cycle docの移行 (Reason: Grandfathering方針。D1参照)
+- docs/cycles/archive/ の検証 (Reason: D2参照)
+- 本文の必須セクション検証 (Reason: fragile。D3参照)
+
+### Files to Change (target: 10 or less)
+- `tests/test-directory-structure.sh` (new)
+- `scripts/validate-cycle-frontmatter.sh` (edit)
+- `skills/onboard/validation.md` (edit)
+- `skills/onboard/reference.md` (edit)
+
+## Environment
+
+### Scope
+- Layer: Shell + Docs
+- Plugin: bash
+- Risk: 15 (PASS)
+
+### Runtime
+- Language: bash (macOS/Linux portable)
+
+### Dependencies (key packages)
+- (none)
+
+### Risk Interview (BLOCK only)
+- (N/A - PASS)
+
+## Context & Dependencies
+
+### Reference Documents
+- `tests/test-plugin-structure.sh` - テストパターン参照元
+- `tests/test-frontmatter-integrity.sh` - TC-I1〜I11 リグレッション対象
+- `scripts/validate-cycle-frontmatter.sh` - 拡張対象 (現在: phase/complexity/test_count/risk_level値検証)
+- `skills/spec/templates/cycle.md` - 正規のfrontmatterテンプレート
+- `skills/onboard/validation.md` - 既存7チェック項目
+
+### Dependent Features
+- Phase 31 (Product Verification PoC) - 本Phaseが構造契約の前提となる
+
+### Related Issues/PRs
+- (none)
+
+## Test List
+
+### TODO
+- [ ] TC-DS01: docs/cycles/ ディレクトリが存在する
+- [ ] TC-DS02: 全Cycle docファイル名が YYYYMMDD_HHMM_*.md パターンに一致 (archive/除外)
+- [ ] TC-DS03: 新形式Cycle docが必須frontmatterフィールドを持つ (feature, cycle, created, updated)
+- [ ] TC-DS04: [Negative] 不正なファイル名パターンを検出 (fixture)
+- [ ] TC-DS05: [Negative] 必須frontmatterフィールド欠落を検出 (fixture)
+- [ ] TC-DS06: 旧形式Cycle doc (status:/title:) がスキップされる
+- [ ] TC-DS07: archiveディレクトリのdocがスキップされる
+- [ ] TC-DS08: frontmatterなしのCycle docがスキップされる
+- [ ] TC-DS09: ファイル名のタイムスタンプが妥当な範囲 (月01-12, 日01-31, 時00-23, 分00-59)
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+docs/cycles/ の構造規約を検証スクリプトで決定論的に強制する。Phase 31 (Product Verification PoC) の前提となる構造契約。
+
+### Background
+v2.6.0リリース後の品質強化。実態調査で以下の問題が判明:
+- Phase 29等の旧形式frontmatter (title/date/status) が混在
+- 一部Cycle docにfrontmatter自体がない (Phase 13, 14等)
+- ファイル命名パターンの検証なし
+
+### Design Approach
+
+**D1: Grandfathering** - 旧形式Cycle docは検証対象外。新テンプレート形式 (`feature:` フィールドあり) のみ検証。完了済みサイクルの移行はリスクに見合わない。
+
+**D2: Archive skip** - `docs/cycles/archive/` は検証対象外。
+
+**D3: Machine-critical invariants のみ**
+
+| Invariant | Level |
+|-----------|-------|
+| ファイル名 `YYYYMMDD_HHMM_*.md` | machine-critical |
+| 必須frontmatter (feature, cycle, phase, complexity, test_count, risk_level, created, updated) | machine-critical |
+| 有効なphase値 | machine-critical (既存validator) |
+| 本文の必須セクション | 対象外 (fragile) |
+
+**D4: 新形式検出ロジック** - frontmatter内に `feature:` があれば新形式とみなし検証。なければスキップ。
+
+**validate-cycle-frontmatter.sh の拡張**
+
+既存の `fm_val()` ヘルパーを再利用。phase検証の前に4フィールドの存在チェックを追加:
+```bash
+# 0. required field presence
+for FIELD in feature cycle created updated; do
+  VAL=$(fm_val "$FIELD")
+  if [ -z "$VAL" ]; then
+    error "required field missing or empty: '$FIELD'"
+  fi
+done
+```
+
+**新形式検出ロジック (test-directory-structure.sh)**
+```bash
+is_new_format() {
+  local file="$1"
+  head -20 "$file" | sed -n '/^---$/,/^---$/p' | grep -q "^feature:"
+}
+```
+
+**ファイル名バリデーション (ポータブル)**
+macOS/Linux両対応のため `date` コマンドでなく正規表現でバリデーション:
+```
+^[0-9]{4}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])_([01][0-9]|2[0-3])[0-5][0-9]_.+\.md$
+```
+
+## Progress Log
+
+### 2026-03-23 23:24 - KICKOFF
+- Design Review Gate: PASS (score: 10/100)
+- Cycle doc created
+- Scope definition confirmed
+
+### 2026-03-23 23:24 - SYNC-PLAN
+- sync-plan completed: Cycle doc generated from plan file
+- Plan Review: PASS (score: 10/100)
+- Phase completed
+
+---
+
+## Next Steps
+
+1. [Done] KICKOFF
+2. [Done] RED
+3. [Done] GREEN
+4. [Done] REFACTOR
+5. [Done] REVIEW (Security: PASS 8, Correctness: WARN 72, Aggregate: PASS 40)
+6. [Done] COMMIT

--- a/scripts/validate-cycle-frontmatter.sh
+++ b/scripts/validate-cycle-frontmatter.sh
@@ -43,6 +43,14 @@ fi
 # Helper: extract value for a key from frontmatter
 fm_val() { echo "$FM" | grep "^$1:" | head -1 | sed "s/^$1: *//"; }
 
+# 0. required field presence (Phase 30: directory structure strictification)
+for FIELD in feature cycle created updated; do
+  VAL=$(fm_val "$FIELD")
+  if [ -z "$VAL" ]; then
+    error "required field missing or empty: '$FIELD'"
+  fi
+done
+
 # 1. phase validation
 PHASE=$(fm_val phase)
 case "$PHASE" in

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -594,6 +594,17 @@ hookなし → セットアップ推奨。
 
 spec スキルの [templates/cycle.md](../spec/templates/cycle.md) をベースに `docs/cycles/YYYYMMDD_0000_project-setup.md` を作成。
 
+### Cycle doc命名規約
+
+| 要素 | 規約 | 例 |
+|------|------|-----|
+| ファイル名 | `YYYYMMDD_HHMM_<feature-name>.md` | `20260323_2324_phase30-directory-structure.md` |
+| YYYYMMDD | 日付 (ゼロ埋め) | `20260323` |
+| HHMM | 時刻 (24h, ゼロ埋め) | `2324` |
+| feature-name | kebab-case 識別子 | `phase30-directory-structure` |
+
+検証: `tests/test-directory-structure.sh` で自動チェック。
+
 ---
 
 ## 変数一覧

--- a/skills/onboard/validation.md
+++ b/skills/onboard/validation.md
@@ -13,6 +13,7 @@ onboard完了時の健全性チェック。FAILは警告のみ（修正は強制
 | 5 | .claude/rules/ | git-safety存在 | test -f .claude/rules/git-safety.md |
 | 6 | .claude/rules/ | security存在 | test -f .claude/rules/security.md |
 | 7 | CONSTITUTION.md | 存在確認 | test -f CONSTITUTION.md |
+| 8 | docs/cycles/ | 命名規約 | `ls docs/cycles/*.md 2>/dev/null \| xargs -I{} basename {} \| grep -vE '^[0-9]{8}_[0-9]{4}_.+\.md$'` が空 |
 
 ## 実行方法
 

--- a/tests/test-directory-structure.sh
+++ b/tests/test-directory-structure.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+# test-directory-structure.sh - docs/cycles/ directory structure validation
+# TC-DS01〜TC-DS09
+
+set -euo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf "  \033[32mPASS\033[0m %s\n" "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf "  \033[31mFAIL\033[0m %s\n" "$1"; }
+
+# Helper: 新形式判定 (frontmatter内に feature: があれば新形式)
+is_new_format() {
+  local file="$1"
+  head -20 "$file" | sed -n '/^---$/,/^---$/p' | grep -q "^feature:"
+}
+
+# Helper: frontmatter存在判定
+has_frontmatter() {
+  head -1 "$1" | grep -q "^---$"
+}
+
+# Helper: ファイル名パターン検証 (YYYYMMDD_HHMM_*.md)
+# macOS/Linux両対応の純粋正規表現マッチ
+is_valid_filename() {
+  local name="$1"
+  # bash extended glob: grepでポータブルに検証
+  echo "$name" | grep -qE \
+    '^[0-9]{4}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])_([01][0-9]|2[0-3])[0-5][0-9]_.+\.md$'
+}
+
+echo "=== Directory Structure Tests ==="
+
+# TC-DS01: docs/cycles/ ディレクトリが存在する
+echo ""
+echo "TC-DS01: docs/cycles/ directory exists"
+CYCLES_DIR="$BASE_DIR/docs/cycles"
+if [ -d "$CYCLES_DIR" ]; then
+  pass "docs/cycles/ directory exists"
+else
+  fail "docs/cycles/ directory does NOT exist"
+fi
+
+# TC-DS02: 全Cycle docファイル名が YYYYMMDD_HHMM_*.md パターンに一致 (archive/除外)
+echo ""
+echo "TC-DS02: all Cycle doc filenames match YYYYMMDD_HHMM_*.md pattern (excluding archive/)"
+invalid_names=()
+while IFS= read -r -d '' filepath; do
+  name="$(basename "$filepath")"
+  if ! is_valid_filename "$name"; then
+    invalid_names+=("$name")
+  fi
+done < <(find "$CYCLES_DIR" -maxdepth 1 -name "*.md" -print0 2>/dev/null)
+
+if [ "${#invalid_names[@]}" -eq 0 ]; then
+  pass "All Cycle doc filenames match YYYYMMDD_HHMM_*.md pattern"
+else
+  fail "Invalid filenames found: ${invalid_names[*]}"
+fi
+
+# TC-DS03: 新形式Cycle docが必須frontmatterフィールドを持つ (feature, cycle, phase, created, updated)
+echo ""
+echo "TC-DS03: new-format Cycle docs have required frontmatter fields"
+tc03_fail=0
+while IFS= read -r -d '' filepath; do
+  if ! has_frontmatter "$filepath"; then
+    continue
+  fi
+  if ! is_new_format "$filepath"; then
+    continue
+  fi
+  name="$(basename "$filepath")"
+  # frontmatter ブロック抽出: 1行目の --- から次の --- まで (awk でポータブルに)
+  fm_block=$(awk 'NR==1 && /^---$/{found=1; next} found && /^---$/{exit} found{print}' "$filepath")
+  for field in feature cycle phase created updated; do
+    if ! echo "$fm_block" | grep -q "^${field}:"; then
+      fail "[$name] required field missing: '$field'"
+      tc03_fail=$((tc03_fail + 1))
+    fi
+  done
+done < <(find "$CYCLES_DIR" -maxdepth 1 -name "*.md" -print0 2>/dev/null)
+
+if [ "$tc03_fail" -eq 0 ]; then
+  pass "All new-format Cycle docs have required frontmatter fields"
+fi
+
+# TC-DS04: [Negative] 不正なファイル名パターンを検出 (fixture)
+echo ""
+echo "TC-DS04: [Negative] detects invalid filename pattern"
+tmpdir=$(mktemp -d)
+touch "$tmpdir/invalid_name.md"
+touch "$tmpdir/20260399_9999_bad-timestamp.md"
+touch "$tmpdir/20260101_1200_valid.md"
+
+invalid_count=0
+for filepath in "$tmpdir"/*.md; do
+  name="$(basename "$filepath")"
+  if ! is_valid_filename "$name"; then
+    invalid_count=$((invalid_count + 1))
+  fi
+done
+
+if [ "$invalid_count" -eq 2 ]; then
+  pass "Correctly detected 2 invalid filenames (expected)"
+else
+  fail "Expected 2 invalid filenames, got $invalid_count"
+fi
+rm -rf "$tmpdir"
+
+# TC-DS05: [Negative] 必須frontmatterフィールド欠落を検出 (fixture)
+echo ""
+echo "TC-DS05: [Negative] detects missing required frontmatter field"
+tmpdir=$(mktemp -d)
+# feature フィールドはあるが created/updated が欠落した新形式doc
+cat > "$tmpdir/20260101_1200_missing-fields.md" << 'EOF'
+---
+feature: test-feature
+cycle: test-cycle
+phase: RED
+complexity: trivial
+test_count: 1
+risk_level: low
+---
+
+# Missing created/updated fields
+EOF
+
+found_missing=0
+filepath="$tmpdir/20260101_1200_missing-fields.md"
+if has_frontmatter "$filepath" && is_new_format "$filepath"; then
+  fm_block=$(awk 'NR==1 && /^---$/{found=1; next} found && /^---$/{exit} found{print}' "$filepath")
+  for field in feature cycle phase created updated; do
+    if ! echo "$fm_block" | grep -q "^${field}:"; then
+      found_missing=$((found_missing + 1))
+    fi
+  done
+fi
+
+if [ "$found_missing" -gt 0 ]; then
+  pass "Correctly detected $found_missing missing required fields in fixture"
+else
+  fail "Failed to detect missing frontmatter fields"
+fi
+rm -rf "$tmpdir"
+
+# TC-DS06: 旧形式Cycle doc (title:/status: フィールドあり、feature: なし) がスキップされる (fixture)
+echo ""
+echo "TC-DS06: old-format Cycle doc (no feature: field) is skipped"
+tmpdir=$(mktemp -d)
+# 旧形式: title:/status: あり、feature: なし
+cat > "$tmpdir/20260323_1352_old-format.md" << 'EOF'
+---
+phase: DONE
+title: "Phase 29: Old Format"
+date: 2026-03-23
+status: DONE
+---
+
+# Old Format Doc
+EOF
+
+skip_count=0
+filepath="$tmpdir/20260323_1352_old-format.md"
+if has_frontmatter "$filepath" && ! is_new_format "$filepath"; then
+  skip_count=$((skip_count + 1))
+fi
+
+if [ "$skip_count" -eq 1 ]; then
+  pass "Old-format Cycle doc correctly skipped (no feature: field)"
+else
+  fail "Old-format Cycle doc was NOT skipped"
+fi
+rm -rf "$tmpdir"
+
+# TC-DS07: archiveディレクトリのdocがスキップされる
+echo ""
+echo "TC-DS07: docs in archive/ directory are skipped"
+ARCHIVE_DIR="$CYCLES_DIR/archive"
+if [ -d "$ARCHIVE_DIR" ]; then
+  # find with maxdepth 1 excludes archive/ subdirectory
+  archive_in_main=$(find "$CYCLES_DIR" -maxdepth 1 -name "*.md" -path "*/archive/*" 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$archive_in_main" -eq 0 ]; then
+    pass "archive/ docs are not included in maxdepth 1 search (correctly excluded)"
+  else
+    fail "archive/ docs were unexpectedly included in main search"
+  fi
+else
+  pass "archive/ directory does not exist (no docs to skip)"
+fi
+
+# TC-DS08: frontmatterなしのCycle docがスキップされる (fixture)
+echo ""
+echo "TC-DS08: Cycle doc without frontmatter is skipped"
+tmpdir=$(mktemp -d)
+# frontmatterなしのdoc
+cat > "$tmpdir/20260101_1200_no-frontmatter.md" << 'EOF'
+# No Frontmatter Doc
+
+This document has no YAML frontmatter at all.
+EOF
+
+skip_count=0
+filepath="$tmpdir/20260101_1200_no-frontmatter.md"
+if ! has_frontmatter "$filepath"; then
+  skip_count=$((skip_count + 1))
+fi
+
+if [ "$skip_count" -eq 1 ]; then
+  pass "Doc without frontmatter correctly skipped"
+else
+  fail "Doc without frontmatter was NOT skipped"
+fi
+rm -rf "$tmpdir"
+
+# TC-DS09: ファイル名のタイムスタンプが妥当な範囲 (月01-12, 日01-31, 時00-23, 分00-59)
+echo ""
+echo "TC-DS09: filename timestamps are in valid range"
+tc09_fail=0
+
+# 妥当なタイムスタンプ (TC-DS09用、より厳密なパターンで検証)
+while IFS= read -r -d '' filepath; do
+  name="$(basename "$filepath")"
+  if ! is_valid_filename "$name"; then
+    continue
+  fi
+  # YYYYMMDD_HHMM から各要素を抽出
+  mm="${name:4:2}"   # 月 (05 in 20260523)
+  dd="${name:6:2}"   # 日
+  hh="${name:9:2}"   # 時 (後の _ を除く)
+  mn="${name:11:2}"  # 分
+
+  # 数値変換して範囲チェック
+  mm_num=$((10#$mm))
+  dd_num=$((10#$dd))
+  hh_num=$((10#$hh))
+  mn_num=$((10#$mn))
+
+  if [ "$mm_num" -lt 1 ] || [ "$mm_num" -gt 12 ]; then
+    fail "[$name] month out of range: $mm"
+    tc09_fail=$((tc09_fail + 1))
+  elif [ "$dd_num" -lt 1 ] || [ "$dd_num" -gt 31 ]; then
+    fail "[$name] day out of range: $dd"
+    tc09_fail=$((tc09_fail + 1))
+  elif [ "$hh_num" -gt 23 ]; then
+    fail "[$name] hour out of range: $hh"
+    tc09_fail=$((tc09_fail + 1))
+  elif [ "$mn_num" -gt 59 ]; then
+    fail "[$name] minute out of range: $mn"
+    tc09_fail=$((tc09_fail + 1))
+  fi
+done < <(find "$CYCLES_DIR" -maxdepth 1 -name "*.md" -print0 2>/dev/null)
+
+if [ "$tc09_fail" -eq 0 ]; then
+  pass "All Cycle doc timestamps are in valid range"
+fi
+
+# Summary
+echo ""
+echo "=== Summary ==="
+echo "PASS: $PASS / FAIL: $FAIL / TOTAL: $((PASS + FAIL))"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-frontmatter-integrity.sh
+++ b/tests/test-frontmatter-integrity.sh
@@ -276,6 +276,84 @@ else
   pass "TC-I11: unclosed frontmatter rejected"
 fi
 
+# --- Required field presence (Phase 30: directory structure strictification) ---
+
+# TC-I12: Missing feature field -> FAIL
+echo ""
+echo "TC-I12: Missing feature field -> FAIL"
+FIXTURE=$(make_fixture "i12.md" "$(cat <<'FM'
+cycle: test-cycle
+phase: RED
+complexity: standard
+test_count: 5
+risk_level: medium
+created: 2026-03-09 10:00
+updated: 2026-03-09 10:00
+FM
+)")
+if bash "$VALIDATOR" "$FIXTURE" >/dev/null 2>&1; then
+  fail "TC-I12: missing feature field accepted"
+else
+  pass "TC-I12: missing feature field rejected"
+fi
+
+# TC-I13: Missing cycle field -> FAIL
+echo ""
+echo "TC-I13: Missing cycle field -> FAIL"
+FIXTURE=$(make_fixture "i13.md" "$(cat <<'FM'
+feature: test-feature
+phase: GREEN
+complexity: standard
+test_count: 3
+risk_level: low
+created: 2026-03-09 10:00
+updated: 2026-03-09 10:00
+FM
+)")
+if bash "$VALIDATOR" "$FIXTURE" >/dev/null 2>&1; then
+  fail "TC-I13: missing cycle field accepted"
+else
+  pass "TC-I13: missing cycle field rejected"
+fi
+
+# TC-I14: Missing created field -> FAIL
+echo ""
+echo "TC-I14: Missing created field -> FAIL"
+FIXTURE=$(make_fixture "i14.md" "$(cat <<'FM'
+feature: test-feature
+cycle: test-cycle
+phase: RED
+complexity: trivial
+test_count: 2
+risk_level: low
+updated: 2026-03-09 10:00
+FM
+)")
+if bash "$VALIDATOR" "$FIXTURE" >/dev/null 2>&1; then
+  fail "TC-I14: missing created field accepted"
+else
+  pass "TC-I14: missing created field rejected"
+fi
+
+# TC-I15: Missing updated field -> FAIL
+echo ""
+echo "TC-I15: Missing updated field -> FAIL"
+FIXTURE=$(make_fixture "i15.md" "$(cat <<'FM'
+feature: test-feature
+cycle: test-cycle
+phase: RED
+complexity: standard
+test_count: 5
+risk_level: medium
+created: 2026-03-09 10:00
+FM
+)")
+if bash "$VALIDATOR" "$FIXTURE" >/dev/null 2>&1; then
+  fail "TC-I15: missing updated field accepted"
+else
+  pass "TC-I15: missing updated field rejected"
+fi
+
 # Summary
 echo ""
 echo "=== Summary ==="


### PR DESCRIPTION
## Summary

- `tests/test-directory-structure.sh` 新設: docs/cycles/ のファイル命名規約・frontmatterフォーマットを検証 (TC-DS01〜DS09)
- `validate-cycle-frontmatter.sh` 拡張: feature/cycle/created/updated フィールドの存在チェック追加
- `test-frontmatter-integrity.sh` 拡張: TC-I12〜I15 (必須フィールド欠落検出)
- onboard スキルに命名規約を反映 (validation.md, reference.md)
- 旧形式Cycle doc 8件に phase: DONE frontmatter追加 (pre-red-gate互換)

## Design Decisions

- **D1: Grandfathering**: 旧形式Cycle docは検証対象外 (`feature:` フィールドの有無で判定)
- **D2: Archive skip**: `docs/cycles/archive/` は対象外
- **D3: Machine-critical invariants のみ**: 本文セクション検証は fragile のため除外

## Test plan

- [ ] `bash tests/test-directory-structure.sh` → 9/9 PASS
- [ ] `bash tests/test-frontmatter-integrity.sh` → 15/15 PASS
- [ ] `for f in tests/test-*.sh; do bash "$f"; done` → リグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)