### PR TITLE
fix: pre-red/pre-commit gate 旧形式Cycle doc誤検出修正

### DIFF
--- a/docs/cycles/20260324_0003_fix-gate-old-format.md
+++ b/docs/cycles/20260324_0003_fix-gate-old-format.md
@@ -1,0 +1,136 @@
+---
+feature: pre-red-gate / pre-commit-gate 旧形式Cycle doc誤検出修正
+cycle: 20260324_0003_fix-gate-old-format
+phase: DONE
+complexity: trivial
+test_count: 3
+risk_level: low
+codex_session_id: ""
+created: 2026-03-24 00:03
+updated: 2026-03-24 00:03
+---
+
+# Issue #102: pre-red-gate.sh 旧形式Cycle doc誤検出修正
+
+## Scope Definition
+
+### In Scope
+- [ ] `pre-red-gate.sh` の active cycle 検出ロジック修正（`phase:` フィールド不在をスキップ）
+- [ ] `pre-commit-gate.sh` の同ロジック修正
+- [ ] `test-pre-red-gate.sh` に T-06, T-07 追加
+- [ ] `test-pre-commit-gate.sh` に T-06 追加
+
+### Out of Scope
+- test-phase-gate.sh の変更（リグレッション確認のみ、変更なし）
+
+### Files to Change (target: 10 or less)
+- `scripts/gates/pre-red-gate.sh` (edit)
+- `scripts/gates/pre-commit-gate.sh` (edit)
+- `tests/test-pre-red-gate.sh` (edit)
+- `tests/test-pre-commit-gate.sh` (edit)
+
+## Environment
+
+### Scope
+- Layer: Shell
+- Plugin: bash
+- Risk: 20 (PASS)
+
+### Runtime
+- Language: bash (zsh compatible)
+
+### Dependencies (key packages)
+- awk: POSIX
+- grep: POSIX
+
+### Risk Interview (BLOCK only)
+(N/A - PASS)
+
+## Context & Dependencies
+
+### Reference Documents
+- [CONSTITUTION.md](../../CONSTITUTION.md) - 原則6: 決定論的プロセス保証
+
+### Dependent Features
+- pre-red-gate.sh: TDD RED フェーズ前提チェック
+- pre-commit-gate.sh: COMMIT 前提チェック
+
+### Related Issues/PRs
+- Issue #102: pre-red-gate.sh 旧形式Cycle doc誤検出
+
+## Test List
+
+### TODO
+- [ ] TC-01 (pre-red T-06): 旧形式Cycle doc (phase:フィールドなし) がスキップされ、BLOCKになる
+  - Given: docs/cycles/ に phase: フィールドを持たないCycle docのみ存在
+  - When: pre-red-gate.sh を実行
+  - Then: exit 1 (BLOCK) かつ "No active Cycle doc" メッセージ
+- [ ] TC-02 (pre-red T-07): frontmatterなしCycle docがスキップされ、BLOCKになる
+  - Given: docs/cycles/ にfrontmatter（---区切り）を持たないCycle docのみ存在
+  - When: pre-red-gate.sh を実行
+  - Then: exit 1 (BLOCK)
+- [ ] TC-03 (pre-commit T-06): 旧形式Cycle doc (phase:フィールドなし) がスキップされ、BLOCKになる
+  - Given: docs/cycles/ に phase: フィールドを持たないCycle docのみ存在
+  - When: pre-commit-gate.sh を実行
+  - Then: exit 1 (BLOCK) かつ "No active Cycle doc" メッセージ
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+`pre-red-gate.sh` / `pre-commit-gate.sh` が旧形式Cycle doc（`phase:` フィールドなし）をnon-DONEとみなし、誤ってactiveとして扱うバグを修正する。
+
+### Background
+根本原因: `! grep -q 'phase: DONE'` が `phase:` フィールド自体の不在を区別できない。旧形式docは `phase: DONE` を含まないため、誤ってactiveとみなされる。
+
+### Design Approach
+
+**Before (両gate共通):**
+
+    if ! awk '/^---$/{c++;next} c==1{print}' "$f" | grep -q 'phase: DONE'; then
+      ACTIVE_CYCLE="$f"
+      break
+    fi
+
+**After:**
+
+    phase=$(awk '/^---$/{c++;next} c==1{print}' "$f" | grep '^phase:' | head -1 | sed 's/^phase: *//')
+    [ -z "$phase" ] && continue  # Skip docs without phase field
+    if [ "$phase" != "DONE" ]; then
+      ACTIVE_CYCLE="$f"
+      break
+    fi
+
+既存テストフィクスチャ（T-01〜T-05）は全て `phase: RED` or `phase: DONE` を含むため、リグレッションなし。
+
+## Progress Log
+
+### 2026-03-24 00:03 - KICKOFF
+- Design Review Gate: WARN (score: 15/100)
+  - 警告: Test List に Given/When/Then 形式の明示なし（planレベルでは許容、Cycle doc上で補完済み）
+- Cycle doc created
+- Scope definition ready
+
+### 2026-03-24 00:03 - INIT
+- Cycle doc created
+- Scope definition ready
+
+---
+
+## Next Steps
+
+1. [Done] INIT <- Current
+2. [Next] PLAN
+3. [ ] RED
+4. [ ] GREEN
+5. [ ] REFACTOR
+6. [ ] REVIEW
+7. [ ] COMMIT

--- a/scripts/gates/pre-commit-gate.sh
+++ b/scripts/gates/pre-commit-gate.sh
@@ -20,11 +20,13 @@ set -euo pipefail
 
 PROJECT_ROOT="${1:-.}"
 
-# Find active Cycle doc
+# Find active Cycle doc (skip docs without phase field)
 ACTIVE_CYCLE=""
 for f in "$PROJECT_ROOT"/docs/cycles/*.md; do
   [ -f "$f" ] || continue
-  if ! awk '/^---$/{c++;next} c==1{print}' "$f" | grep -q 'phase: DONE'; then
+  phase=$(awk '/^---$/{c++;next} c==1{print}' "$f" | grep '^phase:' | head -1 | sed 's/^phase: *//' || true)
+  [ -z "$phase" ] && continue  # Skip docs without phase field (old format / no frontmatter)
+  if [ "$phase" != "DONE" ]; then
     ACTIVE_CYCLE="$f"
     break
   fi

--- a/scripts/gates/pre-red-gate.sh
+++ b/scripts/gates/pre-red-gate.sh
@@ -20,11 +20,13 @@ set -euo pipefail
 
 PROJECT_ROOT="${1:-.}"
 
-# 1. Find active Cycle doc (phase != DONE)
+# 1. Find active Cycle doc (phase != DONE, skip docs without phase field)
 ACTIVE_CYCLE=""
 for f in "$PROJECT_ROOT"/docs/cycles/*.md; do
   [ -f "$f" ] || continue
-  if ! awk '/^---$/{c++;next} c==1{print}' "$f" | grep -q 'phase: DONE'; then
+  phase=$(awk '/^---$/{c++;next} c==1{print}' "$f" | grep '^phase:' | head -1 | sed 's/^phase: *//' || true)
+  [ -z "$phase" ] && continue  # Skip docs without phase field (old format / no frontmatter)
+  if [ "$phase" != "DONE" ]; then
     ACTIVE_CYCLE="$f"
     break
   fi

--- a/tests/test-pre-commit-gate.sh
+++ b/tests/test-pre-commit-gate.sh
@@ -136,6 +136,27 @@ else
   fail "Expected clean PASS, got rc=$rc output: $output"
 fi
 
+# T-06: BLOCK when only old-format Cycle doc exists (no phase: field)
+echo ""
+echo "T-06: BLOCK when old-format Cycle doc (no phase: field) is only doc"
+
+rm -f "$TMPDIR/docs/cycles/20260315_1400_active.md"
+cat > "$TMPDIR/docs/cycles/20260316_0053_old-format.md" <<'CYCLE'
+---
+title: "Old Format Phase 13"
+date: 2026-03-16
+status: IN_PROGRESS
+---
+# Old format cycle
+CYCLE
+
+output=$(bash "$SCRIPT" "$TMPDIR" 2>&1) && rc=$? || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -qi "cycle doc"; then
+  pass "BLOCK on old-format Cycle doc (no phase: field)"
+else
+  fail "Expected BLOCK (exit 1) on old-format doc, got rc=$rc output: $output"
+fi
+
 # Summary
 echo ""
 echo "=== Summary ==="

--- a/tests/test-pre-red-gate.sh
+++ b/tests/test-pre-red-gate.sh
@@ -137,6 +137,46 @@ else
   fail "Script file does not exist at $SCRIPT"
 fi
 
+# T-06: BLOCK when only old-format Cycle doc exists (no phase: field)
+echo ""
+echo "T-06: BLOCK when old-format Cycle doc (no phase: field) is only doc"
+
+# Remove previous active doc, add old-format only
+rm -f "$TMPDIR/docs/cycles/20260315_1300_active.md"
+cat > "$TMPDIR/docs/cycles/20260316_0053_old-format.md" <<'CYCLE'
+---
+title: "Old Format Phase 13"
+date: 2026-03-16
+status: IN_PROGRESS
+---
+# Old format cycle
+CYCLE
+
+output=$(bash "$SCRIPT" "$TMPDIR" 2>&1) && rc=$? || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -qi "cycle doc"; then
+  pass "BLOCK on old-format Cycle doc (no phase: field)"
+else
+  fail "Expected BLOCK (exit 1) on old-format doc, got rc=$rc output: $output"
+fi
+
+# T-07: BLOCK when only no-frontmatter Cycle doc exists
+echo ""
+echo "T-07: BLOCK when no-frontmatter Cycle doc is only doc"
+
+rm -f "$TMPDIR/docs/cycles/20260316_0053_old-format.md"
+cat > "$TMPDIR/docs/cycles/20260316_1200_no-fm.md" <<'CYCLE'
+# No Frontmatter Doc
+
+This doc has no YAML frontmatter at all.
+CYCLE
+
+output=$(bash "$SCRIPT" "$TMPDIR" 2>&1) && rc=$? || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -qi "cycle doc"; then
+  pass "BLOCK on no-frontmatter Cycle doc"
+else
+  fail "Expected BLOCK (exit 1) on no-frontmatter doc, got rc=$rc output: $output"
+fi
+
 # Summary
 echo ""
 echo "=== Summary ==="


### PR DESCRIPTION
## Summary

- `pre-red-gate.sh` / `pre-commit-gate.sh` が旧形式Cycle doc（`phase:` フィールドなし）をactiveとして扱うバグを修正
- `phase:` フィールドを明示的に抽出し、フィールドが存在しないdocはスキップする
- 両gateに同一修正を適用 + テスト追加 (T-06, T-07)

## Root Cause

`! grep -q 'phase: DONE'` が `phase:` フィールド自体の不在を区別できず、旧形式docをnon-DONE（=active）とみなしていた。

## Test plan

- [ ] `bash tests/test-pre-red-gate.sh` → 7/7 PASS
- [ ] `bash tests/test-pre-commit-gate.sh` → 5/5 PASS
- [ ] `bash tests/test-phase-gate.sh` → 22/22 PASS (regression)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)