### PR TITLE
chore: release v2.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "dev-crew",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "source": "./",
       "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-crew",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction.",
   "author": {
     "name": "morodomi"


### PR DESCRIPTION
## Summary

Version bump to v2.9.0.

### 主な変更 (cycle 20260525_1249)

- **新 rule**: `rules/agent-prompts.md` に「並列起動時の prompt 契約 (3+ subagent fan-out)」section 追加 (canonical + mirror)
  - Kimi Agent Swarm 記事から抽出: specificity scales with parallelism
  - 5 要素 (担当範囲/入力/出力形式/統合キー/検証条件) を明示
- **新 sub-section**: `skills/review/steps-subagent.md` Step 5 に「Findings Synthesis」追加
  - Synthesis bottleneck 対策: 重複排除 + 3-category 分類 (review-triage.md SSOT) + raw finding index 保持
  - raw blocking_score (Socrates 入力) / final blocking_score (Verdict 確定) の時系列契約
- **新 test**: 2 file (TC01 + TC02 各 4 sub-cases)、test-codify-insight.sh TC-19 collateral fix (110 → 112)
- **DISCOVERED**: #135 (CLAUDE.md staleness), #136 (Block 0 baseline), #137 (REVIEW accept-defer 5件)

### Process

- Codex plan review BLOCK → re-review PASS (session 019e5d42)
- risk-classifier HIGH (75) → 5 reviewers + Codex competitive (6 並列)
- 新 rule dogfood: 本 cycle REVIEW で即時 execute (final score 32 = PASS)

## Test plan

- [x] tests/test-rule-agent-prompts-parallel-clause.sh PASS
- [x] tests/test-review-step5-synthesis-clause.sh PASS
- [x] tests/test-rules-mirror.sh PASS
- [x] tests/test-codify-insight.sh PASS
- [x] claude plugin validate . PASS (warning only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)