### PR TITLE
fix: Post-Approve Actionでsync-planを直接呼ばせない

### DIFF
--- a/.claude/rules/post-approve.md
+++ b/.claude/rules/post-approve.md
@@ -5,3 +5,11 @@ Plan mode を抜けたら `/orchestrate` を起動する。それだけ。
 orchestrate が sync-plan → plan-review → RED → GREEN → REFACTOR → REVIEW → COMMIT を全て管理する。
 
 Edit/Write は orchestrate 起動まで hook でブロックされる。
+
+## 禁止事項
+
+- `Skill(dev-crew:sync-plan)` の直接呼び出し禁止（sync-plan は Agent であり Skill ではない）
+- `Skill(dev-crew:review --plan)` の /orchestrate 外での呼び出し禁止
+- sync-plan → plan-review → orchestrate のような分解実行禁止
+
+全て `/orchestrate` に委譲すること。orchestrate が内部で適切に呼び出す。

--- a/agents/sync-plan.md
+++ b/agents/sync-plan.md
@@ -1,6 +1,6 @@
 ---
 name: sync-plan
-description: planファイルからCycle docを生成する軽量エージェント。spec内部からTask()で呼ばれる。ユーザー直接起動不可。
+description: planファイルからCycle docを生成する軽量エージェント。orchestrate内部からAgent()で呼ばれる。Skill()での直接呼び出し不可 — 必ず /orchestrate 経由で使用すること。
 model: sonnet
 ---
 

--- a/docs/cycles/20260326_1710_fix-post-approve-sync-plan-direct-call.md
+++ b/docs/cycles/20260326_1710_fix-post-approve-sync-plan-direct-call.md
@@ -1,0 +1,132 @@
+---
+feature: fix-post-approve-sync-plan-direct-call
+cycle: 20260326_1710
+phase: DONE
+complexity: trivial
+test_count: 3
+risk_level: low
+codex_session_id: ""
+created: 2026-03-26 17:10
+updated: 2026-03-26 17:20
+---
+
+# fix: Post-Approve Action で sync-plan を直接呼ばせない
+
+## Scope Definition
+
+### In Scope
+- [ ] agents/sync-plan.md の description に「Skill()での直接呼び出し不可」を追記
+- [ ] .claude/rules/post-approve.md に禁止事項セクションを追加
+- [ ] skills/onboard/reference.md の Post-Approve Action テンプレートを /orchestrate 一本に簡素化
+- [ ] tests/test-post-approve-action.sh のテストを orchestrate 経由に更新
+
+### Out of Scope
+- tests/test-onboard-tdd-workflow-template.sh のワークフロー概念図変更（直接呼び出し指示ではないため変更不要）
+
+### Files to Change (target: 10 or less)
+- agents/sync-plan.md (edit)
+- .claude/rules/post-approve.md (edit)
+- skills/onboard/reference.md (edit)
+- tests/test-post-approve-action.sh (edit)
+
+## Environment
+
+### Scope
+- Layer: Shell script (Bash) + Markdown
+- Plugin: N/A
+- Risk: LOW (PASS)
+
+### Runtime
+- Language: Bash / Markdown
+
+### Dependencies (key packages)
+- (なし)
+
+### Risk Interview (BLOCK only)
+- (Risk: LOW のためスキップ)
+
+## Context & Dependencies
+
+### Reference Documents
+- agents/sync-plan.md - 修正対象（description 強化）
+- .claude/rules/post-approve.md - 修正対象（禁止事項追加）
+- skills/onboard/reference.md - 修正対象（テンプレート簡素化）
+- tests/test-post-approve-action.sh - 修正対象（テスト更新）
+
+### Dependent Features
+- orchestrate: sync-plan を内部で Agent() として呼び出す設計
+
+### Related Issues/PRs
+- (なし)
+
+## Test List
+
+### TODO
+- [ ] TC-01: agents/sync-plan.md の description に「Skill()での直接呼び出し不可」が含まれる
+- [ ] TC-02: .claude/rules/post-approve.md に「Skill(dev-crew:sync-plan)」の直接呼び出し禁止が記載されている
+- [ ] TC-03: skills/onboard/reference.md の Post-Approve Action テンプレートが /orchestrate に委譲し、dev-crew:sync-plan の直接呼び出しを含まない
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+`Skill(dev-crew:sync-plan)` の "Unknown skill" エラーを防ぐ。sync-plan は Agent（subagent_type）であり Skill ではないため、LLM が Skill() で直接呼び出さないようドキュメントを修正する。
+
+### Background
+sync-plan は orchestrate が内部で Agent として呼ぶ設計だが、onboard テンプレートの Post-Approve Action セクションが `dev-crew:sync-plan` を直接呼ぶ手順を記載しているため、LLM がそのまま `Skill()` で呼んでしまい "Unknown skill" エラーになる。
+
+### Design Approach
+3点の修正で誤呼び出しを防止する:
+
+1. **agents/sync-plan.md description 強化**: 「Skill()での直接呼び出し不可 — 必ず /orchestrate 経由」を明記
+2. **.claude/rules/post-approve.md 禁止事項追加**: `Skill(dev-crew:sync-plan)` 直接呼び出し禁止、分解実行禁止を明記
+3. **onboard/reference.md テンプレート簡素化**: Post-Approve Action を「/orchestrate を起動する。それだけ。」に統一し、sync-plan/plan-review の個別手順を削除
+
+テスト (test-post-approve-action.sh) も「sync-plan が存在するか」から「/orchestrate への委譲か」「直接 sync-plan 呼び出しがないか」に更新する。
+
+## Verification
+
+```bash
+bash tests/test-post-approve-action.sh && bash tests/test-onboard-tdd-workflow-template.sh
+```
+
+Evidence: 23/23 PASS (test-post-approve-action 15 + test-onboard-tdd-workflow-template 8)
+
+## Progress Log
+
+### 2026-03-26 17:10 - INIT
+- Cycle doc created
+- Scope definition ready
+
+### 2026-03-26 17:12 - RED
+- TC-01, TC-02 追加、TC-03 更新。TC-01/TC-02 FAIL確認
+
+### 2026-03-26 17:15 - GREEN
+- sync-plan.md description 強化
+- post-approve.md 禁止事項セクション追加
+- onboard/reference.md テンプレート簡素���
+- 23/23 PASS
+
+### 2026-03-26 17:18 - REVIEW
+- PASS (LOW risk, docs-only changes)
+- Phase completed
+
+---
+
+## Next Steps
+
+1. [Done] INIT
+2. [Done] PLAN
+3. [Done] RED
+4. [Done] GREEN
+5. [Done] REFACTOR (skip - docs only)
+6. [Done] REVIEW
+7. [Done] COMMIT

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -418,16 +418,15 @@ Cycle docs: `docs/cycles/YYYYMMDD_HHMM_<topic>.md`
 
 ### Post-Approve Action
 
-Plan mode を抜けたら、直接実装に入らず以下を順に実行する:
+Plan mode を抜けたら `/orchestrate` を起動する。それだけ。
 
-1. Plan mode を抜けたら、Cycle Doc に内容をコピーする (`dev-crew:sync-plan`)
-   - Cycle Doc なしの実装は `pre-red-gate.sh` でブロックされる
-2. Cycle Doc をレビューする (`dev-crew:review --plan`)
-   - BLOCK 判定なら Plan に戻る
-3. レビュー通過後、実装フローを回す (`dev-crew:orchestrate`)
-   - RED → GREEN → REFACTOR → REVIEW → COMMIT を自律管理
-   - PASS/WARN → 自動進行、BLOCK → 再試行 → ユーザー報告
-   - COMMIT 前に `pre-commit-gate.sh` で REVIEW 完了を検証
+orchestrate が以下を全て内部で管理する:
+- sync-plan（Cycle doc 生成）
+- plan-review（設計レビュー）
+- RED → GREEN → REFACTOR → REVIEW → COMMIT
+
+sync-plan や review --plan を直接呼ばないこと（orchestrate 経由で呼ばれる）。
+Edit/Write は orchestrate 起動まで hook でブロックされる。
 ```
 
 ### CLAUDE.md 必須セクション

--- a/tests/test-post-approve-action.sh
+++ b/tests/test-post-approve-action.sh
@@ -40,11 +40,18 @@ else
   fail "onboard/reference.md TDD Workflow template missing Post-Approve Action"
 fi
 
-# Verify sync-plan appears before orchestrate in template's Post-Approve Action
-if awk '/Post-Approve Action/,/^```$/' "$TEMPLATE_FILE" | grep -q "sync-plan"; then
-  pass "onboard/reference.md Post-Approve Action has sync-plan"
+# Verify Post-Approve Action delegates to orchestrate (not direct sync-plan call)
+if awk '/Post-Approve Action/,/^```$/' "$TEMPLATE_FILE" | grep -q "/orchestrate"; then
+  pass "onboard/reference.md Post-Approve Action delegates to /orchestrate"
 else
-  fail "onboard/reference.md Post-Approve Action missing sync-plan"
+  fail "onboard/reference.md Post-Approve Action missing /orchestrate delegation"
+fi
+
+# Verify Post-Approve Action does NOT instruct direct sync-plan call
+if awk '/Post-Approve Action/,/^```$/' "$TEMPLATE_FILE" | grep -q 'dev-crew:sync-plan)'; then
+  fail "onboard/reference.md Post-Approve Action still has direct sync-plan call"
+else
+  pass "onboard/reference.md Post-Approve Action has no direct sync-plan call"
 fi
 
 # --- orchestrate/SKILL.md Block 0 ---
@@ -118,6 +125,23 @@ if grep -A 20 "socrates-plan-review" "$DIR/skills/orchestrate/reference.md" | gr
   pass "socrates plan review references CONSTITUTION"
 else
   fail "socrates plan review missing CONSTITUTION reference"
+fi
+
+# TC-NEW-01: sync-plan.md description に「Skill()不可」が記載されている
+echo "-- sync-plan description --"
+if grep -q 'Skill().*不可\|直接呼び出し不可' "$DIR/agents/sync-plan.md"; then
+  pass "sync-plan.md description has Skill() prohibition"
+else
+  fail "sync-plan.md description missing Skill() prohibition"
+fi
+
+# TC-NEW-02: post-approve.md に sync-plan 直接呼び出し禁止が記載
+echo "-- post-approve prohibition --"
+RULE_FILE="$DIR/.claude/rules/post-approve.md"
+if grep -q 'Skill(dev-crew:sync-plan)' "$RULE_FILE" && grep -q '禁止' "$RULE_FILE"; then
+  pass "post-approve.md has sync-plan direct call prohibition"
+else
+  fail "post-approve.md missing sync-plan direct call prohibition"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- `Skill(dev-crew:sync-plan)` が "Unknown skill" エラーになる問題を修正
- sync-plan agent description に「Skill()直接呼び出し不可」を明記
- post-approve.md に禁止事項セクション追加
- onboard テンプレートを `/orchestrate` 一本に簡素化

## Test plan
- [x] `bash tests/test-post-approve-action.sh` 15 PASS
- [x] `bash tests/test-onboard-tdd-workflow-template.sh` 8 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)