### PR TITLE
feat: v2.8 Cycle A1 — retro_status foundation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,30 @@ v2.6.6 リリース済み。全完了済みバージョン:
 - v2.7 (Phase 24-25): 動的スキルコンテンツ注入
 - v3 (Phase 1-8): Constitution-Driven Development
 
-次: 未定（Issue駆動 or 新バージョン計画）
+次: v2.8 Agile Loop（計画中）
+
+---
+
+## v2.8 Agile Loop（計画中）
+
+dev-crew 内 agile namespace で Cycle Retrospective + Goal Layer + Knowledge Lifecycle を吸収する。別プラグイン化しない。詳細は [ADR-002](docs/decisions/adr-cycle-retrospective.md)。
+
+| Step | 内容 | 状態 |
+|------|------|------|
+| 1   | cycle-retrospective (REVIEW→DISCOVERED→retro→COMMIT, auto blocking, 抽出のみ inline) | 未着手 |
+| 1b  | codify-insight (次回 /orchestrate 開始時 decide gate, codify/defer/no-codify を明示判断) | 未着手 |
+| 1.5 | captured 可視化 (未処理 insight 件数の警告) | 未着手 |
+| 2   | search-task → agile-next 化 + Goal doc 新設 (docs/goals/) | 未着手 |
+| 3a  | Cycle doc frontmatter 最小拡張 (cycle_id/goal_id/issue_id/status/retro_status/review_verdict/verification_status) | 未着手 |
+| -   | 運用評価ポイント（Step 3a 完了後、Step 3b 以降の必要性を再判定） | - |
+| 3b  | flow metrics 構造化 (本文 ## Metrics or sidecar) | 未着手 |
+| 4   | 知見 lifecycle (codify 先 artifact に origin_cycle / evidence_count / last_validated) | 未着手 |
+| 5   | knowledge-prune (手動起動、候補列挙のみ、削除実行は通常 cycle に乗せる) | 未着手 |
+
+### スコープ明文化（CONSTITUTION.md / docs/architecture.md に反映予定）
+
+- dev-crew が含む: Goal 定義 / Backlog 選択 / Cycle 実行 / Retrospective / Flow 分析 / Knowledge 管理
+- 含まない: 価値計測（実ユーザー反応・KPI）/ 事業横断 portfolio review / Marketing・Sales 判断 → 別社員として将来採用
 
 ---
 

--- a/agents/sync-plan.md
+++ b/agents/sync-plan.md
@@ -101,6 +101,7 @@ Output: Cycle doc生成完了。結果JSONを返却。
 | complexity | trivial/standard/complex (planのRiskから仮設定) |
 | test_count | Test Listのカウント |
 | risk_level | low/medium/high |
+| retro_status | none (Cycle 完了後に cycle-retrospective が captured/resolved に遷移) |
 | codex_session_id | "" (空文字。plan review 時に記録) |
 | created | 現在日時 |
 | updated | 現在日時 |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,18 +5,19 @@
 | Metric | Value |
 |--------|-------|
 | In-Progress Cycles | 0 |
-| Done (unarchived) | 38 |
+| Done (unarchived) | 39 |
 | Archived Cycles | 37 |
 | Skills | 30 |
 | Agents | 41 |
-| Test Scripts | 98 |
+| Test Scripts | 99 |
 
-Last updated: 2026-03-27
+Last updated: 2026-04-20
 
 ## Completed (Recent)
 
 | Date | Cycle | Type |
 |------|-------|------|
+| 2026-04-20 | v2.8 Cycle A1: retro_status foundation (validator + template + state-ownership + sync-plan) | feat |
 | 2026-03-27 | v2.6.6: post-approve-gate廃止 + orchestrate TaskCreate導入 | refactor |
 | 2026-03-27 | v2.6.5: Post-Approve sync-plan直接呼び出し禁止 + risk-classifier修正 | fix |
 | 2026-03-26 | v2.6.4: hookのpwdをCLAUDE_PROJECT_DIRに置換 | fix |
@@ -79,8 +80,19 @@ Last updated: 2026-03-27
 - [x] v2.6.4: hookのpwd置換 + set -u除去
 - [x] v2.6.5: Post-Approve sync-plan直接呼び出し禁止 + risk-classifier修正
 - [x] v2.6.6: post-approve-gate廃止 + orchestrate TaskCreate導入
+- [x] v2.8 Cycle A1: retro_status foundation (Step 1+1b 一括から Cycle 分割した結果の最小基盤) — 2026-04-20 完了
+- [ ] v2.8 Cycle A2: cycle-retrospective skill 本体 + orchestrate 統合 + pre-commit-gate enable + workflow/architecture/README/AGENTS/CLAUDE 同期 (Codex BLOCK 対応で分離)
+- [ ] v2.8 Step 1: cycle-retrospective skill (advisory, auto blocking, 抽出のみ inline)
+- [ ] v2.8 Step 1b: codify-insight skill (次回 /orchestrate 開始時 decide gate)
+- [ ] v2.8 Step 1.5: captured 可視化
+- [ ] v2.8 Step 2: search-task → agile-next 化 + Goal doc 新設
+- [ ] v2.8 Step 3a: Cycle doc frontmatter 最小拡張
+- [ ] (運用評価ポイント — Step 3b 以降の必要性を再判定)
+- [ ] v2.8 Step 3b: flow metrics 構造化
+- [ ] v2.8 Step 4: 知見 lifecycle (artifact metadata)
+- [ ] v2.8 Step 5: knowledge-prune
 
-詳細は [ROADMAP.md](../ROADMAP.md) 参照。
+詳細は [ROADMAP.md](../ROADMAP.md) 参照。設計根拠は [ADR-002](decisions/adr-cycle-retrospective.md)。
 
 ## Cycle Doc Lifecycle
 

--- a/docs/cycles/20260420_1314_v2.8-retro-foundation.md
+++ b/docs/cycles/20260420_1314_v2.8-retro-foundation.md
@@ -1,0 +1,364 @@
+---
+feature: v2.8-retro-foundation
+cycle: 20260420_1314
+phase: DONE
+complexity: standard
+test_count: 9
+risk_level: low
+retro_status: none
+codex_session_id: ""
+created: 2026-04-20 13:14
+updated: 2026-04-20 14:00
+---
+
+# v2.8 Agile Loop Cycle A1 — retro_status Foundation
+
+## Scope Definition
+
+### In Scope
+
+- [ ] `skills/spec/templates/cycle.md` 編集: frontmatter に `retro_status: none` を追加 (placeholder セクションは入れない、Codex 2nd #2 対応)
+- [ ] `agents/sync-plan.md` 編集: Cycle doc 初期化時に `retro_status: none` を frontmatter に含める旨を明記
+- [ ] `scripts/validate-cycle-frontmatter.sh` 編集:
+  - frontmatter 内 retro_status の値が none|captured|resolved 以外なら reject
+  - フィールド不在は許容 (legacy doc 互換)
+  - body 内 (frontmatter 範囲外) に **行頭** `retro_status:` が現れる場合は body contamination として detect (Codex 2nd #5 対応、判定基準は行頭限定で確定)
+- [ ] `rules/state-ownership.md` 編集: retro_status owner ルール追加 (sync-plan が初期化、cycle-retrospective が遷移と予告)
+- [ ] `tests/test-frontmatter-retro-status.sh` 新規: fixture-based validator test (9 TC)
+
+### Out of Scope
+
+#### Cycle A2 (次サイクル):
+- skills/cycle-retrospective/SKILL.md / reference.md (本体)
+- skills/orchestrate/SKILL.md / reference.md / steps-subagent.md / steps-teams.md / steps-codex.md (Block 2f 統合 + idempotency check)
+- skills/commit/SKILL.md (Pre-COMMIT Gate に retro_status check)
+- scripts/gates/pre-commit-gate.sh (retro_status check enable)
+- tests/test-pre-commit-gate-retro.sh / test-cycle-retrospective.sh
+- docs/workflow.md / docs/architecture.md (cycle-retrospective 追記)
+- README.md / AGENTS.md / CLAUDE.md / docs/STATUS.md (skill count + 構成同期)
+- override の proceed / abort 分離
+
+#### Cycle B (codify-insight, 元 Step 1b):
+- skills/codify-insight/* (decide gate)
+- captured insight queue 管理
+- codify now の artifact 自動生成 (codify 用 cycle 起票 or GitHub issue)
+
+### Files to Change (target: 10 or less)
+
+| Path | 操作 | 理由 |
+|------|------|------|
+| skills/spec/templates/cycle.md | edit | frontmatter に retro_status: none 追加 |
+| agents/sync-plan.md | edit | 初期化に retro_status: none を含める |
+| scripts/validate-cycle-frontmatter.sh | edit | retro_status 値検証 + body contamination check |
+| rules/state-ownership.md | edit | retro_status owner ルール |
+| tests/test-frontmatter-retro-status.sh | new | fixture-based test |
+
+合計 5 ファイル (new 1 / edit 4)。
+
+## Environment
+
+### Scope
+
+- Layer: Backend (markdown 設定 + shell スクリプト + bash テスト)
+- Plugin: dev-crew 自身のメタ開発
+- Risk: 30 (WARN)
+
+### Runtime
+
+- bash 5.x / awk / yamllint / jq
+
+### Risk Interview (WARN)
+
+- **代替案**: ADR-002 で複数案検討済み。Codex 2 連続 BLOCK を受けて scope を最小基盤に絞った版がベスト
+- **影響範囲**: validator は既存 cycle に対しても実行されるが retro_status 不在許容で互換性確保。state-ownership 追記は宣言のみで挙動非変更
+
+## Context & Dependencies
+
+### Reference Documents
+
+- [docs/decisions/adr-cycle-retrospective.md] - ADR-002: cycle-retrospective + codify-insight 設計
+- [ROADMAP.md] - v2.8 Agile Loop 計画
+
+### Upstream Context
+
+dev-crew の TDD サイクルは技術的に完結しているが、サイクル中の「最初の失敗 → 最終解 → 事前知識化」のループが閉じていない。これを mizchi/retrospective-codify 方式で実装する設計を ADR-002 で固定済み。
+
+当初 Step 1+1b 一括実装を試みたが、Codex plan-review で 2 連続 BLOCK (5 + 5 = 10 懸念点)。Files to Change が 22+ に肥大化したため、ユーザー判断で **Cycle 分割** に方針転換:
+
+- **Cycle A1 (本サイクル)**: `retro_status` field の最小基盤のみ。validator / template / sync-plan agent / state-ownership / fixture test
+- **Cycle A2 (次サイクル)**: cycle-retrospective skill 本体 + orchestrate 統合 (Block 2f) + pre-commit-gate enable + commit/SKILL.md + workflow/architecture/README/AGENTS/CLAUDE/STATUS 同期
+- **Cycle B (次次サイクル以降)**: codify-insight (元 Step 1b) を別 spec から仕切り直し
+
+### Codex 懸念への扱い (10 点中 A1 で対処する点)
+
+| # | 懸念 | A1 対応 |
+|---|------|---------|
+| 1ラウンド目 #1 決定論的 gate 欠落 | A2 で pre-commit-gate.sh 改修 |
+| 1ラウンド目 #2 orchestrate 実体 scope 漏れ | A2 で steps-*.md 改修 |
+| 1ラウンド目 #3 retro_status 契約矛盾 | **A1 で部分対処**: state-ownership.md の sync-plan 行に `retro_status (= none)` を追加。cycle-retrospective 行の transition 記述は A2 で skill 実装と同時に追加 (dead field 化防止) |
+| 1ラウンド目 #4 codify now 実効性 | Cycle B (codify-insight) で対処 |
+| 1ラウンド目 #5 構造テスト偏重 | **A1 で対処**: fixture-based validator test |
+| 2ラウンド目 #1 idempotency | A2 で Block 2f に `retro_status != none なら skip` 明記 |
+| 2ラウンド目 #2 append vs placeholder 矛盾 | **A1 で対処**: template に placeholder を **入れない**。A2 で cycle-retrospective が EOF append する方針 |
+| 2ラウンド目 #3 override 拒否時の弱さ | A2 で proceed / abort/BLOCK の 2 路に分離 |
+| 2ラウンド目 #4 root docs 同期漏れ | A2 で README/AGENTS/CLAUDE/STATUS 同期 (skill 追加が A2) |
+| 2ラウンド目 #5 body contamination test 漏れ | **A1 で対処**: validator に body 内 retro_status 検出 + negative test |
+
+## Test List
+
+### TODO
+
+- [ ] TC-01: cycle.md template に retro_status: none フィールド追加
+  - Given: skills/spec/templates/cycle.md
+  - When: grep "retro_status: none" を実行
+  - Then: ヒット
+- [ ] TC-02: cycle.md template に ## Retrospective placeholder が**ない** (Codex 2nd #2 対応: A2 で append に統一するため A1 では先置きしない)
+  - Given: skills/spec/templates/cycle.md
+  - When: grep "## Retrospective" を実行
+  - Then: ヒットしない (もしくは "Next Steps" 等の隣接セクションのみ)
+- [ ] TC-03: agents/sync-plan.md が retro_status: none 初期化を含める記述あり
+  - Given: agents/sync-plan.md
+  - When: grep "retro_status" を実行
+  - Then: 「none で初期化」相当の記述ヒット
+- [ ] TC-04: validate-cycle-frontmatter.sh が retro_status: none/captured/resolved を accept (fixture)
+  - Given: 各値を持つ test fixture .md (frontmatter のみ含む 3 ファイル、tests/fixtures/ 配下に配置 or test 内で動的生成)
+  - When: validate-cycle-frontmatter.sh を fixture に対して実行
+  - Then: 全て exit code 0
+- [ ] TC-05: validate-cycle-frontmatter.sh が retro_status: invalid を reject (fixture)
+  - Given: retro_status: active の fixture
+  - When: validate-cycle-frontmatter.sh を実行
+  - Then: exit code 非 0、stderr に retro_status を含む
+- [ ] TC-06: validate-cycle-frontmatter.sh が retro_status フィールド不在を許容 (legacy compat, fixture)
+  - Given: retro_status を持たない fixture
+  - When: validate-cycle-frontmatter.sh を実行
+  - Then: exit code 0
+- [ ] TC-07: validate-cycle-frontmatter.sh が body 内の **行頭** retro_status: を contamination detect (Codex 2nd #5 対応, fixture)
+  - **判定基準確定**: 「frontmatter 範囲外で **行頭** に `retro_status:` が現れる」を contamination とする (Codex 3rd 推奨に従い行頭のみ確定)。インライン文字列 (`Some text retro_status: ...`) は誤検知回避のため検出対象外
+  - Given: frontmatter に retro_status: none を持ち、body 内に **行頭** で `retro_status: captured` を含む fixture (state-like metadata 混入)
+  - When: validate-cycle-frontmatter.sh を実行
+  - Then: exit code 非 0、stderr に body contamination または retro_status を含む
+- [ ] TC-07b: validate-cycle-frontmatter.sh が inline 文字列内の retro_status: を誤検知しない (行頭限定の確認)
+  - Given: frontmatter に retro_status: none を持ち、body 内にインライン文字列 `Some text retro_status: captured` を含む fixture (行頭でない)
+  - When: validate-cycle-frontmatter.sh を実行
+  - Then: exit code 0 (誤検知なし)
+- [ ] TC-08: rules/state-ownership.md の sync-plan 行に retro_status 記載 (既存 2 列 format 維持)
+  - Given: rules/state-ownership.md
+  - When: sync-plan を含む行を検索
+  - Then: その行に "retro_status" を含む (cycle-retrospective 行は A2 で追加するため A1 では不要)
+- [ ] TC-09: validator が present-but-empty retro_status を reject (REVIEW で Codex BLOCK 対応として追加)
+  - Given: `retro_status:` (空値) と `retro_status:    ` (whitespace のみ) の fixture
+  - When: validate-cycle-frontmatter.sh を実行
+  - Then: 両方 exit 非 0、stderr に "invalid retro_status" を含む
+
+### WIP
+
+(none)
+
+### DISCOVERED
+
+- sync-plan.md は `phase: RED` で初期化、template は `phase: INIT`。このズレは A1 scope 外。別 cycle で対応。
+
+### DONE
+
+(none)
+
+## Implementation Notes
+
+### Goal
+
+`retro_status` field の最小基盤を作る。具体的には:
+1. 新規 cycle で sync-plan が `retro_status: none` を frontmatter に含める
+2. validator が retro_status 値を検証 (none/captured/resolved 以外 reject、不在許容、body contamination detect)
+3. state-ownership.md に owner ルール記載
+
+これにより A2 で cycle-retrospective skill 本体と pre-commit-gate enable を入れたとき、基盤が既にあるためスムーズに gate 化できる。
+
+### Design Approach
+
+#### skills/spec/templates/cycle.md
+
+```yaml
+# 既存 frontmatter に 1 行追加 (retro_status: none を risk_level の後に挿入)
+# フィールド例: feature, cycle, phase (INIT), complexity, test_count, risk_level, retro_status (none), codex_session_id, created, updated
+```
+
+`## Retrospective` placeholder は **入れない** (A2 で cycle-retrospective skill が EOF append する方針)。
+
+#### agents/sync-plan.md
+
+Cycle doc 生成時の frontmatter テンプレートに `retro_status: none` を追加。既存の他フィールドと同列。
+
+#### scripts/validate-cycle-frontmatter.sh
+
+既存の case ブロック (phase / complexity / risk_level) と同パターンで `retro_status` ケース追加:
+
+```bash
+# 既存 case ブロックと同パターン
+retro_status)
+  case "$VALUE" in
+    none|captured|resolved) ;;
+    *) error "invalid retro_status value: '$VALUE' (expected: none|captured|resolved)" ;;
+  esac
+  ;;
+```
+
+**フィールド不在は許容** (required リストには含めない)。
+
+**body contamination check** (新規):
+
+```bash
+# Body 部分 (frontmatter 後) に行頭 retro_status: が現れたら contamination
+BODY_CONTAMINATED=$(awk '/^---$/{c++;next} c>=2{print}' "$FILE" | grep -c '^retro_status:' || echo 0)
+if [ "$BODY_CONTAMINATED" -gt 0 ]; then
+  error "retro_status appears in body (state-like metadata leak). Should only be in frontmatter."
+fi
+```
+
+#### rules/state-ownership.md
+
+**既存 format に合わせて修正** (Codex 3rd #1 対応): 現行の Frontmatter Update Permissions テーブルは 2 列 (Phase / Allowed Updates)。3 列形式は採用せず、既存 sync-plan 行に retro_status を追加するのみ。
+
+```markdown
+| sync-plan | Initialize all frontmatter fields (feature, phase, complexity, test_count, risk_level, retro_status (= none), created, updated) |
+```
+
+`cycle-retrospective` 行は **A1 では追加しない** (未実装 skill を予告ベースで書くと dead field 化リスク、Codex 指摘)。Cycle A2 で skill 本体実装と同時に行追加する。
+
+#### tests/test-frontmatter-retro-status.sh
+
+fixture-based test。test 内で `mktemp -d` で一時ディレクトリを作成し、各 fixture を動的生成して validate-cycle-frontmatter.sh に渡す。
+
+テスト構造 (詳細は tests/test-frontmatter-retro-status.sh 参照):
+
+- `mktemp -d` で一時ディレクトリ作成、EXIT trap で自動削除
+- assert_pass / assert_fail ヘルパー関数で PASS/FAIL カウント
+- TC-04: retro_status が none/captured/resolved の 3 fixture を動的生成 → assert_pass
+- TC-05: retro_status: active の fixture → assert_fail (stderr に "retro_status")
+- TC-06: retro_status フィールド不在の fixture → assert_pass
+- TC-07: body 内に行頭 `retro_status: captured` を含む fixture → assert_fail (stderr に "body")
+- TC-07b: body 内にインライン `Some text retro_status: captured` を含む fixture → assert_pass
+- 最後に `echo "PASS: $PASS, FAIL: $FAIL"` 出力 + `exit $FAIL`
+
+## Verification
+
+```bash
+# 1. fixture-based validator test
+bash /Users/morodomi/Projects/MorodomiHoldings/agents/dev-crew/tests/test-frontmatter-retro-status.sh
+
+# 2. 既存全テスト regression 確認
+for f in /Users/morodomi/Projects/MorodomiHoldings/agents/dev-crew/tests/test-*.sh; do
+  echo "--- $(basename $f) ---"
+  bash "$f" 2>&1 | tail -3
+done
+
+# 3. 既存 cycle docs (retro_status 不在) が引き続き valid
+for f in /Users/morodomi/Projects/MorodomiHoldings/agents/dev-crew/docs/cycles/*.md; do
+  bash /Users/morodomi/Projects/MorodomiHoldings/agents/dev-crew/scripts/validate-cycle-frontmatter.sh "$f" || echo "FAIL: $f"
+done
+
+# 4. 構造検査
+grep -n "retro_status" /Users/morodomi/Projects/MorodomiHoldings/agents/dev-crew/skills/spec/templates/cycle.md
+grep -n "retro_status" /Users/morodomi/Projects/MorodomiHoldings/agents/dev-crew/agents/sync-plan.md
+grep -n "retro_status" /Users/morodomi/Projects/MorodomiHoldings/agents/dev-crew/rules/state-ownership.md
+```
+
+Evidence: (orchestrate が自動記入)
+
+## A1 Exit Conditions
+
+### 検証可能な exit 条件 (commit 前必須)
+
+1. **A1 commit メッセージに A2 plan の予約を含める**: commit message body に `Next cycle (A2): cycle-retrospective skill 本体 + orchestrate 統合 + pre-commit-gate enable + workflow/architecture/README/AGENTS/CLAUDE/STATUS 同期` を明記。grep 可能な行として残す
+2. **A1 完了直後 (commit 後 1 時間以内目安) に A2 spec を起票**: plan mode で `/spec` から A2 を切り出す。A2 起票が完了したら、A1 の Cycle doc Progress Log の COMMIT エントリに `→ A2 cycle: docs/cycles/<A2 cycle id>` を追記 (append-only)
+
+### 手続き宣言 (運用上の責務)
+
+3. **workflow.md / architecture.md の cycle-retrospective 同期は A2 で必須** (ADR-002 Consequences 要件)
+4. **README/AGENTS/CLAUDE/STATUS.md の skill count 同期は A2 で必須** (commit/SKILL.md ドキュメント更新慣行)
+5. **A1 単体で commit するが**、retro_status: none のまま長期放置はしない。A2 完了までを 1 まとまりとして扱う
+
+## Progress Log
+
+### 2026-04-20 - COMMIT
+
+- pre-commit-gate.sh: PASS (REVIEW + Codex review 記録あり、STATUS.md 同期済み)
+- 変更ファイル: 9 (M 6 + new 3)
+  - M: ROADMAP.md, docs/STATUS.md, agents/sync-plan.md, rules/state-ownership.md, scripts/validate-cycle-frontmatter.sh, skills/spec/templates/cycle.md
+  - new: docs/cycles/20260420_1314_v2.8-retro-foundation.md, docs/decisions/adr-cycle-retrospective.md, tests/test-frontmatter-retro-status.sh
+- A1 Exit Conditions:
+  - #1 commit message に A2 plan 予約を明記 (本 commit で実施)
+  - #2 A2 spec 起票は本 commit 直後に実施予定 (同セッション内で別 spec)
+- Phase completed
+
+### 2026-04-20 - REVIEW
+
+- review --code 実行 (Claude security-reviewer + correctness-reviewer + Codex competitive)
+- security-reviewer: PASS (blocking_score 5)。optional 1 件: テストの set -uo pipefail に -e 欠如 (プロジェクト既知パターン、実害なし)
+- correctness-reviewer: PASS (blocking_score 18)。important 1 件: TC-04 で複数値 reject 時の FAIL カウント過剰問題。optional 3 件
+- **Codex review: BLOCK** — `retro_status:` (present-but-empty) が validator で accept される実装バグ。最小 fixture で再現確認済み
+- **対応**: GREEN 再実行 (max 1 回ルール内)
+  - validate-cycle-frontmatter.sh の retro_status check を「キー存在 vs 値非空」分離に修正 (`RETRO_STATUS_PRESENT=$(grep -c)` → 存在時は値検証必須、空文字も reject)
+  - tests に TC-09 追加: present-but-empty (`retro_status:`) と whitespace-only (`retro_status:    `) を reject 検証
+  - correctness-reviewer の TC-04 important 指摘も同時対応: TC-04 を 1 TC として一回 pass/fail する構造に修正 (FAIL カウント過剰防止)
+  - 再テスト: PASS 10/10 (FAIL 0)
+- 注: test_count frontmatter は 9 のまま (REVIEW phase は phase/updated のみ更新可、state-ownership 遵守)。本文 Test List の TC-09 追加は append-only で記録
+- Phase completed
+
+### 2026-04-20 - REFACTOR
+
+- 対象: scripts/validate-cycle-frontmatter.sh
+- チェックリスト確認結果:
+  - 重複コード: section 6 の retro_status body contamination check (専用 awk) と既存 FIELDS loop (lines 98-102) が重複していたため統合。retro_status を既存 loop の FIELDS リスト末尾に追加して DRY 化 (-7 行)
+  - 定数化 / 未使用 import / let→const / メソッド分割 / N+1 / 命名一貫性: いずれも該当なし
+- Verification Gate: PASS (test-frontmatter-retro-status.sh 9/9 PASS、既存テスト regression なし)
+- Phase completed
+
+### 2026-04-20 - GREEN
+
+- 編集ファイル 4 つ:
+  1. skills/spec/templates/cycle.md: frontmatter に `retro_status: none` 追加 (risk_level の直下)
+  2. agents/sync-plan.md: Frontmatter Initialization テーブルに `retro_status` 行追加
+  3. scripts/validate-cycle-frontmatter.sh: retro_status 値検証 (none|captured|resolved) + body contamination check 追加 (optional field として grep に `|| true` ハンドリング)
+  4. rules/state-ownership.md: sync-plan 行に `retro_status (= none)` 追記
+- テスト実行結果: PASS 9 / FAIL 0 / TOTAL 9
+- regression 確認: 既存テスト全 PASS (既存 FAIL は変更前から存在)
+
+### 2026-04-20 - RED
+
+- テストファイル作成: tests/test-frontmatter-retro-status.sh (9 TC)
+- テスト実行結果: PASS 4 / FAIL 5 / TOTAL 9
+- FAIL TCs (実装が必要):
+  - TC-01: FAIL — cycle.md template に retro_status: none フィールドなし (grep no match)
+  - TC-03: FAIL — agents/sync-plan.md に retro_status 記述なし (grep no match)
+  - TC-05: FAIL — validator が retro_status: active を reject しない (実装なし)
+  - TC-07: FAIL — validator が body 内行頭 retro_status: を検出しない (contamination check 未実装)
+  - TC-08: FAIL — rules/state-ownership.md の sync-plan 行に retro_status なし (grep no match)
+- PASS TCs (設計上 RED でも pass が正常):
+  - TC-02: PASS — cycle.md template に ## Retrospective が存在しない (negative test、仕様通り)
+  - TC-04: PASS — validator が retro_status フィールドを無視 (unknown field は素通り) → accept の結果は正しいが retro_status 専用ロジック未実装
+  - TC-06: PASS — validator が retro_status 不在を素通り (legacy compat として正しい結果)
+  - TC-07b: PASS — validator が body 内 retro_status を未実装のため inline も行頭も区別なく通過 (偶然 pass)
+- 注意事項: TC-04/06/07b は「retro_status 専用ロジックがなく素通り」による偶発的 pass。TC-05/07 実装後に TC-04/06/07b が引き続き pass であることを GREEN で確認する
+
+### 2026-04-20 13:14 - KICKOFF
+
+- Cycle doc 生成 (sync-plan via architect)
+- Design Review Gate: PASS (score: 12)
+- plan: /Users/morodomi/.claude/plans/validated-marinating-hopper.md (v5 最終版)
+- v5 追加修正: (1) Codex 1ラウンド目 #3 行を「A1 で部分対処、cycle-retrospective 行は A2」に修正 (2) TC-07 行頭明記 + TC-07b (inline 誤検知防止) 追加 (test_count=9) (3) A1 Exit Conditions に検証可能条件追加
+- Codex review: 4 ラウンド実施済み (5 ラウンド目は overengineering と判断してスキップ)
+
+---
+
+## Next Steps
+
+1. [Done] KICKOFF
+2. [Done] RED
+3. [Done] GREEN
+4. [Done] REFACTOR
+5. [Done] REVIEW (Codex BLOCK → GREEN re-run → 10 TC PASS)
+6. [Done] COMMIT <- Current
+
+A2 spec を即起票 (A1 Exit Conditions #2)。
+5. [ ] REVIEW
+6. [ ] COMMIT

--- a/docs/cycles/20260420_1314_v2.8-retro-foundation.md
+++ b/docs/cycles/20260420_1314_v2.8-retro-foundation.md
@@ -3,12 +3,12 @@ feature: v2.8-retro-foundation
 cycle: 20260420_1314
 phase: DONE
 complexity: standard
-test_count: 9
+test_count: 10
 risk_level: low
 retro_status: none
 codex_session_id: ""
 created: 2026-04-20 13:14
-updated: 2026-04-20 14:00
+updated: 2026-04-20 14:15
 ---
 
 # v2.8 Agile Loop Cycle A1 — retro_status Foundation
@@ -157,6 +157,8 @@ dev-crew の TDD サイクルは技術的に完結しているが、サイクル
 ### DISCOVERED
 
 - sync-plan.md は `phase: RED` で初期化、template は `phase: INIT`。このズレは A1 scope 外。別 cycle で対応。
+- state-ownership.md の REVIEW 行: 「Body log only」と書きつつ BLOCK→GREEN 再実行時は実質的に GREEN 相当の作業 (TC 追加) が発生。test_count 更新権限の整理が必要 (本 A1 では準用で対応)。
+- cycle doc の Verification セクション: 「既存 cycle docs が引き続き valid」の repo-wide 確認は元から不可能 (古い cycle docs が validator を通らない)。誤誘導記述。template / sync-plan agent 側で Verification の書き方ガイドを整備すべき。
 
 ### DONE
 
@@ -278,6 +280,17 @@ Evidence: (orchestrate が自動記入)
 5. **A1 単体で commit するが**、retro_status: none のまま長期放置はしない。A2 完了までを 1 まとまりとして扱う
 
 ## Progress Log
+
+### 2026-04-20 - POST-COMMIT FIX
+
+Codex post-commit review (commit 717e232) で 2 件の妥当な指摘:
+
+- **P2 test_count stale**: frontmatter `test_count: 9` のままだが Test List は 10 TC (TC-09 を REVIEW で追加)。downstream metric scripts (例: scripts/analyze-cycle-complexity.sh) が誤値を読む。
+  - 対応: frontmatter `test_count: 10` に修正。state-ownership は REVIEW で test_count 更新を許可しないが、本ケースは BLOCK→GREEN 再実行で実質的に GREEN 相当の作業 (TC 追加) を含むため、RED の test_count 更新権限を準用して修正。state-ownership.md 自体の更新ルール明確化は別 cycle 課題として DISCOVERED 化を検討。
+- **P3 TC-03/08 が presence のみ確認**: `retro_status` field が存在するかしか見ていないため、`= none` 初期化契約の regression を捕捉できない (e.g. 将来 default を変更しても tests は pass)。
+  - 対応: TC-03 を強化 — retro_status を含む行に "none" も含むことを assert。TC-08 を強化 — sync-plan 行に `retro_status[^|]*none` の regex マッチを assert。
+- 再テスト: 10 TC 全 PASS (回帰なし)
+- 残留リスク (Codex 注記): cycle doc の Verification セクションは「既存 cycle docs が引き続き valid」と書いたが、repo に元から validator を通らない古い cycle doc が複数存在するため、緑回帰確認には使えない。本セクションの記述は誤誘導なので別 cycle で削除/修正する課題として記録。
 
 ### 2026-04-20 - COMMIT
 

--- a/docs/decisions/adr-cycle-retrospective.md
+++ b/docs/decisions/adr-cycle-retrospective.md
@@ -1,0 +1,99 @@
+# ADR-002: cycle-retrospective + codify-insight 設計（v2.8 Agile Loop Step 1+1b）
+
+## Status: accepted
+
+## Context
+
+dev-crew の TDD サイクルは spec → orchestrate → sync-plan → plan-review → RED → GREEN → REFACTOR → REVIEW → COMMIT で完結している。一方、サイクル中の「最初の失敗 → 最終解 → 事前知識化」のループは閉じていない。既存の learn / evolve は hook ログから非同期にパターンを抽出する仕組みで、failure-success ペアの言語化は扱わない。
+
+mizchi/chezmoi-dotfiles の `retrospective-codify` skill を参考に、サイクル末で技術知見を codify するループを dev-crew に組み込む方針を検討した。
+
+設計は Codex との 2 ラウンドの批判的レビューを経て合意した。Codex の主要な修正提案を取り込んだ最終仕様を本 ADR に固定する。
+
+## Decision Scorecard
+
+| 項目 | 評価 | 理由 |
+|------|------|------|
+| Requirements Fit | A | 既存 learn/evolve では拾えない failure-success ペアの codify ループを閉じる |
+| Security | A | inline 実行は抽出のみで repo 改変は Cycle doc の append に限定。codify は人間承認 |
+| Operability | B | auto blocking で忘却防止。extraction failure 時は retry + override で hard-block を回避 |
+| Complexity | C | 5 ステップに分割、Step 3a 完了後に運用評価で 3b 以降の必要性を再判定 |
+| Testability | B | inline 抽出は LLM 出力依存。Cycle doc セクション追記・frontmatter 状態遷移は検証可能 |
+
+## Arguments
+
+### Accepted
+
+- **位置**: cycle-retrospective を REVIEW → DISCOVERED 処理 → cycle-retrospective → COMMIT に配置。同じ COMMIT に Retrospective セクションを含める（post-commit の worktree 汚染を回避）
+- **inline 範囲**: blocking path には抽出のみ。dedup と codify target 分類は codify-insight 側で実行（重い処理を inline から外す）
+- **失敗時挙動**: retry 上限 N 回 + ユーザー override 可。LLM 都合の一時失敗で hard-block しない
+- **codify-insight = decide gate**: 次回 /orchestrate 開始時、`retro_status: captured` がある Cycle に対し、各 insight に `codify now` / `defer with reason` / `no-codify` を選択させる。「明示判断」のみ強制、「codify 実行」は強制しない（緊急修正フローを止めない）
+- **状態モデル**: frontmatter は `retro_status: none | captured | resolved` の 3 値。本文 insight 個別に `codified | deferred | no-codify` を持たせる
+- **resolved の意味**: 全 insight 処理方針が決定済み（codify 実行有無は問わない）。「insight なし」と「override skip」も resolved に含める
+- **rejected insight は instinct 自動送りしない**: 軸が違う（採用/却下 = 意思決定、codify/instinct = 知識成熟度）ので混ぜない
+- **Goal doc**: 2-8 Cycle / 1-3 週の中間粒度。docs/goals/YYYYMMDD_<name>.md。時間箱なし、達成 or abandon で閉じる
+- **frontmatter 最小化**: cycle_id / goal_id / issue_id / status / retro_status / review_verdict / verification_status まで。phase metrics は本文 ## Metrics か sidecar に逃がす
+- **timestamp は orchestrate のみが書く**: 各 phase skill や hook は書かない
+- **agile namespace で dev-crew 内吸収**: 別プラグイン化しない。`dev-crew:agile-*` 命名で内部 namespace 整理
+- **flow-analyze / knowledge-prune は最初手動**: 定期実行は運用で価値が見えてから
+- **段階的実装**: Step 1 → 1.5 → 2 → 3a → 運用評価 → 3b → 4 → 5
+
+### Rejected
+
+- **COMMIT 後に新 gate を足す**: worktree が汚れ、TDD の完了定義が崩れる
+- **N Cycle = Sprint**: AI では 1 cycle の重さが揺れすぎ、N を先に決めても意味がない
+- **Stakeholder proxy 役**: 実ユーザー入力なしだと AI が自分で作った acceptance criteria を自分で採点する
+- **Velocity tracker に authority を持たせる**: 計測器に留めるべき
+- **LLM 抽出失敗を hard-block**: モデル都合の一時失敗まで停止させるとフローが弱くなる
+- **codify 実行を強制**: ast-grep ルールや skill 追記は実質的にプロダクト変更で、別 cycle に分けるべき場合がある。緊急修正前に強制すると詰まる。decide gate で十分
+- **rejected insight → instinct 自動送り**: 採用/却下と知識成熟度を混ぜると学習系が濁る
+- **frontmatter に phase metrics 全載せ**: 既存の validate-cycle-frontmatter.sh と state-ownership.md をほぼ作り直しになる。会話コンテキストも圧迫
+- **agile-crew 別プラグイン化**: 社員モデル膨張防止のため namespace で吸収
+- **8 事業 sprint 同期**: project-local flow + portfolio sync の方が AI-first に合う
+
+### Deferred
+
+- Step 3a 完了後の運用評価で Step 3b 以降の必要性を再判定
+- マルチプロジェクト global view（将来 repo 外 index で集約）
+- Sprint overlay（cadence 管理が必要になったら導入）
+- agile-crew 系で auto-discovery 劣化が顕在化した場合の追加対策（公開 skill 制限・narrow trigger 化）
+
+## Decision
+
+v2.8 Agile Loop の Step 1+1b として以下を実装する。残りステップは Step 1+1b の運用結果を踏まえて段階的に進める。
+
+### Step 1: cycle-retrospective skill
+
+- 配置: `skills/cycle-retrospective/SKILL.md`
+- 起動: REVIEW 合格 → DISCOVERED 処理 → cycle-retrospective → COMMIT に自動 blocking で挿入
+- 入力: 当該 Cycle doc 全体（plan / phase summaries / review verdicts / test failures / retry log / DISCOVERED 処理結果）
+- 処理: failure → final fix → insight ペアを抽出（mizchi 方式）。dedup と codify target 分類は実行しない
+- 出力: Cycle doc の `## Retrospective` セクションに append、frontmatter `retro_status: captured` を立てる
+- 失敗時: retry 上限 N 回（推奨 2 回）。超過した場合はユーザー override を求める
+  - override 採択時は `## Retrospective` に `Extraction skipped by override` を残し、`retro_status: resolved` に遷移
+  - 全 retry 失敗で override も拒否された場合は `Extraction failed after N retries` を残す（同じく `resolved`）
+  - **override は `no-codify` に偽装しない**。`no-codify` は実際に抽出された insight への判断にのみ使う
+
+### Step 1b: codify-insight skill
+
+- 配置: `skills/codify-insight/SKILL.md`
+- 起動: 次回 /orchestrate 開始時、`docs/cycles/` をスキャンして `retro_status: captured` がある Cycle が見つかったら自動起動（新 Cycle 開始の前段）
+- 処理: captured insight ごとにユーザーへ提示し、以下のいずれかを必ず選択させる
+  - `codify now`: 即時 ast-grep / CLAUDE.md / skill に書き出し、または codify 用の新 cycle を起票
+  - `defer with reason`: 後回し。理由必須
+  - `no-codify`: 採用しない。理由は任意
+- 全 insight 処理完了で `retro_status: resolved` に遷移
+- 強制対象は「明示判断」のみ。codify 実行を強制しない
+
+### 学びゼロケース
+
+- 抽出結果が空の場合、`## Retrospective` に `No reusable lesson this cycle` を残し `retro_status: resolved` で完了
+- decide gate もスキップ（処理対象なし）
+
+## Consequences
+
+- 知見の codify ループが閉じる。failure-success ペアを retrospective が、横断観測パターンを learn/evolve が担う、という責務分離が成立する
+- /orchestrate 起動時に decide gate が走るため、初回適用時には既存 cycle に対して captured が無い前提（migration 不要）
+- LLM 抽出失敗時の override 経路により hard-block を回避する一方、運用初期に override が多発する可能性がある。retry 件数と override 発生は flow-analyze（Step 3b）で監視対象とする
+- 既存 learn / evolve / known-gotchas / DISCOVERED との境界を明文化する必要があるため、Step 1 実装時に workflow.md と architecture.md を同時更新する
+- agile namespace を導入することで dev-crew のスキル数が増える。auto-discovery 劣化の兆候が出たら Deferred 項目（公開制限・narrow trigger）を発動する

--- a/rules/state-ownership.md
+++ b/rules/state-ownership.md
@@ -24,7 +24,7 @@ Cycle doc records what was done; source files define what is.
 
 | Phase | Allowed Updates |
 |-------|----------------|
-| sync-plan | Initialize all frontmatter fields (feature, phase, complexity, test_count, risk_level, created, updated) |
+| sync-plan | Initialize all frontmatter fields (feature, phase, complexity, test_count, risk_level, retro_status (= none), created, updated) |
 | red | complexity, test_count, phase, updated |
 | green | phase, updated |
 | refactor | phase, updated |

--- a/scripts/validate-cycle-frontmatter.sh
+++ b/scripts/validate-cycle-frontmatter.sh
@@ -80,8 +80,19 @@ case "$RISK_LEVEL" in
   *) error "invalid risk_level value: '$RISK_LEVEL'" ;;
 esac
 
-# 5. body contamination check
-for FIELD in phase complexity test_count risk_level; do
+# 5. retro_status validation (optional field — absence is allowed for legacy compat,
+#    but if the key is present it must have a valid value; empty/whitespace-only is rejected)
+RETRO_STATUS_PRESENT=$(echo "$FM" | grep -c "^retro_status:" || true)
+if [ "$RETRO_STATUS_PRESENT" -gt 0 ]; then
+  RETRO_STATUS=$(echo "$FM" | grep "^retro_status:" | head -1 | sed "s/^retro_status: *//")
+  case "$RETRO_STATUS" in
+    none|captured|resolved) ;;
+    *) error "invalid retro_status value: '$RETRO_STATUS' (expected: none|captured|resolved)" ;;
+  esac
+fi
+
+# 6. body contamination check (state-like metadata leak)
+for FIELD in phase complexity test_count risk_level retro_status; do
   if echo "$BODY" | grep -q "^${FIELD}:"; then
     error "state-like metadata in body: '${FIELD}:'"
   fi

--- a/skills/spec/templates/cycle.md
+++ b/skills/spec/templates/cycle.md
@@ -12,6 +12,7 @@ phase: INIT
 complexity: [trivial|standard|complex]
 test_count: [number]
 risk_level: [low|medium|high]
+retro_status: none
 codex_session_id: ""
 created: YYYY-MM-DD HH:MM
 updated: YYYY-MM-DD HH:MM

--- a/tests/test-frontmatter-retro-status.sh
+++ b/tests/test-frontmatter-retro-status.sh
@@ -74,14 +74,21 @@ else
 fi
 
 # TC-03: agents/sync-plan.md includes retro_status: none initialization
+# Strengthened (Codex P3): assert that the same line containing retro_status also specifies "none"
+# default — presence alone is insufficient (would pass on any text mentioning the field).
 echo ""
-echo "TC-03: agents/sync-plan.md includes retro_status initialization"
+echo "TC-03: agents/sync-plan.md includes retro_status: none initialization (default contract)"
 if [ ! -f "$SYNC_PLAN_AGENT" ]; then
   fail "TC-03: agents/sync-plan.md does not exist"
-elif grep -q "retro_status" "$SYNC_PLAN_AGENT"; then
-  pass "TC-03: agents/sync-plan.md contains retro_status reference"
 else
-  fail "TC-03: agents/sync-plan.md does NOT contain retro_status"
+  RETRO_LINE="$(grep "retro_status" "$SYNC_PLAN_AGENT" | head -1 || true)"
+  if [ -z "$RETRO_LINE" ]; then
+    fail "TC-03: agents/sync-plan.md does NOT contain retro_status"
+  elif echo "$RETRO_LINE" | grep -q "none"; then
+    pass "TC-03: agents/sync-plan.md initializes retro_status to none (line: '$RETRO_LINE')"
+  else
+    fail "TC-03: agents/sync-plan.md mentions retro_status but does NOT specify 'none' default (line: '$RETRO_LINE')"
+  fi
 fi
 
 # TC-04: validate-cycle-frontmatter.sh accepts retro_status: none/captured/resolved
@@ -174,18 +181,24 @@ if [ "$TC09_PASS" = "true" ]; then
   pass "TC-09: validator rejected present-but-empty retro_status (empty + whitespace-only)"
 fi
 
-# TC-08: rules/state-ownership.md sync-plan row mentions retro_status
+# TC-08: rules/state-ownership.md sync-plan row mentions retro_status with default
+# Strengthened (Codex P3): assert the sync-plan row specifies the "= none" default,
+# not just the field name. Otherwise default semantics regression slips through.
 echo ""
-echo "TC-08: rules/state-ownership.md sync-plan row includes retro_status"
+echo "TC-08: rules/state-ownership.md sync-plan row includes retro_status (= none) default"
 if [ ! -f "$STATE_OWNERSHIP" ]; then
   fail "TC-08: rules/state-ownership.md does not exist"
 else
-  # Find the sync-plan row and check it contains retro_status
   SYNCPLAN_LINE="$(grep "sync-plan" "$STATE_OWNERSHIP" || true)"
   if [ -z "$SYNCPLAN_LINE" ]; then
     fail "TC-08: rules/state-ownership.md has no sync-plan entry"
   elif echo "$SYNCPLAN_LINE" | grep -q "retro_status"; then
-    pass "TC-08: rules/state-ownership.md sync-plan row contains retro_status"
+    # Stricter check: must also document the default value
+    if echo "$SYNCPLAN_LINE" | grep -qE "retro_status[^|]*none"; then
+      pass "TC-08: rules/state-ownership.md sync-plan row specifies retro_status with 'none' default"
+    else
+      fail "TC-08: rules/state-ownership.md sync-plan row mentions retro_status but does NOT specify 'none' default (line: $SYNCPLAN_LINE)"
+    fi
   else
     fail "TC-08: rules/state-ownership.md sync-plan row does NOT contain retro_status (line: $SYNCPLAN_LINE)"
   fi

--- a/tests/test-frontmatter-retro-status.sh
+++ b/tests/test-frontmatter-retro-status.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# test-frontmatter-retro-status.sh - retro_status field foundation tests
+# TC-01 to TC-08 (9 TCs total) for v2.8 Agile Loop Cycle A1
+
+set -uo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+TMPDIR_FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_FIXTURE"' EXIT
+
+pass() { PASS=$((PASS + 1)); printf "  \033[32mPASS\033[0m %s\n" "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf "  \033[31mFAIL\033[0m %s\n" "$1"; }
+
+# Helper: build a minimal valid cycle doc fixture (frontmatter + body)
+make_fixture() {
+  local file="$1"
+  local retro_line="$2"   # e.g. "retro_status: none" or "" (empty = omit field)
+  local body="$3"         # additional body lines (may be empty)
+
+  {
+    echo "---"
+    echo "feature: test-feature"
+    echo "cycle: 20260101_0000"
+    echo "phase: RED"
+    echo "complexity: standard"
+    echo "test_count: 1"
+    echo "risk_level: low"
+    if [ -n "$retro_line" ]; then
+      echo "$retro_line"
+    fi
+    echo 'codex_session_id: ""'
+    echo "created: 2026-01-01 00:00"
+    echo "updated: 2026-01-01 00:00"
+    echo "---"
+    echo ""
+    echo "# Test Fixture"
+    echo ""
+    if [ -n "$body" ]; then
+      echo "$body"
+    fi
+  } > "$file"
+}
+
+VALIDATOR="$BASE_DIR/scripts/validate-cycle-frontmatter.sh"
+CYCLE_TEMPLATE="$BASE_DIR/skills/spec/templates/cycle.md"
+SYNC_PLAN_AGENT="$BASE_DIR/agents/sync-plan.md"
+STATE_OWNERSHIP="$BASE_DIR/rules/state-ownership.md"
+
+echo "=== retro_status Foundation Tests (v2.8 Cycle A1) ==="
+
+# TC-01: cycle.md template contains retro_status: none field
+echo ""
+echo "TC-01: cycle.md template has retro_status: none field"
+if [ ! -f "$CYCLE_TEMPLATE" ]; then
+  fail "TC-01: skills/spec/templates/cycle.md does not exist"
+elif grep -q "retro_status: none" "$CYCLE_TEMPLATE"; then
+  pass "TC-01: cycle.md template contains retro_status: none"
+else
+  fail "TC-01: cycle.md template does NOT contain retro_status: none"
+fi
+
+# TC-02: cycle.md template does NOT have a ## Retrospective placeholder section
+echo ""
+echo "TC-02: cycle.md template has NO ## Retrospective placeholder"
+if [ ! -f "$CYCLE_TEMPLATE" ]; then
+  fail "TC-02: skills/spec/templates/cycle.md does not exist"
+elif grep -q "^## Retrospective" "$CYCLE_TEMPLATE"; then
+  fail "TC-02: cycle.md template CONTAINS ## Retrospective placeholder (should be absent)"
+else
+  pass "TC-02: cycle.md template correctly has no ## Retrospective placeholder"
+fi
+
+# TC-03: agents/sync-plan.md includes retro_status: none initialization
+echo ""
+echo "TC-03: agents/sync-plan.md includes retro_status initialization"
+if [ ! -f "$SYNC_PLAN_AGENT" ]; then
+  fail "TC-03: agents/sync-plan.md does not exist"
+elif grep -q "retro_status" "$SYNC_PLAN_AGENT"; then
+  pass "TC-03: agents/sync-plan.md contains retro_status reference"
+else
+  fail "TC-03: agents/sync-plan.md does NOT contain retro_status"
+fi
+
+# TC-04: validate-cycle-frontmatter.sh accepts retro_status: none/captured/resolved
+# Counted as a single TC: pass once if all 3 accepted, fail once otherwise (avoids inflating FAIL count)
+echo ""
+echo "TC-04: validator accepts retro_status none/captured/resolved"
+TC04_PASS=true
+TC04_REJECTED=""
+for val in none captured resolved; do
+  fixture="$TMPDIR_FIXTURE/tc04_${val}.md"
+  make_fixture "$fixture" "retro_status: ${val}" ""
+  if ! bash "$VALIDATOR" "$fixture" 2>/dev/null; then
+    TC04_PASS=false
+    TC04_REJECTED="${TC04_REJECTED}${val} "
+  fi
+done
+if [ "$TC04_PASS" = "true" ]; then
+  pass "TC-04: validator accepted all valid retro_status values (none/captured/resolved)"
+else
+  fail "TC-04: validator rejected valid value(s): $TC04_REJECTED"
+fi
+
+# TC-05: validate-cycle-frontmatter.sh rejects retro_status: active (invalid)
+echo ""
+echo "TC-05: validator rejects retro_status: active (invalid value)"
+fixture_05="$TMPDIR_FIXTURE/tc05_invalid.md"
+make_fixture "$fixture_05" "retro_status: active" ""
+stderr_05="$(bash "$VALIDATOR" "$fixture_05" 2>&1 >/dev/null || true)"
+if bash "$VALIDATOR" "$fixture_05" 2>/dev/null; then
+  fail "TC-05: validator accepted retro_status: active (should reject)"
+elif echo "$stderr_05" | grep -qi "retro_status"; then
+  pass "TC-05: validator rejected retro_status: active with retro_status in stderr"
+else
+  fail "TC-05: validator rejected but stderr did not mention retro_status (got: $stderr_05)"
+fi
+
+# TC-06: validate-cycle-frontmatter.sh accepts missing retro_status field (legacy compat)
+echo ""
+echo "TC-06: validator accepts missing retro_status field (legacy compat)"
+fixture_06="$TMPDIR_FIXTURE/tc06_absent.md"
+make_fixture "$fixture_06" "" ""
+if bash "$VALIDATOR" "$fixture_06" 2>/dev/null; then
+  pass "TC-06: validator accepted cycle doc without retro_status field"
+else
+  fail "TC-06: validator rejected cycle doc without retro_status field (should accept for legacy compat)"
+fi
+
+# TC-07: validate-cycle-frontmatter.sh detects body-level line-initial retro_status: contamination
+echo ""
+echo "TC-07: validator detects line-initial retro_status: in body (contamination)"
+fixture_07="$TMPDIR_FIXTURE/tc07_body_contamination.md"
+# body line starts at column 0 with "retro_status: captured" — state-like metadata leak
+make_fixture "$fixture_07" "retro_status: none" "retro_status: captured"
+stderr_07="$(bash "$VALIDATOR" "$fixture_07" 2>&1 >/dev/null || true)"
+if bash "$VALIDATOR" "$fixture_07" 2>/dev/null; then
+  fail "TC-07: validator accepted body-level retro_status: line (should detect contamination)"
+elif echo "$stderr_07" | grep -qiE "retro_status|body|contamination"; then
+  pass "TC-07: validator detected body contamination (retro_status: at line start)"
+else
+  fail "TC-07: validator rejected but stderr did not mention retro_status/body/contamination (got: $stderr_07)"
+fi
+
+# TC-07b: validate-cycle-frontmatter.sh does NOT flag inline (non-line-initial) retro_status: in body
+echo ""
+echo "TC-07b: validator ignores inline retro_status: in body (no false positive)"
+fixture_07b="$TMPDIR_FIXTURE/tc07b_inline.md"
+# body line has "retro_status:" embedded mid-sentence — must NOT trigger contamination
+make_fixture "$fixture_07b" "retro_status: none" "Some text retro_status: captured here"
+if bash "$VALIDATOR" "$fixture_07b" 2>/dev/null; then
+  pass "TC-07b: validator correctly ignored inline retro_status: (no false positive)"
+else
+  fail "TC-07b: validator falsely flagged inline retro_status: in body (should pass)"
+fi
+
+# TC-09: validator rejects present-but-empty retro_status (Codex review BLOCK fix)
+echo ""
+echo "TC-09: validator rejects present-but-empty retro_status"
+fixture_09_empty="$TMPDIR_FIXTURE/tc09_empty.md"
+make_fixture "$fixture_09_empty" "retro_status:" ""
+fixture_09_ws="$TMPDIR_FIXTURE/tc09_whitespace.md"
+make_fixture "$fixture_09_ws" "retro_status:    " ""
+TC09_PASS=true
+for fixture in "$fixture_09_empty" "$fixture_09_ws"; do
+  if bash "$VALIDATOR" "$fixture" 2>/dev/null; then
+    fail "TC-09: validator accepted present-but-empty retro_status (should reject): $fixture"
+    TC09_PASS=false
+  fi
+done
+if [ "$TC09_PASS" = "true" ]; then
+  pass "TC-09: validator rejected present-but-empty retro_status (empty + whitespace-only)"
+fi
+
+# TC-08: rules/state-ownership.md sync-plan row mentions retro_status
+echo ""
+echo "TC-08: rules/state-ownership.md sync-plan row includes retro_status"
+if [ ! -f "$STATE_OWNERSHIP" ]; then
+  fail "TC-08: rules/state-ownership.md does not exist"
+else
+  # Find the sync-plan row and check it contains retro_status
+  SYNCPLAN_LINE="$(grep "sync-plan" "$STATE_OWNERSHIP" || true)"
+  if [ -z "$SYNCPLAN_LINE" ]; then
+    fail "TC-08: rules/state-ownership.md has no sync-plan entry"
+  elif echo "$SYNCPLAN_LINE" | grep -q "retro_status"; then
+    pass "TC-08: rules/state-ownership.md sync-plan row contains retro_status"
+  else
+    fail "TC-08: rules/state-ownership.md sync-plan row does NOT contain retro_status (line: $SYNCPLAN_LINE)"
+  fi
+fi
+
+# Summary
+echo ""
+echo "=== Summary ==="
+echo "PASS: $PASS / FAIL: $FAIL / TOTAL: $((PASS + FAIL))"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- v2.8 Agile Loop Cycle A1: `retro_status` frontmatter field の最小基盤実装
- 当初 Step 1+1b 一括実装を試みたが Codex plan-review 4 ラウンド (BLOCK x2 + WARN x2) を経て Cycle 分割
- 9 ファイル変更 (M 6 + new 3) + post-commit fix 2 ファイル

## 変更内容

### 新フィールド `retro_status: none|captured|resolved`
- `skills/spec/templates/cycle.md`: frontmatter に `retro_status: none` 追加
- `agents/sync-plan.md`: 初期化テーブルに `retro_status` 行追加
- `rules/state-ownership.md`: sync-plan 行に `retro_status (= none)` 追記
- `scripts/validate-cycle-frontmatter.sh`:
  - 値検証 (none|captured|resolved 以外 reject)
  - 不在許容 (legacy doc 互換)
  - 「キー存在 vs 値非空」分離 (present-but-empty も reject、Codex code-review BLOCK 対応)
  - body contamination check FIELDS loop に統合 (DRY)

### テスト
- `tests/test-frontmatter-retro-status.sh`: 10 fixture-based TC
  - TC-09 は REVIEW BLOCK→GREEN 再実行で追加 (present-but-empty 検証)
  - TC-03/TC-08 は Codex post-commit review (P3) で `= none` 契約まで強化

### ドキュメント
- `docs/decisions/adr-cycle-retrospective.md`: ADR-002 (Step 1+1b 全体設計)
- `ROADMAP.md`: v2.8 Agile Loop セクション (Step 1〜5 + 運用評価ポイント)
- `docs/STATUS.md`: v2.8 進捗追記
- `docs/cycles/20260420_1314_v2.8-retro-foundation.md`: Cycle doc

## レビュー履歴

- Codex plan-review: 4 ラウンド (BLOCK x2 → WARN x2) → scope を 12 → 18 → 5 ファイルに段階縮小
- Codex code-review: BLOCK (present-but-empty バグ) → GREEN 再実行 (1 回ルール内) → PASS
- Claude security-reviewer: PASS
- Claude correctness-reviewer: PASS (important 1 件は同 GREEN 再実行で対応)
- Codex post-commit review: P2 (test_count stale) + P3 (TC-03/08 弱い assertion) → bab1c62 で修正

## DISCOVERED (別 cycle で対応)

- `sync-plan.md` phase=RED vs template phase=INIT のズレ
- state-ownership.md REVIEW 行の BLOCK→GREEN 再実行ケース整理
- cycle doc Verification の「全 cycle docs valid」が事実上不可能 (古い cycle docs が validator を通らない)

## 次サイクル A2

`Cycle A2: cycle-retrospective skill 本体 + orchestrate (steps-*.md) 統合 + pre-commit-gate enable + workflow.md / architecture.md / README / AGENTS / CLAUDE / STATUS 同期 + override proceed/abort 分離`

## Test plan
- [x] tests/test-frontmatter-retro-status.sh: 10/10 PASS
- [x] 既存 test 群 regression 確認 (新規 retro_status 関連の FAIL なし)
- [x] pre-commit-gate.sh: PASS (REVIEW + Codex 記録あり)
- [x] validate-cycle-frontmatter.sh: 本 cycle doc 自身を validate して exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)