### PR TITLE
fix: test-doc-consistency.sh TC-02 CONSTITUTION 準拠 + v2.7.0 dogfood

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -9,7 +9,7 @@
 | Archived Cycles | 37 |
 | Skills | 31 |
 | Agents | 41 |
-| Test Scripts | 102 |
+| Test Scripts | 103 |
 
 Last updated: 2026-04-21
 
@@ -17,6 +17,7 @@ Last updated: 2026-04-21
 
 | Date | Cycle | Type |
 |------|-------|------|
+| 2026-04-21 | eval-1: test-doc-consistency.sh TC-02 CONSTITUTION 準拠修正 + meta test 新設 (v2.7.0 dogfood) | fix |
 | 2026-04-21 | v2.7.0 リリース (Agile Loop Step 1: A1+A2a+A2b 統合 + post-commit fixes) | docs |
 | 2026-04-20 | v2.7 Cycle A2b: orchestrate Block 2f 統合 + pre-commit-gate retro_status check enable + self-dogfood | feat |
 | 2026-04-20 | v2.7 Cycle A2a: cycle-retrospective skill 本体 (advisory, SKILL.md + reference.md + state-ownership + docs sync) | feat |

--- a/docs/cycles/20260421_1043_test-doc-consistency-tc02-fix.md
+++ b/docs/cycles/20260421_1043_test-doc-consistency-tc02-fix.md
@@ -8,7 +8,7 @@ risk_level: low
 retro_status: captured
 codex_session_id: ""
 created: 2026-04-21 10:43
-updated: 2026-04-21 11:35
+updated: 2026-04-21 11:50
 ---
 
 # test-doc-consistency TC-02 CONSTITUTION 準拠修正
@@ -94,14 +94,22 @@ TC-02 logic のコピーではなく、実 script の振る舞いを end-to-end 
 - **Issues**: なし
 - **Notes**: meta test が実 script を直接実行する end-to-end 方式で drift リスクを排除。`set -euo pipefail` abort 挙動への対処として `|| true` + 空文字チェックは既存パターンと一致。
 
-## Exit Conditions
+## Exit Conditions (Codex post-commit P2-2 を受けて scope 明確化)
 
-このサイクルの完了条件:
-- [ ] `bash tests/test-doc-consistency.sh` が TC-01 〜 TC-15 全て PASS で exit 0
-- [ ] `bash tests/test-meta-doc-consistency.sh` が全 TC PASS で exit 0
-- [ ] FAIL 件数 0（Summary: FAIL: 0）
-- [ ] TC-02 が "CONSTITUTION compliant" 文言を含む PASS を出力する
-- [ ] TC-04 (meta) が "PASS" 文言を strict assertion で確認する
+このサイクルの完了条件 (本 cycle scope に限定):
+- [x] `bash tests/test-doc-consistency.sh` の **TC-02 が PASS** ("does not hardcode" 文言出力)
+- [x] `bash tests/test-meta-doc-consistency.sh` が全 TC PASS で exit 0
+- [x] TC-02 修正による新規 regression なし (test-pre-commit-gate-retro.sh 等 other tests に影響なし)
+
+### 本 cycle scope 外の pre-existing failures (別 cycle で対応)
+
+`tests/test-doc-consistency.sh` 全体が exit 0 にならないのは、TC-13 (recursive runner) が以下の pre-existing failing tests を検出するため:
+
+- `tests/test-codex-delegation-interface.sh`: `steps-codex.md still contains 'advisory'` で exit 1
+- `tests/test-codex-delegation-preference.sh`: `SKILL.md missing user choice priority rule` で exit 1
+- `tests/test-cross-references.sh`: `test-skills-structure.sh` 経由で `AGENTS.md declares 41 agents, actual is 40` で exit 1
+
+これらは v2.7.0 リリース前から存在する failures であり、本 cycle の TC-02 fix とは独立。別 cycle (DISCOVERED) で個別に対応する。本 cycle では「test-doc-consistency.sh 全体が exit 0」を Exit condition として要求しない。
 
 ## Progress Log
 
@@ -158,9 +166,17 @@ Design Review Gate: PASS (score: 8)。plan v2 Codex Revise 2 点対応:
 3. line 38-46: TC-02 を CONSTITUTION 準拠に変更（header 更新 + `|| true` + 空文字チェックで "does not hardcode" PASS 分岐追加）
 4. line 194: TC-13 に `[ "$test_name" = "test-meta-doc-consistency.sh" ] && continue` 追加 — TC-13→meta test→TC-04→test-doc-consistency.sh の無限再帰を防止
 
-meta test TC-01〜TC-03: PASS 確認済み。
-TC-04 手動確認: `arch_count=''`（architecture.md に "N skills" 形式なし）→ "does not hardcode" PASS 文言が出力される → header_hit=true, pass_hit=true → PASS。
-TC-04 自動実行: TC-13 の 100+ テスト実行のため時間要（実行中）。
+meta test TC-01〜TC-04: 全 PASS 確認済み (4/4 PASS、自動実行も完了)。
+
+### 2026-04-21 11:50 - POST-COMMIT FIX (Codex post-commit P2 対応)
+
+Codex post-commit review (commit bbdab73) で 2 件 P2:
+
+- **P2-1 meta test exit status drop**: `... | grep ... || true` で subject script の exit code を捨てており、TC-02 が正しい文言を print しても script broken なら catch できない。さらに grep が全 output 対象なので別 location からも match する false positive 残存
+  - **対応**: TC-01/02/03 を `awk '/^TC-02:/{flag=1} flag{print} /^TC-0[3-9]:|^TC-1[0-9]:|^===/{exit}'` で TC-02 セクションのみ抽出してから grep。これにより「TC-02 セクション内に該当 PASS/FAIL 行が存在」を strict 検証
+  - 再テスト: 4/4 PASS 維持
+- **P2-2 cycle 完了判定が unresolved**: Cycle doc に "TC-04 自動実行: 実行中" 残存 + Exit condition「test-doc-consistency.sh が exit 0」が事実と乖離 (TC-13 が pre-existing failures を検出して exit 1)
+  - **対応**: GREEN log の "実行中" を「全 PASS 確認済み」に更新。Exit Conditions セクションを scope 明確化に書き換え、pre-existing failures (test-codex-delegation-interface.sh / test-codex-delegation-preference.sh / test-cross-references.sh) を本 cycle scope 外として明記
 
 ## Implementation Notes
 

--- a/docs/cycles/20260421_1043_test-doc-consistency-tc02-fix.md
+++ b/docs/cycles/20260421_1043_test-doc-consistency-tc02-fix.md
@@ -1,0 +1,202 @@
+---
+feature: test-doc-consistency-tc02-fix
+cycle: 20260421_1043
+phase: DONE
+complexity: trivial
+test_count: 4
+risk_level: low
+retro_status: captured
+codex_session_id: ""
+created: 2026-04-21 10:43
+updated: 2026-04-21 11:35
+---
+
+# test-doc-consistency TC-02 CONSTITUTION 準拠修正
+
+## Scope Definition
+
+### In Scope
+
+- [ ] `tests/test-doc-consistency.sh` 編集:
+  - TC-02: `arch_count=$(grep ... || true)` + `[ -z "$arch_count" ]` でスキップ処理追加。`set -euo pipefail` 環境での abort を防ぐ
+  - TC-04: assertion を strict 強化（PASS 文言の明示確認）
+  - `BASE_DIR` env override サポート行追加（meta test からの fixture 注入用）
+- [ ] `tests/test-meta-doc-consistency.sh` 新規（または既存に統合）:
+  - meta test: `BASE_DIR=/tmp/fixture-dir bash tests/test-doc-consistency.sh` を実行し PASS 終了を確認する
+
+### Out of Scope
+
+- architecture.md への skill count hardcode 追加（CONSTITUTION 原則「導出可能情報を hardcode しない」により禁止）
+- TC-02 以外の TC の挙動変更
+- test-doc-consistency.sh のリネームや TC 番号の再振り
+
+## TDD Context
+
+### Problem
+
+`test-doc-consistency.sh` の TC-02 は `grep -oE '[0-9]+ skills' "$BASE_DIR/docs/architecture.md"` を実行する。
+`architecture.md` に「N skills」形式のハードコード文字列が存在しない場合、`grep` は exit code 1 を返す。
+スクリプトは `set -euo pipefail` で起動されているため、`grep` の non-zero exit により **スクリプト全体が abort** する。
+TC-03 以降が実行されず、Summary も表示されない。
+
+### Root Cause
+
+CONSTITUTION 原則により `architecture.md` には skill count の hardcode が存在しない（正しい状態）。
+しかし TC-02 は「hardcode があれば比較、なければ FAIL」という設計になっておらず、「grep no-match → abort」となっている。
+
+### Design Approach
+
+CONSTITUTION 準拠の2分岐設計:
+1. `arch_count=$(grep ... || true)` で grep exit を吸収
+2. `[ -z "$arch_count" ]` → `pass "architecture.md has no hardcoded skill count (CONSTITUTION compliant)"` でスキップ
+3. `[ "$arch_count" = "$ACTUAL_COUNT" ]` → `pass` / else `fail` (regression guard)
+
+meta test は `BASE_DIR` env override で fixture ディレクトリを注入し、実 script を直接実行する方式を採用。
+TC-02 logic のコピーではなく、実 script の振る舞いを end-to-end で検証する。
+
+### Files to Change
+
+| File | Type | Description |
+|------|------|-------------|
+| `tests/test-doc-consistency.sh` | edit | TC-02 修正 + TC-04 strict 化 + BASE_DIR override サポート |
+| `tests/test-meta-doc-consistency.sh` | new | meta test: fixture dir で実 script を実行して PASS を確認 |
+
+## Test List
+
+### TC-01: TC-02 がハードコードなし architecture.md で PASS を返す
+
+- **Given**: `arch_count` が空文字（grep no-match + `|| true`）
+- **When**: `[ -z "$arch_count" ]` が true
+- **Then**: `pass "architecture.md has no hardcoded skill count (CONSTITUTION compliant)"` が出力される
+
+### TC-02: TC-02 がハードコードあり architecture.md で比較する
+
+- **Given**: fixture の `docs/architecture.md` に「31 skills」を含む
+- **When**: `arch_count` が実際の skill 数と一致する
+- **Then**: `pass` が出力される
+
+### TC-03: meta test が実 script を fixture dir で実行して PASS 終了する
+
+- **Given**: `BASE_DIR` を fixture ディレクトリに設定
+- **When**: `bash tests/test-doc-consistency.sh` を実行
+- **Then**: exit code 0、かつ出力に "PASS" が含まれる（strict assertion）
+
+### TC-04: meta test が fixture で意図的に FAIL を検出できる
+
+- **Given**: `BASE_DIR` に不整合な fixture（skill count mismatch）を設定
+- **When**: `bash tests/test-doc-consistency.sh` を実行
+- **Then**: exit code 非ゼロ、かつ出力に "FAIL" が含まれる
+
+## Design Review Gate
+
+- **Verdict**: PASS
+- **Score**: 8
+- **Issues**: なし
+- **Notes**: meta test が実 script を直接実行する end-to-end 方式で drift リスクを排除。`set -euo pipefail` abort 挙動への対処として `|| true` + 空文字チェックは既存パターンと一致。
+
+## Exit Conditions
+
+このサイクルの完了条件:
+- [ ] `bash tests/test-doc-consistency.sh` が TC-01 〜 TC-15 全て PASS で exit 0
+- [ ] `bash tests/test-meta-doc-consistency.sh` が全 TC PASS で exit 0
+- [ ] FAIL 件数 0（Summary: FAIL: 0）
+- [ ] TC-02 が "CONSTITUTION compliant" 文言を含む PASS を出力する
+- [ ] TC-04 (meta) が "PASS" 文言を strict assertion で確認する
+
+## Progress Log
+
+### KICKOFF (2026-04-21 10:43)
+
+Design Review Gate: PASS (score: 8)。plan v2 Codex Revise 2 点対応:
+1. TC-02 現状記述を「script abort (set -euo pipefail + grep no-match)」に訂正
+2. meta test を `BASE_DIR env override で実 script を fixture dir で実行` 方式に変更
+3. TC-04 assertion を strict (PASS 文言) に強化
+
+### RED (2026-04-21)
+
+`tests/test-meta-doc-consistency.sh` 新規作成（4 TC）。
+
+実行結果: PASS: 0 / FAIL: 4 / TOTAL: 4 → RED 状態確認済み。
+
+各 TC の失敗理由:
+- TC-01 FAIL: `BASE_DIR` env override が `test-doc-consistency.sh` に実装されていないため fixture を無視、実 repo の arch_count grep が `set -euo pipefail` により abort → "does not hardcode" 文言が出力されない
+- TC-02 FAIL: `BASE_DIR` env override が無効 → fixture の 2 skill dirs を無視 → "PASS.*= actual (2)" が出力されない（実 repo の count=31 が使われる）
+- TC-03 FAIL: `BASE_DIR` env override が無効 → fixture の "99 skills" を無視 → "!= actual" が出力されない
+- TC-04 FAIL: TC-02 の header が現在 "architecture.md skill count matches actual" であり、期待する "skill count check" 文言が存在しない
+
+作成ファイル: `tests/test-meta-doc-consistency.sh`（新規）
+
+### 2026-04-21 11:00 - REVIEW
+
+- Claude correctness-reviewer: PASS (blocking_score 18)
+  - **important 1 件**: meta test TC-02/TC-03 の grep が TC-01 出力 ("README.md skill count (2) = actual (2)") にも誤マッチ可能 → false positive リスク
+  - optional 2 件: set -e 統一, grep pattern 厳密化
+- Codex code review: **Request changes**
+  - 同 important 指摘 (`PASS.*= actual \(2\)` が TC-01 でも成立)
+  - **対応**: GREEN 再実行 (max 1 回ルール内) で meta test grep を `architecture\.md skill count` 接頭辞付きに厳密化、PASS/FAIL 期待文字列を fully qualified に変更
+- 再テスト: meta test 4/4 PASS 維持
+- 総合判定: **PASS** (両 reviewer の important 指摘対処済)
+- Phase completed
+
+### REFACTOR (2026-04-21)
+
+- 対象: tests/test-doc-consistency.sh, tests/test-meta-doc-consistency.sh
+- チェックリスト確認:
+  - 重複コード: TC-01/TC-02 の `grep -oE '[0-9]+ skills' ... | head -1 | grep -oE '[0-9]+' || true` パターンが 2 箇所重複。helper 化は overengineering (2 occurrences のみ、project 慣習 = function 抽出は 3+ から) のため**変更なし**
+  - 定数化 / 未使用 import / let→const / メソッド分割 / N+1 / 命名一貫性: 該当なし
+- Verification Gate: PASS
+  - test-meta-doc-consistency.sh 4/4 PASS
+  - test-doc-consistency.sh TC-02 = "PASS architecture.md does not hardcode skill count (CONSTITUTION principle honored)"
+- Phase completed (no-op refactor、品質基準すでに満たしている)
+
+### GREEN (2026-04-21)
+
+`tests/test-doc-consistency.sh` を 4 箇所修正:
+
+1. line 7: `BASE_DIR="${BASE_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"` — env override サポート追加
+2. line 29: TC-01 の `readme_counts=$(grep ... 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)` — meta test fixture で `set -euo pipefail` abort を防止
+3. line 38-46: TC-02 を CONSTITUTION 準拠に変更（header 更新 + `|| true` + 空文字チェックで "does not hardcode" PASS 分岐追加）
+4. line 194: TC-13 に `[ "$test_name" = "test-meta-doc-consistency.sh" ] && continue` 追加 — TC-13→meta test→TC-04→test-doc-consistency.sh の無限再帰を防止
+
+meta test TC-01〜TC-03: PASS 確認済み。
+TC-04 手動確認: `arch_count=''`（architecture.md に "N skills" 形式なし）→ "does not hardcode" PASS 文言が出力される → header_hit=true, pass_hit=true → PASS。
+TC-04 自動実行: TC-13 の 100+ テスト実行のため時間要（実行中）。
+
+## Implementation Notes
+
+- `grep ... || true` パターンは `test-frontmatter-retro-status.sh` 等の既存テストで採用済み
+- fixture ディレクトリは `/tmp/test-doc-consistency-fixture-$$` 等で一時作成し、テスト後削除
+- `BASE_DIR` override は script 冒頭の `BASE_DIR=` 行より前に env が設定されている必要があるため、script 側で `BASE_DIR=${BASE_DIR:-"$(cd "$(dirname "$0")/.." && pwd)"}` 形式に変更する
+
+## Retrospective
+
+### Insight 1: plan の現状記述は「実コードを実行確認」してから書く
+
+- **Failure**: TC-02 の挙動を「常に FAIL」と簡略化して plan に記述。Codex Revise で「実際は `set -euo pipefail` + grep no-match で script が silent abort する」と指摘
+- **Final fix**: plan の Problem セクションを「abort (or fail) と、どちらにせよ script が完走しない」と訂正
+- **Insight**: plan 作成時、対象 test の挙動は **grep + 実行で確認してから記述**。「FAIL」「abort」「skip」を曖昧に使い分けず、bash の挙動 (set -euo pipefail) も含めて精確に書く
+
+### Insight 2: meta test (test を test する) は対象 script を直接実行する形が drift 防止に強い
+
+- **Failure**: 当初 plan は meta test を「TC-02 logic を copy して fixture で検証」方式で設計。Codex から「実装 drift リスク + TC-04 grep が header だけで通る」と指摘
+- **Final fix**: BASE_DIR env override 方式に変更し、meta test から実 test-doc-consistency.sh を fixture dir で実行
+- **Insight**: meta test は対象 script を**そのまま実行**する形が最も drift に強い。logic copy/paste は最終手段。env override で fixture dir を渡せるよう対象 script に **`${BASE_DIR:-default}` 形式のフック**を入れることが前提
+
+### Insight 3: meta test assertion は対象 TC を**特定する固有 prefix** で絞り込む
+
+- **Failure**: meta test TC-02/TC-03 で `PASS.*= actual (2)` を grep。これは TC-01 の `README.md skill count (2) = actual (2)` にも match → false positive リスク。Codex Request changes + Claude correctness reviewer 一致で important 指摘
+- **Final fix**: grep を `architecture\.md skill count.*= actual \(2\)` のように **検証対象 TC 固有の prefix (file path / section name)** で絞り込み
+- **Insight**: meta test の grep assertion は、検証対象 TC を**一意特定する文字列** (file 名 / section 名 / TC 番号 + 文脈) を含める。共通文字列 (PASS, actual, FAIL 等) のみは false positive 源。**両 reviewer (Claude + Codex) が独立して同じ指摘** → よくある落とし穴
+
+### Insight 4: fixture-based meta test 導入時、対象 script の他 TC が fixture 環境で abort しない defense を当てる
+
+- **Failure**: meta test が空 fixture dir で test-doc-consistency.sh を実行 → TC-01 (README.md grep) が `set -euo pipefail` で abort → meta test 全体が失敗
+- **Final fix**: TC-01 にも `|| true` + `2>/dev/null` を追加 (TC-02 の collateral fix として scope 内で対処)
+- **Insight**: fixture-based meta test を導入するときは、対象 script の **fixture 環境 (空 file / 不在 file) でも abort しない defensive 化** を同時にやる。pipefail + grep no-match の落とし穴は複数 TC に潜むので、一括 sweep が有効
+
+### Insight 5: 既存 test を実行する meta test は recursive runner (TC-13 等) に対する skip を初期に設計
+
+- **Failure**: TC-13 が `tests/test-*.sh` を全実行 → meta test が走る → meta test の TC-04 が `bash tests/test-doc-consistency.sh` を再実行 → 無限再帰のリスク。green-worker が GREEN フェーズで気付いて TC-13 skip 条件を追加
+- **Final fix**: TC-13 の skip リストに `test-meta-doc-consistency.sh` を追加 (1 行)
+- **Insight**: 既存 test を `bash` で再実行する meta test を導入するときは、**recursive runner (test-doc-consistency.sh TC-13 のような他テスト全実行 logic) に対する skip 登録**を plan 段階で明示。後付けで気付くと巻き込み事故になる
+

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BASE_DIR="${BASE_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 PASS=0
 FAIL=0
 
@@ -26,7 +26,7 @@ ACTUAL_COUNT=$(find "$BASE_DIR/skills" -mindepth 1 -maxdepth 1 -type d | wc -l |
 # TC-01: README.md skill count = actual skill directories
 echo ""
 echo "TC-01: README.md skill count matches actual ($ACTUAL_COUNT)"
-readme_counts=$(grep -oE '[0-9]+ skills' "$BASE_DIR/README.md" | head -1 | grep -oE '[0-9]+')
+readme_counts=$(grep -oE '[0-9]+ skills' "$BASE_DIR/README.md" 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)
 if [ "$readme_counts" = "$ACTUAL_COUNT" ]; then
   pass "README.md skill count ($readme_counts) = actual ($ACTUAL_COUNT)"
 else
@@ -35,9 +35,11 @@ fi
 
 # TC-02: architecture.md skill count = actual skill directories
 echo ""
-echo "TC-02: architecture.md skill count matches actual ($ACTUAL_COUNT)"
-arch_count=$(grep -oE '[0-9]+ skills' "$BASE_DIR/docs/architecture.md" | head -1 | grep -oE '[0-9]+')
-if [ "$arch_count" = "$ACTUAL_COUNT" ]; then
+echo "TC-02: architecture.md skill count check (skip if absent per CONSTITUTION)"
+arch_count=$(grep -oE '[0-9]+ skills' "$BASE_DIR/docs/architecture.md" 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)
+if [ -z "$arch_count" ]; then
+  pass "architecture.md does not hardcode skill count (CONSTITUTION principle honored)"
+elif [ "$arch_count" = "$ACTUAL_COUNT" ]; then
   pass "architecture.md skill count ($arch_count) = actual ($ACTUAL_COUNT)"
 else
   fail "architecture.md skill count ($arch_count) != actual ($ACTUAL_COUNT)"
@@ -188,8 +190,9 @@ echo "TC-13: Existing tests pass"
 existing_fail=0
 for test_file in "$BASE_DIR/tests"/test-*.sh; do
   test_name=$(basename "$test_file")
-  # Skip ourselves to avoid recursion
+  # Skip ourselves and meta test to avoid recursion
   [ "$test_name" = "test-doc-consistency.sh" ] && continue
+  [ "$test_name" = "test-meta-doc-consistency.sh" ] && continue
   if ! bash "$test_file" > /dev/null 2>&1; then
     fail "Existing test failed: $test_name"
     existing_fail=1

--- a/tests/test-meta-doc-consistency.sh
+++ b/tests/test-meta-doc-consistency.sh
@@ -57,13 +57,16 @@ echo "TC-01: TC-02 passes when architecture.md has no hardcoded skill count"
 FIXTURE_01="$TMPDIR_FIXTURE/tc01"
 make_fixture "$FIXTURE_01" "# Skills (flat, see STATUS.md for counts)" 2
 
-# BASE_DIR override で test-doc-consistency.sh を実行し TC-02 行のみ抽出
-tc02_output_01="$(BASE_DIR="$FIXTURE_01" bash "$SUBJECT" 2>&1 | grep -E "TC-02|does not hardcode" || true)"
+# BASE_DIR override で test-doc-consistency.sh を実行し、TC-02 セクションのみ抽出
+# (Codex post-commit P2-1 対応: 全 output から grep だと TC-02 以外の location でも match
+#  し得るため、awk で TC-02 ヘッダ〜次 TC-N ヘッダ間に限定)
+full_output_01="$(BASE_DIR="$FIXTURE_01" bash "$SUBJECT" 2>&1 || true)"
+tc02_section_01="$(echo "$full_output_01" | awk '/^TC-02:/{flag=1} flag{print} /^TC-0[3-9]:|^TC-1[0-9]:|^===/&&NR>1&&flag{exit}')"
 
-if echo "$tc02_output_01" | grep -q "does not hardcode"; then
-  pass "TC-01: TC-02 outputs 'does not hardcode' PASS when count absent"
+if echo "$tc02_section_01" | grep -q "does not hardcode"; then
+  pass "TC-01: TC-02 section contains 'does not hardcode' PASS when count absent"
 else
-  fail "TC-01: expected 'does not hardcode' in TC-02 output, got: $tc02_output_01"
+  fail "TC-01: expected 'does not hardcode' inside TC-02 section, got section: $tc02_section_01"
 fi
 
 ########################################
@@ -76,14 +79,14 @@ echo "TC-02: TC-02 passes when architecture.md count matches actual (2)"
 FIXTURE_02="$TMPDIR_FIXTURE/tc02"
 make_fixture "$FIXTURE_02" "# 2 skills available (see STATUS.md for details)" 2
 
-tc02_output_02="$(BASE_DIR="$FIXTURE_02" bash "$SUBJECT" 2>&1 | grep -E "TC-02.*skill count|architecture\.md skill count.*= actual \(2\)" || true)"
+# Codex post-commit P2-1 対応: TC-02 セクション限定
+full_output_02="$(BASE_DIR="$FIXTURE_02" bash "$SUBJECT" 2>&1 || true)"
+tc02_section_02="$(echo "$full_output_02" | awk '/^TC-02:/{flag=1} flag{print} /^TC-0[3-9]:|^TC-1[0-9]:|^===/&&NR>1&&flag{exit}')"
 
-# Tighten to architecture.md-specific PASS line to avoid false-positive match
-# from TC-01's "README.md skill count (2) = actual (2)" (Codex/correctness review)
-if echo "$tc02_output_02" | grep -qE "architecture\.md skill count \(2\) = actual \(2\)"; then
-  pass "TC-02: TC-02 outputs 'architecture.md skill count (2) = actual (2)' PASS"
+if echo "$tc02_section_02" | grep -qE "architecture\.md skill count \(2\) = actual \(2\)"; then
+  pass "TC-02: TC-02 section contains 'architecture.md skill count (2) = actual (2)' PASS"
 else
-  fail "TC-02: expected 'architecture.md skill count (2) = actual (2)' PASS in TC-02 output, got: $tc02_output_02"
+  fail "TC-02: expected 'architecture.md skill count (2) = actual (2)' PASS in TC-02 section, got: $tc02_section_02"
 fi
 
 ########################################
@@ -96,14 +99,14 @@ echo "TC-03: TC-02 fails when architecture.md count does not match actual (99 vs
 FIXTURE_03="$TMPDIR_FIXTURE/tc03"
 make_fixture "$FIXTURE_03" "# 99 skills (outdated)" 2
 
-tc02_output_03="$(BASE_DIR="$FIXTURE_03" bash "$SUBJECT" 2>&1 | grep -E "TC-02|architecture\.md skill count.*!= actual" || true)"
+# Codex post-commit P2-1 対応: TC-02 セクション限定
+full_output_03="$(BASE_DIR="$FIXTURE_03" bash "$SUBJECT" 2>&1 || true)"
+tc02_section_03="$(echo "$full_output_03" | awk '/^TC-02:/{flag=1} flag{print} /^TC-0[3-9]:|^TC-1[0-9]:|^===/&&NR>1&&flag{exit}')"
 
-# Tighten to architecture.md-specific FAIL line to avoid false-positive match
-# from any other test's "!= actual" output (Codex/correctness review)
-if echo "$tc02_output_03" | grep -qE "architecture\.md skill count \(99\) != actual \(2\)"; then
-  pass "TC-03: TC-02 outputs 'architecture.md skill count (99) != actual (2)' FAIL"
+if echo "$tc02_section_03" | grep -qE "architecture\.md skill count \(99\) != actual \(2\)"; then
+  pass "TC-03: TC-02 section contains 'architecture.md skill count (99) != actual (2)' FAIL"
 else
-  fail "TC-03: expected 'architecture.md skill count (99) != actual (2)' FAIL in TC-02 output, got: $tc02_output_03"
+  fail "TC-03: expected 'architecture.md skill count (99) != actual (2)' FAIL in TC-02 section, got: $tc02_section_03"
 fi
 
 ########################################

--- a/tests/test-meta-doc-consistency.sh
+++ b/tests/test-meta-doc-consistency.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# test-meta-doc-consistency.sh - meta test for test-doc-consistency.sh TC-02 semantics
+# Fixture-based: BASE_DIR env override で test-doc-consistency.sh を実行し TC-02 の振る舞いを検証
+# TC-01 ~ TC-04
+
+set -uo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+TMPDIR_FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_FIXTURE"' EXIT
+
+pass() { PASS=$((PASS + 1)); printf "  \033[32mPASS\033[0m %s\n" "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf "  \033[31mFAIL\033[0m %s\n" "$1"; }
+
+SUBJECT="$BASE_DIR/tests/test-doc-consistency.sh"
+
+echo "=== Meta Test: test-doc-consistency.sh TC-02 Semantics ==="
+
+if [ ! -f "$SUBJECT" ]; then
+  echo "ERROR: test-doc-consistency.sh not found at $SUBJECT"
+  exit 1
+fi
+
+########################################
+# Helper: build fixture directory structure
+# $1 - fixture dir (must exist)
+# $2 - architecture.md content
+# $3 - number of skill dirs to create
+########################################
+make_fixture() {
+  local fixture_dir="$1"
+  local arch_content="$2"
+  local skill_count="$3"
+
+  mkdir -p "$fixture_dir/docs" "$fixture_dir/skills"
+  echo "$arch_content" > "$fixture_dir/docs/architecture.md"
+  echo "# placeholder" > "$fixture_dir/README.md"
+
+  local i=1
+  while [ "$i" -le "$skill_count" ]; do
+    mkdir -p "$fixture_dir/skills/skill-$i"
+    touch "$fixture_dir/skills/skill-$i/.gitkeep"
+    i=$((i + 1))
+  done
+}
+
+########################################
+# TC-01: architecture.md に count なし + skills/ 2 dirs
+# → TC-02 が "does not hardcode" PASS を返す
+########################################
+echo ""
+echo "TC-01: TC-02 passes when architecture.md has no hardcoded skill count"
+
+FIXTURE_01="$TMPDIR_FIXTURE/tc01"
+make_fixture "$FIXTURE_01" "# Skills (flat, see STATUS.md for counts)" 2
+
+# BASE_DIR override で test-doc-consistency.sh を実行し TC-02 行のみ抽出
+tc02_output_01="$(BASE_DIR="$FIXTURE_01" bash "$SUBJECT" 2>&1 | grep -E "TC-02|does not hardcode" || true)"
+
+if echo "$tc02_output_01" | grep -q "does not hardcode"; then
+  pass "TC-01: TC-02 outputs 'does not hardcode' PASS when count absent"
+else
+  fail "TC-01: expected 'does not hardcode' in TC-02 output, got: $tc02_output_01"
+fi
+
+########################################
+# TC-02: architecture.md に "2 skills" + skills/ 2 dirs
+# → TC-02 が "= actual (2)" PASS を返す
+########################################
+echo ""
+echo "TC-02: TC-02 passes when architecture.md count matches actual (2)"
+
+FIXTURE_02="$TMPDIR_FIXTURE/tc02"
+make_fixture "$FIXTURE_02" "# 2 skills available (see STATUS.md for details)" 2
+
+tc02_output_02="$(BASE_DIR="$FIXTURE_02" bash "$SUBJECT" 2>&1 | grep -E "TC-02.*skill count|architecture\.md skill count.*= actual \(2\)" || true)"
+
+# Tighten to architecture.md-specific PASS line to avoid false-positive match
+# from TC-01's "README.md skill count (2) = actual (2)" (Codex/correctness review)
+if echo "$tc02_output_02" | grep -qE "architecture\.md skill count \(2\) = actual \(2\)"; then
+  pass "TC-02: TC-02 outputs 'architecture.md skill count (2) = actual (2)' PASS"
+else
+  fail "TC-02: expected 'architecture.md skill count (2) = actual (2)' PASS in TC-02 output, got: $tc02_output_02"
+fi
+
+########################################
+# TC-03: architecture.md に "99 skills" + skills/ 2 dirs (mismatch)
+# → TC-02 が "!= actual" FAIL を返す
+########################################
+echo ""
+echo "TC-03: TC-02 fails when architecture.md count does not match actual (99 vs 2)"
+
+FIXTURE_03="$TMPDIR_FIXTURE/tc03"
+make_fixture "$FIXTURE_03" "# 99 skills (outdated)" 2
+
+tc02_output_03="$(BASE_DIR="$FIXTURE_03" bash "$SUBJECT" 2>&1 | grep -E "TC-02|architecture\.md skill count.*!= actual" || true)"
+
+# Tighten to architecture.md-specific FAIL line to avoid false-positive match
+# from any other test's "!= actual" output (Codex/correctness review)
+if echo "$tc02_output_03" | grep -qE "architecture\.md skill count \(99\) != actual \(2\)"; then
+  pass "TC-03: TC-02 outputs 'architecture.md skill count (99) != actual (2)' FAIL"
+else
+  fail "TC-03: expected 'architecture.md skill count (99) != actual (2)' FAIL in TC-02 output, got: $tc02_output_03"
+fi
+
+########################################
+# TC-04: 実 repo (BASE_DIR default) で test-doc-consistency.sh 実行
+# → TC-02 が PASS + strict assertion:
+#   stdout に "TC-02.*skill count check" + "PASS.*architecture\.md does not hardcode skill count" の両方ヒット
+########################################
+echo ""
+echo "TC-04: Real repo run: TC-02 PASS with strict output assertion (no header-only match)"
+
+real_output="$(bash "$SUBJECT" 2>&1 || true)"
+
+header_hit=false
+pass_hit=false
+
+if echo "$real_output" | grep -qE "TC-02.*skill count check"; then
+  header_hit=true
+fi
+
+if echo "$real_output" | grep -qE "PASS.*architecture\.md does not hardcode skill count"; then
+  pass_hit=true
+fi
+
+if $header_hit && $pass_hit; then
+  pass "TC-04: TC-02 PASS with both header and PASS message present in real repo run"
+elif ! $header_hit; then
+  fail "TC-04: 'TC-02.*skill count check' header not found in output"
+elif ! $pass_hit; then
+  fail "TC-04: 'PASS.*architecture.md does not hardcode skill count' not found in output (header present but PASS text missing)"
+fi
+
+# Summary
+echo ""
+echo "=== Summary ==="
+echo "PASS: $PASS / FAIL: $FAIL / TOTAL: $((PASS + FAIL))"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-meta-doc-consistency.sh
+++ b/tests/test-meta-doc-consistency.sh
@@ -58,13 +58,18 @@ FIXTURE_01="$TMPDIR_FIXTURE/tc01"
 make_fixture "$FIXTURE_01" "# Skills (flat, see STATUS.md for counts)" 2
 
 # BASE_DIR override で test-doc-consistency.sh を実行し、TC-02 セクションのみ抽出
-# (Codex post-commit P2-1 対応: 全 output から grep だと TC-02 以外の location でも match
-#  し得るため、awk で TC-02 ヘッダ〜次 TC-N ヘッダ間に限定)
+# (Codex post-commit P2-1 対応: awk で TC-02 ヘッダ〜次 TC-N ヘッダ間に限定)
+# Subject exit code を捨てず保存 (Codex post-commit P2 round 2 対応):
+# fixture context では他 TC の pre-existing failure により subject は常に exit 1 だが、
+# "=== Summary ===" 行の存在で silent abort (pipefail 途中停止) は検出できる
 full_output_01="$(BASE_DIR="$FIXTURE_01" bash "$SUBJECT" 2>&1 || true)"
+subject_completed_01=$(echo "$full_output_01" | grep -c "^=== Summary ===" || true)
 tc02_section_01="$(echo "$full_output_01" | awk '/^TC-02:/{flag=1} flag{print} /^TC-0[3-9]:|^TC-1[0-9]:|^===/&&NR>1&&flag{exit}')"
 
-if echo "$tc02_section_01" | grep -q "does not hardcode"; then
-  pass "TC-01: TC-02 section contains 'does not hardcode' PASS when count absent"
+if [ "$subject_completed_01" -eq 0 ]; then
+  fail "TC-01: subject script aborted before reaching Summary (silent pipefail abort risk, Codex P2 round 2)"
+elif echo "$tc02_section_01" | grep -q "does not hardcode"; then
+  pass "TC-01: subject reached Summary + TC-02 section contains 'does not hardcode' PASS"
 else
   fail "TC-01: expected 'does not hardcode' inside TC-02 section, got section: $tc02_section_01"
 fi
@@ -79,12 +84,15 @@ echo "TC-02: TC-02 passes when architecture.md count matches actual (2)"
 FIXTURE_02="$TMPDIR_FIXTURE/tc02"
 make_fixture "$FIXTURE_02" "# 2 skills available (see STATUS.md for details)" 2
 
-# Codex post-commit P2-1 対応: TC-02 セクション限定
+# Codex post-commit P2 round 2 対応: section 限定 + Summary 到達 check
 full_output_02="$(BASE_DIR="$FIXTURE_02" bash "$SUBJECT" 2>&1 || true)"
+subject_completed_02=$(echo "$full_output_02" | grep -c "^=== Summary ===" || true)
 tc02_section_02="$(echo "$full_output_02" | awk '/^TC-02:/{flag=1} flag{print} /^TC-0[3-9]:|^TC-1[0-9]:|^===/&&NR>1&&flag{exit}')"
 
-if echo "$tc02_section_02" | grep -qE "architecture\.md skill count \(2\) = actual \(2\)"; then
-  pass "TC-02: TC-02 section contains 'architecture.md skill count (2) = actual (2)' PASS"
+if [ "$subject_completed_02" -eq 0 ]; then
+  fail "TC-02: subject script aborted before reaching Summary (silent pipefail abort risk)"
+elif echo "$tc02_section_02" | grep -qE "architecture\.md skill count \(2\) = actual \(2\)"; then
+  pass "TC-02: subject reached Summary + TC-02 section contains 'architecture.md skill count (2) = actual (2)' PASS"
 else
   fail "TC-02: expected 'architecture.md skill count (2) = actual (2)' PASS in TC-02 section, got: $tc02_section_02"
 fi
@@ -99,12 +107,16 @@ echo "TC-03: TC-02 fails when architecture.md count does not match actual (99 vs
 FIXTURE_03="$TMPDIR_FIXTURE/tc03"
 make_fixture "$FIXTURE_03" "# 99 skills (outdated)" 2
 
-# Codex post-commit P2-1 対応: TC-02 セクション限定
+# Codex post-commit P2 round 2 対応: section 限定 + Summary 到達 check
+# TC-03 は mismatch なので subject exit 1 が期待通り (fixture context と合致)
 full_output_03="$(BASE_DIR="$FIXTURE_03" bash "$SUBJECT" 2>&1 || true)"
+subject_completed_03=$(echo "$full_output_03" | grep -c "^=== Summary ===" || true)
 tc02_section_03="$(echo "$full_output_03" | awk '/^TC-02:/{flag=1} flag{print} /^TC-0[3-9]:|^TC-1[0-9]:|^===/&&NR>1&&flag{exit}')"
 
-if echo "$tc02_section_03" | grep -qE "architecture\.md skill count \(99\) != actual \(2\)"; then
-  pass "TC-03: TC-02 section contains 'architecture.md skill count (99) != actual (2)' FAIL"
+if [ "$subject_completed_03" -eq 0 ]; then
+  fail "TC-03: subject script aborted before reaching Summary (silent pipefail abort risk)"
+elif echo "$tc02_section_03" | grep -qE "architecture\.md skill count \(99\) != actual \(2\)"; then
+  pass "TC-03: subject reached Summary + TC-02 section contains 'architecture.md skill count (99) != actual (2)' FAIL"
 else
   fail "TC-03: expected 'architecture.md skill count (99) != actual (2)' FAIL in TC-02 section, got: $tc02_section_03"
 fi


### PR DESCRIPTION
## Summary

v2.7.0 リリース後の**運用評価第一 cycle** (eval-1)。A1/A2a で 2 回 DISCOVERED 記録された古参問題 (TC-02 vs CONSTITUTION hardcode 原則) を解消。v2.7.0 Step 1 retrospective loop の end-to-end dogfood も兼ねる。

## 変更内容

### `tests/test-doc-consistency.sh` (edit, 4 箇所)
- line 7: `BASE_DIR="${BASE_DIR:-...}"` で env override 対応 (meta test が fixture dir を渡せる)
- line 29: TC-01 grep に `|| true` + `2>/dev/null` (fixture context での abort 防止)
- line 38-46: TC-02 を CONSTITUTION 準拠に
  - count 不在 → `"does not hardcode" PASS` (CONSTITUTION 尊重)
  - count == actual → 従来通り PASS
  - count != actual → 従来通り FAIL (drift 検出維持)
- line 194: TC-13 recursive runner で `test-meta-doc-consistency.sh` を skip (無限再帰防止)

### `tests/test-meta-doc-consistency.sh` (new, 4 TC)
fixture-based meta test。BASE_DIR env override で実 test-doc-consistency.sh を fixture dir で実行:
- TC-01: count 不在 fixture → subject 完走 + TC-02 section "does not hardcode" PASS
- TC-02: count match fixture → subject 完走 + TC-02 section "= actual (2)" PASS
- TC-03: count mismatch fixture → subject 完走 + TC-02 section "!= actual" FAIL
- TC-04: 実 repo strict assertion (header + PASS message 両方存在)

## レビュー履歴

- Codex plan-review **Revise** → 4 点修正 (TC-02 現状記述、env override 方式、BASE_DIR 行追加、TC-04 strict)
- Claude correctness + Codex code review 両者一致で **important**: meta test grep が TC-01 出力にも match (false positive) → `architecture\.md skill count` 接頭辞で厳密化
- Codex post-commit **P2-1**: grep が全 output 対象 → `awk` で TC-02 section 限定
- Codex post-commit **P2-2**: "TC-04 実行中" 残存 + Exit Conditions 乖離 → scope 明確化 + pre-existing failures を別 cycle scope と明記
- Codex post-commit **P2 round 2**: subject exit code 捨てて文言だけ check → `^=== Summary ===` 到達 check 追加 (silent abort 検出)
- Codex 最終確認: **PASS** (前回指摘全対処)

## v2.7.0 dogfood 結果 (Block 2f cycle-retrospective)

本 cycle で cycle-retrospective skill を自身の Cycle doc に手動実行。retro_status: none → **captured**、5 insights を `## Retrospective` に記録:

1. plan の現状記述は実コード grep + 実行で確認してから書く
2. meta test は対象 script を直接実行する形が drift 防止に強い
3. meta test assertion は対象 TC を特定する固有 prefix で絞り込む (Claude + Codex 両者が独立指摘 = よくある落とし穴)
4. fixture-based meta test 導入時、対象 script の他 TC が fixture 環境で abort しない defense を当てる
5. 既存 test を実行する meta test は recursive runner に対する skip を初期に設計

## DISCOVERED (別 cycle で対応)

- architect 生成 Cycle doc Progress Log header 形式 (`### PHASE (date)`) が pre-commit-gate 期待 (`### YYYY-MM-DD HH:MM - PHASE`) と不一致 (本 cycle 内で手修正、template 側根本対応が必要)
- pre-existing failures 3 件 (test-codex-delegation-interface.sh / -preference.sh / test-cross-references.sh) は本 cycle scope 外

## Test plan

- [x] tests/test-meta-doc-consistency.sh: 4/4 PASS (fixture 3 ケース + 実 repo integration)
- [x] tests/test-doc-consistency.sh TC-02: "PASS architecture.md does not hardcode skill count" 出力確認
- [x] pre-commit-gate.sh: PASS (retro_status: captured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)