### PR TITLE
fix: risk-classifier.sh の grep -vc 0件時に整数比較エラー

### DIFF
--- a/docs/cycles/20260326_1654_fix-risk-classifier-grep-vc.md
+++ b/docs/cycles/20260326_1654_fix-risk-classifier-grep-vc.md
@@ -1,0 +1,156 @@
+---
+feature: fix-risk-classifier-grep-vc
+cycle: 20260326_1654
+phase: COMMIT
+complexity: trivial
+test_count: 2
+risk_level: low
+codex_session_id: ""
+created: 2026-03-26 16:54
+updated: 2026-03-26 17:05
+---
+
+# fix: risk-classifier.sh の grep -vc 0件時に整数比較エラー
+
+## Scope Definition
+
+### In Scope
+- [ ] `skills/review/risk-classifier.sh` line 63 の grep -vc パターン修正
+- [ ] `docs/known-gotchas.md` line 32 の対策コード例を正しいパターンに修正
+
+### Out of Scope
+- (特になし)
+
+### Files to Change (target: 10 or less)
+- `skills/review/risk-classifier.sh` (edit)
+- `docs/known-gotchas.md` (edit)
+
+## Environment
+
+### Scope
+- Layer: Shell script (Bash)
+- Plugin: なし
+- Risk: 10 (PASS)
+
+### Runtime
+- Language: Bash (sh)
+
+### Dependencies (key packages)
+- (外部依存なし)
+
+### Risk Interview (BLOCK only)
+- (Risk: LOW のため非該当)
+
+## Context & Dependencies
+
+### Reference Documents
+- `skills/review/risk-classifier.sh` - 修正対象スクリプト
+- `docs/known-gotchas.md` - バグパターン記載ドキュメント（修正対象）
+- `tests/test-risk-classifier.sh` - 既存テストスイート
+
+### Dependent Features
+- plan-review スキル: risk-classifier.sh を呼び出す
+
+### Related Issues/PRs
+- (なし)
+
+## Test List
+
+### TODO
+(none)
+
+### WIP
+(none)
+
+### DONE
+- [x] TC-01 (T-08): Empty file list produces valid integer for file_count
+- [x] TC-02 (T-09): All files are fixture files (0 real files)
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+`risk-classifier.sh` の `grep -vc` が0件ヒット時に整数比較エラーが発生するバグを修正する。
+
+### Background
+`risk-classifier.sh` 63行目で `grep -vc` が0件ヒット時に exit code 1 + stdout "0" を返し、`|| echo "0"` が追加の "0" を出力するため `file_count="0\n0"` となる。整数比較 `[ "$file_count" -gt 5 ]` が失敗し、plan review が実行できない。
+
+加えて `docs/known-gotchas.md` にバグパターンが「対策」として記載されており、同じバグを再生産するリスクがある。
+
+### Design Approach
+
+**risk-classifier.sh line 63 修正:**
+
+Before:
+```bash
+file_count=$(grep -vcE '\.(scm|fixture|snap|mock|seed)$|fixtures/|__snapshots__/' "$FILES_LIST" 2>/dev/null || echo "0")
+```
+
+After:
+```bash
+file_count=$(grep -vcE '\.(scm|fixture|snap|mock|seed)$|fixtures/|__snapshots__/' "$FILES_LIST" 2>/dev/null) || file_count=0
+```
+
+根拠: 70行目の `has_modified` が同じパターンで正しく動作している。
+
+**docs/known-gotchas.md line 32 修正:**
+
+Before:
+```bash
+count=$(grep -c 'pattern' file 2>/dev/null || echo "0")
+```
+
+After:
+```bash
+count=$(grep -c 'pattern' file 2>/dev/null) || count=0
+```
+
+## Verification
+
+```bash
+bash tests/test-risk-classifier.sh
+```
+
+Evidence: 9/9 PASS (T-01~T-09)
+
+## Progress Log
+
+### 2026-03-26 16:54 - INIT
+- Cycle doc created
+- Scope definition ready
+
+### 2026-03-26 16:56 - RED
+- T-08, T-09 追加。T-08 FAIL確認（バグ再現）
+
+### 2026-03-26 16:58 - GREEN
+- risk-classifier.sh line 63: `|| echo "0"` → `) || file_count=0`
+- risk-classifier.sh line 82: dir_count パイプも同パターン修正
+- known-gotchas.md: 対策コード例を正しいパターンに修正
+- 9/9 PASS
+
+### 2026-03-26 17:00 - REFACTOR
+- チェックリスト全項目確認、改善不要
+- Verification Gate PASS (9/9)
+- Phase completed
+
+### 2026-03-26 17:05 - REVIEW
+- Correctness: PASS (25), Security: PASS (0)
+- Aggregate: PASS (12)
+- Phase completed
+
+---
+
+## Next Steps
+
+1. [Done] INIT
+2. [Done] PLAN
+3. [Done] RED
+4. [Done] GREEN
+5. [Done] REFACTOR
+6. [Done] REVIEW
+7. [Next] COMMIT

--- a/docs/cycles/20260326_1654_fix-risk-classifier-grep-vc.md
+++ b/docs/cycles/20260326_1654_fix-risk-classifier-grep-vc.md
@@ -1,7 +1,7 @@
 ---
 feature: fix-risk-classifier-grep-vc
 cycle: 20260326_1654
-phase: COMMIT
+phase: DONE
 complexity: trivial
 test_count: 2
 risk_level: low
@@ -153,4 +153,4 @@ Evidence: 9/9 PASS (T-01~T-09)
 4. [Done] GREEN
 5. [Done] REFACTOR
 6. [Done] REVIEW
-7. [Next] COMMIT
+7. [Done] COMMIT

--- a/docs/known-gotchas.md
+++ b/docs/known-gotchas.md
@@ -29,7 +29,7 @@ expected=$(realpath "$path2")
 
 ### 対策
 ```bash
-count=$(grep -c 'pattern' file 2>/dev/null || echo "0")
+count=$(grep -c 'pattern' file 2>/dev/null) || count=0
 ```
 
 ### 影響範囲

--- a/skills/review/risk-classifier.sh
+++ b/skills/review/risk-classifier.sh
@@ -60,7 +60,7 @@ if [ -f "$FILES_LIST" ]; then
   fi
 
   # File count > 5 (+15) - excluding low-risk file types
-  file_count=$(grep -vcE '\.(scm|fixture|snap|mock|seed)$|fixtures/|__snapshots__/' "$FILES_LIST" 2>/dev/null || echo "0")
+  file_count=$(grep -vcE '\.(scm|fixture|snap|mock|seed)$|fixtures/|__snapshots__/' "$FILES_LIST" 2>/dev/null) || file_count=0
   if [ "$file_count" -gt 5 ]; then
     score=$((score + 15))
   fi
@@ -79,7 +79,7 @@ if [ -f "$FILES_LIST" ]; then
   fi
 
   # Wide change - directory spread >= 3 (+15)
-  dir_count=$(grep '/' "$FILES_LIST" 2>/dev/null | awk -F/ '{print $1}' | sort -u | wc -l | tr -d ' ')
+  dir_count=$(grep '/' "$FILES_LIST" 2>/dev/null | awk -F/ '{print $1}' | sort -u | wc -l | tr -d ' ') || dir_count=0
   if [ "$dir_count" -ge 3 ]; then
     score=$((score + 15))
   fi

--- a/tests/test-risk-classifier.sh
+++ b/tests/test-risk-classifier.sh
@@ -167,6 +167,62 @@ else
 fi
 rm -f "$TMPFILES7" "$TMPDIFF7"
 
+# T-08: Empty file list produces valid integer for file_count
+echo ""
+echo "T-08: Empty file list produces valid integer for file_count"
+
+TMPFILES8=$(mktemp)
+TMPDIFF8=$(mktemp)
+
+# Given: FILES_LIST is empty (0 lines)
+: > "$TMPFILES8"
+: > "$TMPDIFF8"
+
+output8=$(bash "$SCRIPT" "$TMPFILES8" "$TMPDIFF8" 2>&1) && exit_code8=0 || exit_code8=$?
+# When: risk-classifier.sh is executed with empty file list
+# Then: output matches "LOW score:0" and exit code is 0
+if [ "$exit_code8" -eq 0 ] && echo "$output8" | grep -qE '^LOW score:0$'; then
+  pass "T-08: Empty file list outputs 'LOW score:0' and exits 0"
+else
+  fail "T-08: Empty file list failed. exit_code=$exit_code8, output='$output8'"
+fi
+rm -f "$TMPFILES8" "$TMPDIFF8"
+
+# T-09: All files are fixture files (0 real files) - no file_count bonus
+echo ""
+echo "T-09: All files are fixture files (0 real files)"
+
+TMPFILES9=$(mktemp)
+TMPDIFF9=$(mktemp)
+
+# Given: FILES_LIST contains only fixture files (grep -vc returns 0)
+cat > "$TMPFILES9" <<'FILES'
+tests/fixtures/data1.fixture
+tests/fixtures/data2.fixture
+tests/fixtures/data3.fixture
+tests/fixtures/data4.fixture
+tests/fixtures/data5.fixture
+tests/fixtures/data6.fixture
+FILES
+
+# Modified files exist so file_count bonus would apply if count were non-zero
+cat > "$TMPDIFF9" <<'DIFF'
+--- a/tests/fixtures/data1.fixture
++++ b/tests/fixtures/data1.fixture
++changed line
+DIFF
+
+output9=$(bash "$SCRIPT" "$TMPFILES9" "$TMPDIFF9" 2>&1) && exit_code9=0 || exit_code9=$?
+score9=$(echo "$output9" | grep -oE 'score:[0-9]+' | grep -oE '[0-9]+')
+# When: risk-classifier.sh is executed
+# Then: file_count bonus (+15) should NOT apply (0 real files), score stays 0
+if [ "$exit_code9" -eq 0 ] && [ -n "$score9" ] && [ "$score9" -lt 15 ]; then
+  pass "T-09: Fixture-only list produces no file_count bonus (score: $score9)"
+else
+  fail "T-09: Fixture-only list failed. exit_code=$exit_code9, output='$output9'"
+fi
+rm -f "$TMPFILES9" "$TMPDIFF9"
+
 # Summary
 echo ""
 echo "=== Summary ==="


### PR DESCRIPTION
## Summary
- `risk-classifier.sh` line 63 で `grep -vc` が0件ヒット時に `file_count="0\n0"` となり整数比較エラー
- `$(... || echo "0")` → `$(...) || file_count=0` に修正（line 70 の正しいパターンに統一）
- `docs/known-gotchas.md` の対策コード例も修正
- T-08, T-09 テスト追加（9/9 PASS）

## Test plan
- [x] `bash tests/test-risk-classifier.sh` 全テスト PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)