### PR TITLE
chore: release v2.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "dev-crew",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "source": "./",
       "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-crew",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction.",
   "author": {
     "name": "morodomi"


### PR DESCRIPTION
Version bump 2.9.0 → 2.10.0

2サイクルの batch リリース:
- **path-scoping** (#139): test-patterns / skill-authoring rules に `paths:` frontmatter を付与し、関連時のみロード
- **plan-discipline GREEN sweep** (#140): count/status 変更の GREEN 検証を逆向き契約 sweep で全実行する規律を codify

marketplace.json + plugin.json を同期更新（/plugin update 反映のため両方必須）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)