### PR TITLE
docs: STATUS/ROADMAP/CHANGELOGをv2.6.6に更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [2.6.6] - 2026-03-27
+
+post-approve-gate廃止とorchestrateプロセス強化。
+
+### Changed
+
+- post-approve-gateフラグを廃止し、orchestrate TaskCreateに移行
+- orchestrate TaskCreateの7件全登録を必須化
+
+## [2.6.5] - 2026-03-27
+
+Post-Approve Action安全性強化とバグ修正。
+
+### Fixed
+
+- Post-Approve Actionでsync-planを直接呼ばせないルール追加
+- risk-classifier.sh の grep -vc 0件時に整数比較エラー修正
+
+## [2.6.4] - 2026-03-26
+
+hook環境変数の修正。
+
+### Fixed
+
+- hookのpwdをCLAUDE_PROJECT_DIRに置換 + set -u除去
+
+## [2.6.3] - 2026-03-24
+
+バックログ整理。
+
+### Removed
+
+- babysit-prをBacklogから削除
+
 ## [2.0.2] - 2026-03-15
 
 Codex セッション分離と onboard テンプレート品質強化。

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,12 +5,13 @@
 
 ## 現在地
 
-v2.6.2 リリース済み。全完了済みバージョン:
+v2.6.6 リリース済み。全完了済みバージョン:
 - v2 (Phase 11-13): Claude + Codex 統合開発フロー
 - v2.4 (Phase 14-17): Review Taxonomy 体系化 (33→40 agents)
 - v2.5 (Phase 18): Constitution-Driven Enforcement
 - v2.6 (Phase 26-29): スキル成熟化 (Gotchas, On-demand hooks, PLUGIN_DATA)
 - v2.6.x (Phase 30-31, #84, #102): 構造厳格化 + Product Verification + designer AI review
+- v2.6.3-v2.6.6: バグ修正 + post-approve-gate廃止 + orchestrate TaskCreate導入
 - v2.7 (Phase 24-25): 動的スキルコンテンツ注入
 - v3 (Phase 1-8): Constitution-Driven Development
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,18 +5,22 @@
 | Metric | Value |
 |--------|-------|
 | In-Progress Cycles | 0 |
-| Done (unarchived) | 30 |
+| Done (unarchived) | 38 |
 | Archived Cycles | 37 |
 | Skills | 30 |
 | Agents | 41 |
 | Test Scripts | 98 |
 
-Last updated: 2026-03-24
+Last updated: 2026-03-27
 
 ## Completed (Recent)
 
 | Date | Cycle | Type |
 |------|-------|------|
+| 2026-03-27 | v2.6.6: post-approve-gate廃止 + orchestrate TaskCreate導入 | refactor |
+| 2026-03-27 | v2.6.5: Post-Approve sync-plan直接呼び出し禁止 + risk-classifier修正 | fix |
+| 2026-03-26 | v2.6.4: hookのpwdをCLAUDE_PROJECT_DIRに置換 | fix |
+| 2026-03-24 | v2.6.3: babysit-prバックログ削除 | chore |
 | 2026-03-24 | #84: designer AI生成UIレビュー観点追加 (P-13〜P-17) | feat |
 | 2026-03-24 | v2.6 Phase 31: Product Verification PoC | feat |
 | 2026-03-24 | #102: pre-red/pre-commit gate 旧形式Cycle doc誤検出修正 | fix |
@@ -71,6 +75,10 @@ Last updated: 2026-03-24
 - [x] v2.6 Phase 30: ディレクトリ構造厳格化
 - [x] v2.6 Phase 31: Product Verification PoC
 - [x] #84: designer AI生成UIレビュー観点追加
+- [x] v2.6.3: babysit-prバックログ削除
+- [x] v2.6.4: hookのpwd置換 + set -u除去
+- [x] v2.6.5: Post-Approve sync-plan直接呼び出し禁止 + risk-classifier修正
+- [x] v2.6.6: post-approve-gate廃止 + orchestrate TaskCreate導入
 
 詳細は [ROADMAP.md](../ROADMAP.md) 参照。
 


### PR DESCRIPTION
## Summary
- ROADMAP現在地をv2.6.2→v2.6.6に更新
- STATUS.mdにv2.6.3-v2.6.6の完了項目追加、Done数30→38
- CHANGELOGにv2.6.3-v2.6.6の4エントリ追加

## Test plan
- [ ] 各mdファイルのリンク・表記確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)