### PR TITLE
fix: gate の ACTIVE_CYCLE 選択を latest-updated + 明示指定に修正 (#145)

### DIFF
--- a/.claude/rules/integration-verification.md
+++ b/.claude/rules/integration-verification.md
@@ -26,7 +26,7 @@ template / skill docs だけでなく、自 cycle の Verification 実行でも 
 - **Web**: `docker compose up -d && curl -fsS localhost:PORT/health && docker compose down`
 - **Config 変更時** (motivating bug): `python -m myapp --config new.yaml && grep "loaded_from: new.yaml" /tmp/myapp.log`
 - **Library**: `python -c "from mymod import run; run('config.yaml')"`
-- **dev-crew 内 (bash/doc project)**: gate/consumer/validator を real path で実行 — 例 `bash scripts/gates/pre-commit-gate.sh $cycle_doc` or `bash scripts/validate-yaml-frontmatter.sh`。grep/diff のみは structural test として扱う
+- **dev-crew 内 (bash/doc project)**: gate/consumer/validator を real path で実行 — 例 `bash scripts/gates/pre-commit-gate.sh $cycle_doc`（$1 に cycle doc パスを渡すと当該 doc を直接検査。明示指定・推奨。project root を渡すと updated 最新の non-DONE を自動選択）or `bash scripts/validate-yaml-frontmatter.sh`。grep/diff のみは structural test として扱う
 
 ## Evidence 記録
 

--- a/docs/cycles/20260702_1200_skill-inventory-cleanup.md
+++ b/docs/cycles/20260702_1200_skill-inventory-cleanup.md
@@ -5,10 +5,10 @@ phase: COMMIT
 complexity: standard
 test_count: 6
 risk_level: medium
-retro_status: captured
+retro_status: resolved
 codex_session_id: "019f2131-5169-75e1-a43b-c2efa87040f0"
 created: 2026-07-02 12:00
-updated: 2026-07-02 18:10
+updated: 2026-07-02 19:20
 ---
 
 # Skill Inventory Cleanup — phase-compact/reload/strategy 削除 + quality description 修正
@@ -351,7 +351,7 @@ Evidence: (orchestrate が自動記入)
 - REVIEW 修正適用後の最終 full suite: **112/112 全 rc=0**（scratchpad/final.txt）
 - repo 外対応完了: ~/.claude/skills/search-task/SKILL.md 振り分け表（reload→orchestrate 継続、strategy→spec）、Claude メモリ project_phase_compact_status.md + MEMORY.md index 更新
 - branch feature/skill-inventory-cleanup で commit、PR を main 向けに作成（git-safety: main 直接 push 禁止準拠）
-- pre-commit-gate 契約の self-enforce（D4=#145 の弱点があるため PdM が本 cycle doc で直接確認）: REVIEW Progress Log 記録済み / Codex code review session 記録済み / retro_status: captured
+- pre-commit-gate 契約の self-enforce（D4=#145 の弱点があるため PdM が本 cycle doc で直接確認）: REVIEW Progress Log 記録済み / Codex code review session 記録済み / retro_status: resolved
 - Phase completed
 
 ---
@@ -389,3 +389,25 @@ Evidence: (orchestrate が自動記入)
 - **Final fix**: script ヘッダの Usage コメントを確認して `pre-commit-gate.sh .` に訂正。副産物として gate が「最初の non-DONE doc しか検査しない」弱点も発見（DISCOVERED D4 = #145）
 - **Insight**: **Verification block に書く script 呼び出しは、plan 段階でヘッダコメント/--help/実行で usage を実測確認してから記載する**。gate/hook script の引数契約を名前から推測すると、Verification 自体が false negative（誤った BLOCK/PASS）になる
 - **一般化**: plan-discipline「未確認での記述禁止」の Verification-script 版。integration-verification.md の real-path invocation 要件に「invocation 契約の事前実測」を補完する候補
+
+## Codify Decisions
+
+triage 実施: 2026-07-02 19:20（後続 cycle gate-active-cycle-fix の orchestrate Block 0 codify gate で処理）。Recurrence pre-triage: Insight 1 は 20260424_1356 #5（git stash baseline snapshot、deferred）、Insight 2 は 20260424_1356 #4（test の sequential 前提・prior run leak、deferred）の各 2 回目再発に該当し promotion 確定。
+
+### Insight 1
+- **Decision**: codified
+- **Destination**: rule (rules/plan-discipline.md + .claude/rules/ mirror)
+- **Reason**: baseline snapshot テーマの再発 2 回目（前回は stash 方式、今回 copy 方式で並行作業と共存可能に洗練）。「baseline は immutable snapshot 複製上で実測し evidence を並行プロセスから隔離する」を推奨に追記。実装は次の test-hardening cycle（rule 編集を無関係 cycle の commit に混ぜない慣行）
+- **Decided**: 2026-07-02 19:20
+
+### Insight 2
+- **Decision**: codified
+- **Destination**: rule (rules/agent-prompts.md + .claude/rules/ mirror、並列起動時の prompt 契約節)
+- **Reason**: 「読み取り並列・実行直列」原則 + 並列 prompt への「テスト実行可否の明示」。20260424_1356 #4（sequential 前提）の再発 2 回目で、今回は Codex 偽 BLOCK という実害 evidence あり。実装は次の test-hardening cycle
+- **Decided**: 2026-07-02 19:20
+
+### Insight 3
+- **Decision**: codified
+- **Destination**: rule (rules/integration-verification.md + .claude/rules/ mirror)
+- **Reason**: novel だが high-confidence の TDD hardening。「Verification に書く script 呼び出しは usage を実測確認してから記載する」を real-path invocation 要件に補完。なお本 insight の motivating bug（gate 引数契約）自体は次 cycle（gate-active-cycle-fix、#145）が polymorphic 引数で恒久解消する。実装は次の test-hardening cycle
+- **Decided**: 2026-07-02 19:20

--- a/docs/cycles/20260702_1930_gate-active-cycle-fix.md
+++ b/docs/cycles/20260702_1930_gate-active-cycle-fix.md
@@ -1,0 +1,348 @@
+---
+feature: gate-active-cycle-fix
+cycle: 20260702_1930
+phase: COMMIT
+complexity: standard
+test_count: 9
+risk_level: medium
+retro_status: captured
+codex_session_id: ""
+created: 2026-07-02 19:30
+updated: 2026-07-02 22:40
+---
+
+# Gate Active Cycle Fix — pre-commit/pre-red gate の ACTIVE_CYCLE 選択修正（issue #145）
+
+## Scope Definition
+
+### In Scope
+- [ ] `scripts/gates/pre-commit-gate.sh` L24-41 の引数解釈 + ACTIVE_CYCLE 選択ロジックを新契約に書き換え（$1 polymorphic: `.md` ファイル=明示指定 / ディレクトリ=latest-updated non-DONE 選択 / それ以外=BLOCK invalid argument。後続チェック L43-90 は不変）
+- [ ] `scripts/gates/pre-red-gate.sh` L24-33 に同型の書き換え
+- [ ] `tests/test-pre-commit-gate.sh` へ TC 追加（新規ファイル禁止、count 112 維持）: 複数 non-DONE で latest-updated 選択 / `$1` 明示指定 / `$1` 不在パス BLOCK / updated 形式混在の決定論
+- [ ] `tests/test-pre-red-gate.sh` へ同型 TC 追加（複数 non-DONE + 明示指定）
+- [ ] `rules/integration-verification.md` + `.claude/rules/integration-verification.md`（byte-identical mirror）— L29 の実行例を明示指定形式の正式な使い方として更新
+
+### Out of Scope
+- 旧 non-DONE 15 doc の phase を DONE へ一括遷移する cleanup（Reason: COMMIT→DONE 遷移の責務が workflow に未定義という根本問題を含む。別 cycle へ defer。DISCOVERED で起票）
+- parallel スキルの削除/作り直し判断（Reason: ユーザー確認待ち。本 cycle のスコープ外）
+- #143 inverse contract / test-patterns rule 実装 / RED false-pass step（Reason: 次の test hardening cycle に束ねる）
+
+### Files to Change（全量、plan 承認時点。独自判断で追加・削除しないこと）
+1. `scripts/gates/pre-commit-gate.sh` — L24-41 の引数解釈 + 選択ロジックを新契約に書き換え（後続チェック L43-90 は不変）
+2. `scripts/gates/pre-red-gate.sh` — L24-33 に同型の書き換え
+3. `tests/test-pre-commit-gate.sh` — TC 追加（新規ファイルは作らない、count 112 維持）:
+   - 複数 non-DONE fixture（古い COMMIT doc + 新しい REVIEW doc）で latest-updated が選ばれる
+   - `$1` = cycle doc パス明示指定でその doc だけ検査される
+   - `$1` = 不在パスで invalid argument BLOCK
+   - updated 日付のみ / 日時あり混在で決定論的に選択される
+4. `tests/test-pre-red-gate.sh` — 同型 TC 追加（複数 non-DONE + 明示指定）
+5. `rules/integration-verification.md` + `.claude/rules/integration-verification.md`（byte-identical mirror）— L29 の実行例を新契約の正式な使い方として明記（`$cycle_doc` 明示指定を推奨形に）
+6. `docs/cycles/20260702_1930_gate-active-cycle-fix.md` — Cycle doc（本ファイル）
+
+count 変更なし（STATUS.md / test-codify-insight.sh TC-19 は触らない）。STATUS.md は COMMIT 時の Completed 行追記のみ。
+
+## Environment
+
+### Scope
+- Layer: Backend（bash gate scripts + bash test scripts + doc mirror）
+- Plugin: dev-crew 内 bash/doc project（integration-verification.md の project type 分類に準拠）
+- Risk: 40（WARN）
+
+### Runtime
+- Bash（macOS zsh 実行環境、スクリプト自体は `#!/bin/bash` + `set -euo pipefail`）
+
+### Dependencies (key packages)
+- なし（awk / grep / sed / mktemp のみ、標準 POSIX/GNU 互換ツール）
+
+### Risk Interview (BLOCK only)
+- 該当なし（Risk ~40 は WARN 帯であり BLOCK 帯（60+）に未到達のため、Risk Interview は不要）
+
+## Context & Dependencies
+
+### Reference Documents
+- `rules/integration-verification.md` — L29 の実行例が現行 project_root 契約と矛盾しており本 cycle で解消する対象
+- `.claude/rules/multi-file-consistency.md` — 「deterministic gate は case 文で期待値を enumerate し、それ以外は明示的に reject する」原則。新契約の `$1` 三分岐（.md file / directory / else→BLOCK）はこの原則に準拠
+- `.claude/rules/plan-discipline.md` — baseline 実測・逆向き契約 sweep の規律。本 plan は Explore 調査で該当箇所を実測済み
+- CONSTITUTION.md 原則6「決定論的プロセス保証」— pre-commit-gate.sh / pre-red-gate.sh の存在意義そのもの
+
+### Dependent Features
+- `scripts/gates/pre-commit-gate.sh` — 後続チェック（REVIEW log / Codex review / retro_status、L43-90）は `$ACTIVE_CYCLE` 変数を読むのみで選択ロジックの変更に影響されない
+- `scripts/gates/pre-red-gate.sh` — 同様に sync-plan / Plan Review チェック（L40-50）は `$ACTIVE_CYCLE` を読むのみ
+- gate script の呼び出し元: orchestrate / commit skill は言及のみで bash 実行する呼び出し元は存在しない（Explore 調査で確定）。唯一の実行例が `rules/integration-verification.md:29`
+
+### Related Issues/PRs
+- Issue #145: pre-commit-gate.sh の ACTIVE_CYCLE 選択が glob 先頭の non-DONE cycle を検査し、REVIEW を飛ばした COMMIT を機械的に BLOCK する gate の存在意義が実質無効化されているバグ
+- Stacked on PR #146（feature/skill-inventory-cleanup、base: d6a3c91）
+
+## Test List
+
+### TODO
+- [ ] TC-06: Given 既存 TC 全量（test-pre-commit-gate / -retro / test-pre-red-gate）+ full suite, When 一括実行, Then 112/112 で回帰なし（GREEN 後の VERIFY で実施）
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+- [x] TC-01: Given 古い `phase: COMMIT`（updated 旧）と新しい `phase: COMMIT`（updated 新）の 2 doc を持つ fixture, When `pre-commit-gate.sh <fixture_root>` を実行, Then updated 最新の REVIEW doc が検査対象になる（REVIEW log 不足の BLOCK メッセージが新 doc 起因で出る） — test-pre-commit-gate.sh TC-08 として契約化（GREEN: rc=1、"20260601_0000_new" を出力に含み PASS）
+- [x] TC-02: Given 検査対象 doc のパスを `$1` に直接指定, When gate 実行, Then その doc のみが検査され、他の non-DONE doc の状態に影響されない — test-pre-commit-gate.sh TC-09 / test-pre-red-gate.sh T-09 として契約化（GREEN: 明示 doc は new=BLOCK(1)/old=PASS(0) で PASS）
+- [x] TC-03: Given `$1` に存在しないパス, When gate 実行, Then `BLOCK: invalid argument` 相当で exit 1 — test-pre-commit-gate.sh TC-10 として契約化（GREEN: rc=1 + "invalid" 文字列ありで PASS）
+- [x] TC-04: Given updated が `YYYY-MM-DD`（時刻なし）と `YYYY-MM-DD HH:MM` の混在 fixture, When fallback 選択, Then lexicographic 最大が決定論的に選ばれる — tie-break として test-pre-commit-gate.sh TC-11 に具体化（updated 同値時の filename tail 選択、GREEN: b が選ばれ PASS）。明示 DONE doc の enumerate-and-reject は TC-12 で契約化（GREEN: doc 名を含む BLOCK メッセージで PASS）
+- [x] TC-05: Given pre-red-gate に同型の複数 non-DONE fixture, When 実行, Then latest-updated doc が選ばれる + 明示指定モードが機能する — test-pre-red-gate.sh T-08（dir mode 選択）/ T-09（明示指定）として契約化（GREEN: 両方 PASS）
+- [x] TC-09 (test-phase-gate.sh, F1 sweep): Given skills/red・green・refactor・commit・review/SKILL.md + orchestrate/steps-subagent.md・steps-teams.md の 7 ファイル, When 探索行を検査, Then 全ファイルが新スニペット（contiguous phrase `sort | tail -1 | cut -f2`）を使い `| head -1` が残存しない — test-phase-gate.sh TC-09 として契約化（GREEN: 7 ファイル全て新型で PASS）
+
+## Implementation Notes
+
+### Goal
+`pre-commit-gate.sh` / `pre-red-gate.sh` の ACTIVE_CYCLE 選択ロジックを、glob 先頭の non-DONE cycle doc を機械的に選ぶ現行実装から、`updated` frontmatter 最新の doc を選ぶ（または `$1` で明示指定できる）新契約に書き換え、REVIEW を飛ばした COMMIT を機械的に BLOCK する gate の存在意義を回復する。
+
+### Background
+cycle 20260702_1200 の COMMIT 時に実測で露呈したバグ（issue #145）。`pre-commit-gate.sh` は glob（辞書=時系列）順で最初の non-DONE cycle doc を ACTIVE_CYCLE として検査するため、non-DONE doc が複数併存すると本来の対象 cycle を検査しない。実測: non-DONE 15件が滞留しており、現在 gate が検査するのは 2ヶ月前の `20260421_1809`（本来の対象は updated 最新の doc）。CONSTITUTION 原則6「決定論的プロセス保証」が実質無効化されている。
+
+兄弟 gate `pre-red-gate.sh:24-33` にも完全同型のバグが存在し横展開が必須。後続チェック（REVIEW log / Codex review / retro_status）は全て `$ACTIVE_CYCLE` 変数を読むだけのため、修正は選択ロジックに閉じる。gate を bash 実行する呼び出し元は存在せず、唯一の実行例 `rules/integration-verification.md:29` は cycle doc パスを渡す想定で書かれており、現行の project_root 契約と矛盾している（cycle 20260702_1200 の VERIFY で誤用として実測発覚済み）。
+
+### Design Approach
+
+**選択ロジックの新契約（両 gate 共通）**: `$1` を polymorphic に解釈する。
+
+| $1 | 挙動 |
+|----|------|
+| `.md` ファイルパス（実在） | その doc を ACTIVE_CYCLE として直接検査（明示指定モード）。`docs/cycles/` 配下であることは要求しない（fixture 互換） |
+| ディレクトリ（実在、default `.`） | `$1/docs/cycles/*.md` の non-DONE から frontmatter `updated:` が lexicographic 最大の doc を選択。同値時は filename 降順（新しい cycle 番号優先）。updated 欠落 doc は `0000-00-00` 扱いで最古に |
+| それ以外（不在パス等） | `BLOCK: invalid argument` で exit 1（multi-file-consistency の enumerate-and-reject 準拠） |
+
+採用理由:
+- 明示指定モードは決定論性が最大で、`rules/integration-verification.md:29` の既存記述（`$cycle_doc` を渡す）がそのまま正しくなる（文書と実装の矛盾解消）
+- ディレクトリモードの latest-updated 選択は手動実行・後方互換用 fallback。updated は non-DONE 全 15件に存在することを実測確認済み
+- 旧 doc 15件の phase を DONE に一括遷移する案は不採用（歴史的 doc の状態一括変更は別の意思決定。DISCOVERED で起票）
+
+**逆向き契約 sweep（実測済み）**:
+- gate script への参照: `rules/integration-verification.md:29`（+mirror）のみが実行例。`agents/sync-plan.md:143,155` は Progress Log header 互換性の説明で、選択ロジック変更の影響なし
+- 既存 gate テスト（T-01〜TC-11）は全て単一 doc fixture + project_root 引数 → ディレクトリモードの fallback として引き続き成立（単一 non-DONE なら latest-updated = その doc）。回帰なしを full suite で検証
+- count 112 の hardcode 契約（TC-19）: 新規テストファイルを作らないため不変
+
+**Design Review Gate 判定（Read-only 調査、tests/ 実行なし）**:
+- PASS（Risk ~40, WARN 帯）
+- 検証1（既存 gate テスト単一 doc fixture の回帰）: `tests/test-pre-commit-gate.sh` T-01〜T-04・TC-06・TC-07、`tests/test-pre-red-gate.sh` T-01〜T-07、`tests/test-pre-commit-gate-retro.sh`（固定 fixture ファイル名 `20260101_0000_test.md` 単一 doc）を確認。全て単一 non-DONE doc の fixture のみで構成されており、ディレクトリモードの fallback は「候補が1件なら無条件でその doc を選ぶ」ため回帰なしと判定
+- 検証2（updated 欠落 doc の 0000-00-00 扱いと T-06/T-07 の整合）: T-06/T-07 は `phase:` frontmatter 自体が存在しない doc（old-format / no-frontmatter）が唯一の doc であるケースで、これらは既存の `[ -z "$phase" ] && continue` により phase チェック段階で完全に除外され ACTIVE_CYCLE 候補にすら入らない（BLOCK: No active Cycle doc found）。新契約の「updated 欠落 → 0000-00-00 扱い」は phase フィールドを持つが updated フィールドを欠く doc にのみ適用される別ケースであり、両者は排他的条件のため矛盾なし
+- 検証3（multi-file-consistency.md の enumerate-and-reject 原則との整合）: 新契約の `$1` 三分岐（`.md` file 実在 / directory 実在 / それ以外）は「期待値を enumerate し、それ以外は明示的に reject する」原則に準拠。GREEN 実装では `if [ -f ] / elif [ -d ] / else BLOCK` の enumerate 構造で実装すること
+- Files to Change 現物確認: `pre-commit-gate.sh` L24-41（PROJECT_ROOT 代入 〜 ACTIVE_CYCLE 空チェックの `fi`）、`pre-red-gate.sh` L24-33（ACTIVE_CYCLE 選択 for ループ）、`rules/integration-verification.md` L29 と `.claude/rules/integration-verification.md` L29 が byte-identical であることを Read で実測確認済み。plan の行番号記述と実物が一致
+
+## Verification（real-path invocation）
+
+**Real-path invocation を最低 1 件含めること** (rules/integration-verification.md)。
+
+```bash
+SCRATCH=/private/tmp/claude-501/-Users-morodomi-Projects-MorodomiHoldings-agents-dev-crew/74f3a9a9-3af1-4977-80a3-f0ee96a13dd1/scratchpad
+
+# 1) real-path: 実 repo で fallback 選択が最新 updated の doc を選ぶ（修正前は 20260421_1809 を選んでいた）
+bash scripts/gates/pre-commit-gate.sh . 2>&1 | head -3; echo "rc=$?"
+# 期待: 検査対象が updated 最新の non-DONE doc（本 cycle doc）になっていること
+
+# 2) real-path: 明示指定モード（integration-verification.md L29 の記載形式がそのまま動く）
+bash scripts/gates/pre-commit-gate.sh docs/cycles/20260702_1930_gate-active-cycle-fix.md; echo "rc=$?"
+
+# 3) real-path: pre-red-gate も同様に確認
+bash scripts/gates/pre-red-gate.sh . 2>&1 | head -3; echo "rc=$?"
+
+# 4) mirror byte-identical
+diff rules/integration-verification.md .claude/rules/integration-verification.md && echo IDENTICAL
+
+# 5) full suite（snapshot baseline と diff、rc≠0 は FAIL 扱い、|| true で握り潰さない）
+for f in tests/test-*.sh; do timeout 2400 bash "$f" >/dev/null 2>&1; printf "%s rc=%d\n" "$(basename $f)" "$?"; done | sort > "$SCRATCH/after.txt"
+if grep -v "rc=0" "$SCRATCH/after.txt"; then echo "VERIFY FAIL"; false; else echo "all rc=0"; fi
+diff "$SCRATCH/baseline-gatefix.txt" "$SCRATCH/after.txt" && echo "no regression"
+```
+
+baseline（`baseline-gatefix.txt`）は orchestrate Block 0 で snapshot 複製上で取得する（前 cycle Insight 1: live tree での baseline は並行プロセスに破壊されるため隔離必須）。
+
+Evidence: (orchestrate が自動記入)
+
+## Progress Log
+
+Format for each phase entry (**strict, required by pre-commit-gate.sh**):
+
+```
+### YYYY-MM-DD HH:MM - PHASE_NAME
+- [completed action]
+- Phase completed
+```
+
+### 2026-07-02 19:30 - KICKOFF
+- Cycle doc created from plan `/Users/morodomi/.claude/plans/delegated-roaming-pelican.md`（issue #145）
+- Design Review Gate 実施（Read-only、tests/ 未実行 — baseline 実測は PdM が snapshot 複製上で並行取得中のため、テスト実行プロセスの直列化原則に従い本 gate では実行しない）
+- 判定: PASS（Risk ~40, WARN 帯）。既存 gate テストの単一 doc fixture 回帰なし、updated 欠落 doc の扱いと T-06/T-07 の非矛盾、multi-file-consistency.md の enumerate-and-reject 原則との整合を確認
+- Files to Change 全量（6件）を plan から verbatim 転記。独自判断での追加・削除なし
+- Scope definition ready
+- Phase completed
+
+### 2026-07-02 19:50 - PLAN REVIEW (Codex competitive)
+- Codex plan review: **BLOCK**（F1）+ WARN 3（F2-F4）。triage（全て accept-apply、reject 0）:
+- **F1 (BLOCK: sweep 漏れ — LLM 側手順に同型バグ) → accept-apply、scope +7 files**:
+  - Codex 指摘は steps-subagent.md / steps-teams.md / commit SKILL.md の 3 箇所だが、PdM 追加 sweep で **7 箇所**を確定: `grep -L 'phase: DONE' ... | head -1` 型 = skills/red/SKILL.md:18, skills/green/SKILL.md:19, skills/refactor/SKILL.md:21, skills/commit/SKILL.md:10。awk first-match 型 = skills/review/SKILL.md, skills/orchestrate/steps-subagent.md:42, skills/orchestrate/steps-teams.md:35
+  - 全 7 箇所を gate と同一セマンティクス（updated lexicographic 最大の non-DONE、filename 昇順 tie-break で tail 選択）の canonical one-liner に差し替える。GREEN の scope に追加（rules/doc-mutations.md SSOT 即時同期に従い本エントリで Files list を拡張）
+  - 逆向き契約確認済み: test-phase-gate.sh TC-01〜 は「`phase: DONE` 文字列 + BLOCK|spec の存在」のみを assert し、新スニペットも `phase: DONE` を含むため非破壊。test-review-plan-gate.sh の orchestrate 参照も文字列レベルで互換
+- **F2 (WARN: tie-break TC 欠如) → accept-apply**: Test List に TC-07 を追加（updated 同値 2 doc で filename 降順選択）
+- **F3 (WARN: 明示指定モードの穴) → accept-apply**: 契約を補強 — 明示指定 doc が phase 欠落 or `phase: DONE` の場合は BLOCK（enumerate-and-reject）。STATUS.md count 警告用の PROJECT_ROOT は `*/docs/cycles/*.md` パターン時に doc の 2 階層上から導出、それ以外は `.`。Test List に TC-08 を追加（DONE doc 明示指定で BLOCK）
+- **F4 (WARN: updated 比較の将来堅牢性) → accept-apply**: 実装指針 — `printf '%s\t%s\n' "$updated" "$f" | sort | tail -1 | cut -f2` の全行 lexicographic 比較とし、空白 field split（sort -k1,1 等）を使わない。ISO T 形式混入時も文字列比較で破綻しない
+- **Notes → accept**: 新規 multi-doc TC は TC ごとに fixture サブディレクトリを隔離（test-pre-commit-gate-retro.sh の make_gate_fixture 方式踏襲）
+- **追加 TC-09**（前 cycle codify Insight 1/2 の contiguous-phrase pin を dogfood）: 7 skill docs の探索行が新スニペット（`sort | tail -1 | cut -f2` を含む）であり `| head -1` 型 first-match が残存しないことを assert する TC を test-phase-gate.sh に追加
+- test_count: 6 → 9（frontmatter 同期）
+- Codex session id: stdout 非出力のため未記録
+- 判定: BLOCK 事由（F1）は scope 拡張で解消 → Block 2a (RED) へ
+
+#### Files to Change 拡張（F1 反映後の全量、GREEN はこれを正とする）
+1-6. plan 記載の 6 項目（両 gate / 両 gate テスト / integration-verification.md + mirror / Cycle doc）
+7. skills/red/SKILL.md:18 — Hard Gate 探索行を canonical one-liner に差し替え
+8. skills/green/SKILL.md:19 — 同上
+9. skills/refactor/SKILL.md:21 — 同上
+10. skills/commit/SKILL.md:10 — Cycle Doc Gate 探索行を同差し替え
+11. skills/review/SKILL.md — awk first-match 探索を同セマンティクスに差し替え
+12. skills/orchestrate/steps-subagent.md:42 — 同上
+13. skills/orchestrate/steps-teams.md:35 — 同上
+14. tests/test-phase-gate.sh — TC-09（スニペット pin）追加
+
+### 2026-07-02 20:20 - RED
+- 対象 3 ファイルに TC 追加（新規テストファイル作成なし、count 112 維持）:
+  - `tests/test-pre-commit-gate.sh`: TC-08〜TC-12（5件、各 TC 専用 fixture サブディレクトリ `$TMPDIR/tc08`〜`tc12` で隔離）
+    - TC-08: dir mode で updated 最新の non-DONE doc（new）が選ばれ REVIEW 未完了で BLOCK
+    - TC-09: 明示指定モード（$1=doc パス）で new/old それぞれ単独検査
+    - TC-10: $1 不在パスで `invalid` 文字列を含む BLOCK
+    - TC-11: updated 同値 tie-break で filename tail（b）が選ばれる
+    - TC-12: 明示指定 + `phase: DONE` doc で BLOCK
+  - `tests/test-pre-red-gate.sh`: T-08〜T-09（2件、`$TMPDIR/t08`〜`t09` で隔離）
+    - T-08: dir mode で updated 最新の non-DONE doc（new）が選ばれ Plan Review 未完了で BLOCK
+    - T-09: 明示指定モードで new/old それぞれ単独検査
+  - `tests/test-phase-gate.sh`: TC-09（1件、`check_selection_snippet` helper で 7 ファイル一括検査、TC-17 の ALL_UNDER 集約パターンに準拠し単一 pass/fail に集約）
+    - 対象 7 ファイル: skills/red/SKILL.md, skills/green/SKILL.md, skills/refactor/SKILL.md, skills/commit/SKILL.md, skills/review/SKILL.md, skills/orchestrate/steps-subagent.md, skills/orchestrate/steps-teams.md
+    - 探索行の特定は `docs/cycles/*.md`（fixed-string）+ `phase: DONE` の AND 条件で一意化（orchestrate 2 ファイルの retro_status codify-gate ループと Current State 表示行を誤検出しないことを事前 dry-run で確認済み）
+- 3 ファイル個別実行結果（full suite 未実行、直列化原則に従い個別のみ）:
+  - `bash tests/test-pre-commit-gate.sh` rc=1、PASS 7 / FAIL 5（TC-08〜TC-12 のみ FAIL、T-01〜T-04・T-06・TC-06・TC-07 は PASS 維持）
+  - `bash tests/test-pre-red-gate.sh` rc=1、PASS 7 / FAIL 2（T-08〜T-09 のみ FAIL、T-01〜T-07 は PASS 維持）
+  - `bash tests/test-phase-gate.sh` rc=1、PASS 22 / FAIL 1（TC-09 のみ FAIL、TC-01〜TC-22 は PASS 維持）
+- 想定外事象: なし。全新規 TC が意図通り FAIL（RED）、既存 TC は全て PASS を維持
+- test_count: frontmatter 9 のまま据え置き（Test List WIP 6項目のうち TC-09(phase-gate) は plan review F1 由来の追加契約点）
+- Phase completed
+
+### 2026-07-02 20:50 - GREEN
+- Files to Change 拡張後の全量（14 項目）を対象に、選択ロジックを新契約へ書き換え:
+  - `scripts/gates/pre-commit-gate.sh` L22-... — `$1` 三分岐（`.md` file 実在=明示指定 / directory 実在=dir mode fallback / else=BLOCK invalid argument）に書き換え。明示指定は phase 欠落・`phase: DONE` を enumerate-and-reject。dir mode は `updated\tpath` を `sort | tail -1 | cut -f2` の全行 lexicographic 比較で選択（F4 準拠、sort -k 未使用）。updated 欠落は `0000-00-00` 扱い。選択確定時に `Active Cycle: <path>` を出力。PROJECT_ROOT は明示指定時 `*docs/cycles/*.md` パターンなら doc の 2 階層上、それ以外は `.`。後続チェック（L43-90 相当）は無変更
+  - `scripts/gates/pre-red-gate.sh` — 同型の書き換え（後続の sync-plan / Plan Review チェックは無変更）
+  - `skills/red/SKILL.md:18`, `skills/green/SKILL.md:19`, `skills/refactor/SKILL.md:21`, `skills/commit/SKILL.md:10`, `skills/review/SKILL.md:22`, `skills/orchestrate/steps-subagent.md:42`, `skills/orchestrate/steps-teams.md:35` — 探索行を canonical one-liner（`for f in docs/cycles/*.md; do awk ... grep -q 'phase: DONE' || printf '%s\t%s\n' "$(awk ... updated ...)" "$f"; done | sort | tail -1 | cut -f2`）に統一差し替え。各ファイル 1 行差し替えのみで行数不変
+  - `rules/integration-verification.md` L29 + `.claude/rules/integration-verification.md` L29 — 実行例を「$1 に cycle doc パスを渡すと明示検査（推奨）。project root を渡すと updated 最新の non-DONE を自動選択」に更新。`diff` で byte-identical 確認済み
+- GREEN 確認（個別実行、rc 一覧）:
+  - `tests/test-pre-commit-gate.sh` rc=0（PASS 12 / FAIL 0、TC-08〜TC-12 含む全 PASS）
+  - `tests/test-pre-red-gate.sh` rc=0（PASS 9 / FAIL 0、T-08〜T-09 含む全 PASS）
+  - `tests/test-pre-commit-gate-retro.sh` rc=0（PASS 6 / FAIL 0、既存 retro fixture 回帰なし）
+  - `tests/test-phase-gate.sh` rc=0（PASS 23 / FAIL 0、TC-09 selection snippet 含む全 PASS、TC-17 SKILL.md 行数上限 PASS）
+  - `tests/test-review-plan-gate.sh` rc=0（PASS 13 / FAIL 0、orchestrate 文字列契約回帰なし）
+  - `tests/test-orchestrate-compact.sh` rc=0（PASS 17 / FAIL 0）
+  - `tests/test-skill-map.sh` rc=0（PASS 7 / FAIL 0）
+- real-path smoke:
+  - `bash scripts/gates/pre-commit-gate.sh .` → `Active Cycle: ./docs/cycles/20260702_1930_gate-active-cycle-fix.md` を選択（updated 最新の non-DONE = 本 cycle doc）。REVIEW 未完了で `BLOCK: REVIEW not completed in Progress Log.` (rc=1、想定通り)
+  - `bash scripts/gates/pre-commit-gate.sh docs/cycles/20260702_1930_gate-active-cycle-fix.md`（明示指定、integration-verification.md L29 記載形式）→ 同じ doc を検査し同じ BLOCK (rc=1、想定通り)
+  - `bash scripts/gates/pre-red-gate.sh .` → 同 doc を選択し `PASS: All pre-RED gate checks passed.` (rc=0、sync-plan + Plan Review 記録済みのため想定通り)
+- SKILL.md 行数確認: red 81 / green 52 / refactor 59 / commit 91 / review 50（review/SKILL.md は 100 行制約外だが確認、全て 100 行以下）
+- 想定外事象: なし
+- Phase completed
+
+### 2026-07-02 21:00 - REFACTOR (PdM 検証)
+- 選択ロジックは本 cycle で新規に書き直したテスト済みコードのため構造的リファクタ不要（no-op）
+- Verification Gate: `bash -n` 両 gate OK（shellcheck はローカル不在で skip）、spot 4 test（pre-commit-gate / pre-red-gate / phase-gate / pre-commit-gate-retro）全 rc=0、integration-verification.md mirror byte-identical、real-path で `Active Cycle: ./docs/cycles/20260702_1930_gate-active-cycle-fix.md` の正選択を確認
+- green-worker の指示外調整 1 件を承認: PROJECT_ROOT 導出パターンを `*/docs/cycles/*.md` → `*docs/cycles/*.md`（先頭スラッシュなし）に変更。相対パス呼び出し（integration-verification.md 記載形式）がマッチしないための技術的必然
+- Phase completed
+
+### 2026-07-02 21:30 - VERIFY (Product Verification, Block 2c.5)
+- Evidence: /tmp/dev-crew-verify-20260702_1930/verify.log
+- real-path: dir mode → `Active Cycle: ./docs/cycles/20260702_1930_gate-active-cycle-fix.md`（updated 最新の non-DONE を正選択。修正前は 20260421_1809 を選んでいた）+ REVIEW 未完了 BLOCK（この時点の正常挙動）
+- real-path: 明示指定モード（integration-verification.md L29 記載形式）→ 同 doc を直接検査。文書と実装の矛盾解消を実証
+- real-path: pre-red-gate → 同 doc 選択、PASS
+- mirror byte-identical
+- **full suite: 112/112 全 rc=0、baseline-gatefix.txt との diff 空 = 回帰ゼロ**（snapshot 隔離 baseline との機械的比較、rc≠0 は握り潰さない改訂 Verification を実行）
+- Phase completed
+
+### 2026-07-02 21:55 - REVIEW FIX (green-worker)
+- REVIEW で BLOCK した findings 5点を修正。red-first で TC-13/TC-14 を先に追加し FAIL を確認してから fix を適用:
+  - **Fix 1 (security HIGH)**: 両 gate の明示指定分岐に docs/cycles/ 配下必須チェックを追加。`ARG_ABS="$(cd "$(dirname "$ARG")" && pwd)/$(basename "$ARG")"` で絶対パス正規化した上で `case "$ARG_ABS" in */docs/cycles/*.md) ;; *) BLOCK; esac`。pin: test-pre-commit-gate.sh TC-13（docs/cycles/ 外の偽造 .md を明示指定 → BLOCK + 出力に "docs/cycles" を含む）。red 確認: fix 前は rc=0 で PASS してしまう（TC-13 FAIL）。fix 後 rc=1 で BLOCK（TC-13 PASS）
+  - **Fix 2 (correctness BLOCK)**: 両 gate の明示指定分岐の PROJECT_ROOT 導出を dirname 2重 → 3重に修正（`docs/cycles/foo.md` → project root は 3 階層上）。ARG_ABS 基準で導出。pre-red-gate は PROJECT_ROOT 未消費（dead value）だが同型維持のため同修正。pin: test-pre-commit-gate.sh TC-14（STATUS.md 不一致 count fixture を明示指定で実行し WARN 出力を assert）。red 確認: fix 前は PROJECT_ROOT が1階層浅く STATUS.md が見つからず WARN 未出力（TC-14 FAIL）。fix 後 WARN 出力（TC-14 PASS）
+  - **Fix 3 (Codex BLOCK)**: 7 skill docs（red/green/refactor/commit/review/SKILL.md, orchestrate/steps-subagent.md, orchestrate/steps-teams.md）の canonical one-liner を、空 glob 対応（`[ -f "$f" ] || continue`）+ phase 存在必須（`grep -q '^phase:' || continue`）+ DONE 除外（`grep -q 'phase: DONE' && continue`）+ updated の ISO-T 正規化（`gsub(/T/," ")`）を含む形に差し替え、gate 本体とのセマンティクス一致を確保。test-phase-gate.sh TC-09（sort|tail|cut-f2 契約 + head -1 非残存）で差し替え後も PASS を確認
+  - **Fix 4 (Codex WARN)**: 両 gate の dir mode で updated 値の `T` を空白に正規化（`tr 'T' ' '`）してから sort。ISO 形式混入時も同日内の時系列比較を保証
+  - **Fix 5 (maint HIGH×3)**: tests/test-pre-commit-gate.sh:239, tests/test-pre-red-gate.sh:181, tests/test-phase-gate.sh:300 のコメントから「, issue #145」等の追跡番号句を削除（TC 番号・内容は無変更）。新規 TC-13/TC-14 のコメントにも追跡番号は付与していない
+  - 適用外（PdM 判断により defer/reject、対応不要）: maint MED（gate 間重複の drift guard）と LOW（echo 集約）→ DISCOVERED へ defer。Codex note（tab/newline パス）→ reject（doc パスは repo 命名規約下で発生しない）
+- 完了確認（個別実行、全 rc=0）:
+  - `tests/test-pre-commit-gate.sh` rc=0（PASS 14 / FAIL 0、TC-13/TC-14 含む）
+  - `tests/test-pre-red-gate.sh` rc=0（PASS 9 / FAIL 0）
+  - `tests/test-phase-gate.sh` rc=0（PASS 23 / FAIL 0、TC-09 selection snippet 新契約で PASS）
+  - `tests/test-pre-commit-gate-retro.sh` rc=0（PASS 6 / FAIL 0、既存 retro fixture 回帰なし）
+- real-path smoke（期待通り）:
+  - `bash scripts/gates/pre-commit-gate.sh .` → `Active Cycle: ./docs/cycles/20260702_1930_gate-active-cycle-fix.md` 選択、REVIEW 未完了で BLOCK rc=1
+  - `bash scripts/gates/pre-commit-gate.sh docs/cycles/20260702_1930_gate-active-cycle-fix.md`（明示指定）→ 同 doc を検査、同じ BLOCK rc=1
+- 想定外事象: なし
+- Phase completed
+
+### 2026-07-02 22:10 - REVIEW (Codex competitive + 3 Claude reviewers, MED tier)
+- 判定: Codex **BLOCK** / correctness **BLOCK** / security **BLOCK 相当（HIGH 1）** / maintainability **WARN（HIGH 3 + MED/LOW）**
+- findings 3-category triage:
+  - **accept-apply（5 fix、全て red-first で pin TC 付き適用済み）**:
+    1. security HIGH: 明示指定モードが docs/cycles/ 外の任意 .md を信頼（偽造 doc で gate 通過を実機実証）→ ARG_ABS 正規化 + `*/docs/cycles/*.md` 必須化。pin: TC-13
+    2. correctness BLOCK（Codex F2 同指摘）: PROJECT_ROOT の dirname 1 回不足で STATUS.md count 警告が明示指定モードで silent skip → dirname 3 重化。pin: TC-14
+    3. Codex BLOCK: 7 skill docs one-liner が gate と非同一セマンティクス（空 glob false-found・phase 欠落 doc を候補化）→ `[ -f ]` + phase 存在必須 + DONE 除外 + T 正規化を含む canonical form に統一
+    4. Codex WARN: updated の ISO `T` 形式混在で同日順序が崩れる → 両 gate で tr 'T' ' ' 正規化
+    5. maint HIGH×3: テストコメントの「issue #145」追跡番号を除去（グローバル規約準拠、TC 内容不変）
+  - **accept-defer → DISCOVERED**: maint MED（両 gate の選択ロジック重複に drift guard なし）、maint LOW（Active Cycle echo の分岐重複）
+  - **reject（根拠付き）**: Codex note の tab/newline 含みパス — cycle doc パスは repo 命名規約（YYYYMMDD_HHMM_topic.md）下にあり発生しない。fixture も同規約
+- 適用後検証: test-pre-commit-gate（14 PASS、TC-13/14 含む）/ test-pre-red-gate（9 PASS）/ test-phase-gate（23 PASS）/ test-pre-commit-gate-retro（6 PASS）全 rc=0。PdM による偽造 doc 実弾確認で BLOCK を確認
+- BLOCK 事由は全て解消 → Block 2e へ
+- Phase completed
+
+### 2026-07-02 22:12 - DISCOVERED (Block 2e)
+- D1: 旧 non-DONE cycle doc 15 件の phase: DONE 一括遷移 + COMMIT→DONE 遷移責務の workflow 未定義（plan スコープ外宣言済み。gate の latest-updated 選択で実害は解消したが、「non-DONE = active」の意味論修復は残課題）→ issue 起票
+- D2: 両 gate の選択ロジック重複（約48行）に drift guard がない（maint MED）+ Active Cycle echo の分岐重複（maint LOW）。共有 lib 化は「gate 単体 full validation」原則との整合検討が必要 → issue 起票
+- parallel 削除/作り直し・test hardening 束ね cycle は既存 issue（#142/#143）で追跡済みのため新規起票なし
+- issue 起票結果: D1=#147, D2=#148
+
+### 2026-07-02 22:40 - COMMIT
+- REVIEW FIX 適用後の最終 full suite: **112/112 全 rc=0、baseline-gatefix.txt との diff 空（回帰ゼロ）**（scratchpad/final-gatefix.txt）
+- pre-commit gate は本 cycle で修正した gate 自身を**明示指定モードで dogfood**（`bash scripts/gates/pre-commit-gate.sh docs/cycles/20260702_1930_gate-active-cycle-fix.md`）— #145 の「対象 cycle を検査しない」穴が塞がった状態での初の実運用
+- branch feature/gate-active-cycle-fix（#146 の上に stack）で commit、PR を feature/skill-inventory-cleanup base で作成
+- Phase completed
+
+---
+
+## Next Steps
+
+1. [Done] KICKOFF
+2. [Done] RED
+3. [Done] GREEN <- Current
+4. [ ] REFACTOR
+5. [ ] REVIEW
+6. [ ] COMMIT
+7. [ ] DONE
+
+## Retrospective
+
+抽出時刻: 2026-07-02 22:30
+抽出方法: Cycle doc 全体（PLAN REVIEW BLOCK / REVIEW 4系統 BLOCK×3+WARN / red-first fix）からの失敗→最終解→insight ペア抽出
+
+### Insight 1: パス引数を取る gate は「信頼するディレクトリ境界」を契約に含める
+- **Failure**: 明示指定モードの設計（plan + Codex plan review F3 の補強後も）は引数の**形式**（.md file / dir / other）は enumerate したが**位置**（tree 内/外）を定義せず、docs/cycles/ 外の偽造 doc（phase: COMMIT + REVIEW 記録 + retro_status: resolved を完備）で COMMIT gate を素通りできる穴が GREEN 実装に入った。security reviewer が実機再現で検出
+- **Final fix**: `cd+pwd` による絶対パス正規化 + `*/docs/cycles/*.md` 必須化 + 偽造 doc fixture の TC-13 で pin
+- **Insight**: **ファイルパスを受ける gate/validator の enumerate-and-reject は、値の形式だけでなく「どのディレクトリ配下を信頼するか」の境界を含めて列挙する**。discipline gate は adversary への防御ではないが、LLM の hallucination パス渡しは現実的な入力分布であり境界検証が実害を防ぐ
+- **一般化**: rules/multi-file-consistency.md の enumerate-and-reject 原則の拡張候補（「位置も enumerate する」）
+
+### Insight 2: 分岐追加時は「新分岐 × 既存チェック」の組み合わせ経路に観測可能な TC を置く
+- **Failure**: 明示指定モード（新分岐）と STATUS.md count 警告（既存チェック）の組み合わせ経路に TC がなく、PROJECT_ROOT の dirname off-by-one（`docs` を指す）で警告が silent skip されるバグが GREEN を素通り。RED の 8 TC は全て選択ロジック自体を検査し、非ブロッキング警告の消失は全体 rc に現れない。correctness reviewer が fixture 実測で検出
+- **Final fix**: dirname 3 重化 + TC-14（明示指定 + STATUS 不一致 fixture で `WARN:` 出力文字列を assert）
+- **Insight**: **分岐を追加したら、分岐ごとに既存チェックの出力（特に非ブロッキング WARN）が生きていることを出力文字列 assert で観測する**。rc のみの検証は「黙って何もしなくなった」regression を検出できない
+- **一般化**: 20260701_1120 Insight 1（追記内容の contiguous phrase pin）の実行時版 — 「観測されない経路は壊れていても GREEN」
+
+### Insight 3: 「同一セマンティクス」の複数実装は挙動チェックリストを列挙してから適用する
+- **Failure**: PLAN REVIEW で PdM が起草した canonical one-liner が gate 実装の guard（空 glob の -f check、phase 欠落 doc の除外）を欠いた簡略版で、「gate と同一セマンティクス」の要求を自ら満たさなかった。文字列 pin（test-phase-gate TC-09）は再混入防止には効くがセマンティクス同値性は検証しないため素通り。Codex code review が bash 実行で挙動差を検出
+- **Final fix**: 空 glob / phase 欠落 / DONE 除外 / ISO-T 正規化を含む canonical form に 7 ファイル統一
+- **Insight**: **複数実装に「同一セマンティクス」を要求する時は、先に挙動チェックリスト（空入力・欠落フィールド・形式混在・異常系）を列挙し、各実装をリストに対して検証する**。代表実装からの目視転記は guard を落とす
+- **一般化**: 本 cycle の maint MED（gate 間 drift guard 不在、#148）と同根。セマンティクス同値性の検証は文字列比較でなく挙動比較
+
+### 成功事例（observation）: perspective-diverse review の相補性
+- 4 系統が互いに排他的な欠陥を検出: security=偽造パス、correctness=dirname off-by-one、Codex=one-liner セマンティクス乖離、maintainability=追跡番号混入。重複指摘は dirname 1 件のみ。レンズ分離設計（rules/review-triage.md MED tier）の有効性を実証

--- a/rules/integration-verification.md
+++ b/rules/integration-verification.md
@@ -26,7 +26,7 @@ template / skill docs だけでなく、自 cycle の Verification 実行でも 
 - **Web**: `docker compose up -d && curl -fsS localhost:PORT/health && docker compose down`
 - **Config 変更時** (motivating bug): `python -m myapp --config new.yaml && grep "loaded_from: new.yaml" /tmp/myapp.log`
 - **Library**: `python -c "from mymod import run; run('config.yaml')"`
-- **dev-crew 内 (bash/doc project)**: gate/consumer/validator を real path で実行 — 例 `bash scripts/gates/pre-commit-gate.sh $cycle_doc` or `bash scripts/validate-yaml-frontmatter.sh`。grep/diff のみは structural test として扱う
+- **dev-crew 内 (bash/doc project)**: gate/consumer/validator を real path で実行 — 例 `bash scripts/gates/pre-commit-gate.sh $cycle_doc`（$1 に cycle doc パスを渡すと当該 doc を直接検査。明示指定・推奨。project root を渡すと updated 最新の non-DONE を自動選択）or `bash scripts/validate-yaml-frontmatter.sh`。grep/diff のみは structural test として扱う
 
 ## Evidence 記録
 

--- a/scripts/gates/pre-commit-gate.sh
+++ b/scripts/gates/pre-commit-gate.sh
@@ -21,22 +21,57 @@
 
 set -euo pipefail
 
-PROJECT_ROOT="${1:-.}"
-
-# Find active Cycle doc (skip docs without phase field)
+ARG="${1:-.}"
+PROJECT_ROOT="."
 ACTIVE_CYCLE=""
-for f in "$PROJECT_ROOT"/docs/cycles/*.md; do
-  [ -f "$f" ] || continue
-  phase=$(awk '/^---$/{c++;next} c==1{print}' "$f" | grep '^phase:' | head -1 | sed 's/^phase: *//' || true)
-  [ -z "$phase" ] && continue  # Skip docs without phase field (old format / no frontmatter)
-  if [ "$phase" != "DONE" ]; then
-    ACTIVE_CYCLE="$f"
-    break
-  fi
-done
 
-if [ -z "$ACTIVE_CYCLE" ]; then
-  echo "BLOCK: No active Cycle doc found."
+# $1 is polymorphic: a `.md` file path selects that doc explicitly; a directory
+# falls back to picking the updated-latest non-DONE doc; anything else is rejected.
+if [ -f "$ARG" ] && case "$ARG" in *.md) true;; *) false;; esac; then
+  # Explicit mode: inspect only the given doc (enumerate-and-reject on bad state)
+  ACTIVE_CYCLE="$ARG"
+  # Normalize to absolute path (no realpath dependency) so the docs/cycles/
+  # containment check can't be bypassed via relative-path tricks.
+  ARG_ABS="$(cd "$(dirname "$ACTIVE_CYCLE")" && pwd)/$(basename "$ACTIVE_CYCLE")"
+  case "$ARG_ABS" in
+    */docs/cycles/*.md) : ;;
+    *) echo "BLOCK: cycle doc must reside under docs/cycles/ (got: $ARG)"; exit 1 ;;
+  esac
+  phase=$(awk '/^---$/{c++;next} c==1{print}' "$ACTIVE_CYCLE" | grep '^phase:' | head -1 | sed 's/^phase: *//' || true)
+  if [ -z "$phase" ]; then
+    echo "BLOCK: invalid cycle doc '$ACTIVE_CYCLE' (no phase field)"
+    exit 1
+  fi
+  if [ "$phase" = "DONE" ]; then
+    echo "BLOCK: cycle doc '$ACTIVE_CYCLE' is already DONE"
+    exit 1
+  fi
+  PROJECT_ROOT=$(dirname "$(dirname "$(dirname "$ARG_ABS")")")
+  echo "Active Cycle: $ACTIVE_CYCLE"
+elif [ -d "$ARG" ]; then
+  # Directory mode: fall back to updated-latest non-DONE doc (manual / legacy use)
+  PROJECT_ROOT="$ARG"
+  candidates=""
+  for f in "$PROJECT_ROOT"/docs/cycles/*.md; do
+    [ -f "$f" ] || continue
+    phase=$(awk '/^---$/{c++;next} c==1{print}' "$f" | grep '^phase:' | head -1 | sed 's/^phase: *//' || true)
+    [ -z "$phase" ] && continue  # Skip docs without phase field (old format / no frontmatter)
+    [ "$phase" = "DONE" ] && continue
+    updated=$(awk '/^---$/{c++;next} c==1{print}' "$f" | grep '^updated:' | head -1 | sed 's/^updated: *//' | tr 'T' ' ' || true)
+    [ -z "$updated" ] && updated="0000-00-00"
+    # ISO-T normalized to space so ISO-T and space-separated updated values
+    # compare consistently. Full-line lexicographic compare (no field-splitting
+    # sort -k) keeps the tie-break deterministic.
+    candidates="${candidates}${updated}"$'\t'"${f}"$'\n'
+  done
+  ACTIVE_CYCLE=$(printf '%s' "$candidates" | sort | tail -1 | cut -f2)
+  if [ -z "$ACTIVE_CYCLE" ]; then
+    echo "BLOCK: No active Cycle doc found."
+    exit 1
+  fi
+  echo "Active Cycle: $ACTIVE_CYCLE"
+else
+  echo "BLOCK: invalid argument '$ARG' (expected project root dir or cycle doc .md path)"
   exit 1
 fi
 

--- a/scripts/gates/pre-red-gate.sh
+++ b/scripts/gates/pre-red-gate.sh
@@ -18,22 +18,57 @@
 
 set -euo pipefail
 
-PROJECT_ROOT="${1:-.}"
-
-# 1. Find active Cycle doc (phase != DONE, skip docs without phase field)
+ARG="${1:-.}"
+PROJECT_ROOT="."
 ACTIVE_CYCLE=""
-for f in "$PROJECT_ROOT"/docs/cycles/*.md; do
-  [ -f "$f" ] || continue
-  phase=$(awk '/^---$/{c++;next} c==1{print}' "$f" | grep '^phase:' | head -1 | sed 's/^phase: *//' || true)
-  [ -z "$phase" ] && continue  # Skip docs without phase field (old format / no frontmatter)
-  if [ "$phase" != "DONE" ]; then
-    ACTIVE_CYCLE="$f"
-    break
-  fi
-done
 
-if [ -z "$ACTIVE_CYCLE" ]; then
-  echo "BLOCK: No active Cycle doc found (all DONE or none exist). Run spec first."
+# $1 is polymorphic: a `.md` file path selects that doc explicitly; a directory
+# falls back to picking the updated-latest non-DONE doc; anything else is rejected.
+if [ -f "$ARG" ] && case "$ARG" in *.md) true;; *) false;; esac; then
+  # Explicit mode: inspect only the given doc (enumerate-and-reject on bad state)
+  ACTIVE_CYCLE="$ARG"
+  # Normalize to absolute path (no realpath dependency) so the docs/cycles/
+  # containment check can't be bypassed via relative-path tricks.
+  ARG_ABS="$(cd "$(dirname "$ACTIVE_CYCLE")" && pwd)/$(basename "$ACTIVE_CYCLE")"
+  case "$ARG_ABS" in
+    */docs/cycles/*.md) : ;;
+    *) echo "BLOCK: cycle doc must reside under docs/cycles/ (got: $ARG)"; exit 1 ;;
+  esac
+  phase=$(awk '/^---$/{c++;next} c==1{print}' "$ACTIVE_CYCLE" | grep '^phase:' | head -1 | sed 's/^phase: *//' || true)
+  if [ -z "$phase" ]; then
+    echo "BLOCK: invalid cycle doc '$ACTIVE_CYCLE' (no phase field)"
+    exit 1
+  fi
+  if [ "$phase" = "DONE" ]; then
+    echo "BLOCK: cycle doc '$ACTIVE_CYCLE' is already DONE"
+    exit 1
+  fi
+  PROJECT_ROOT=$(dirname "$(dirname "$(dirname "$ARG_ABS")")")
+  echo "Active Cycle: $ACTIVE_CYCLE"
+elif [ -d "$ARG" ]; then
+  # Directory mode: fall back to updated-latest non-DONE doc (manual / legacy use)
+  PROJECT_ROOT="$ARG"
+  candidates=""
+  for f in "$PROJECT_ROOT"/docs/cycles/*.md; do
+    [ -f "$f" ] || continue
+    phase=$(awk '/^---$/{c++;next} c==1{print}' "$f" | grep '^phase:' | head -1 | sed 's/^phase: *//' || true)
+    [ -z "$phase" ] && continue  # Skip docs without phase field (old format / no frontmatter)
+    [ "$phase" = "DONE" ] && continue
+    updated=$(awk '/^---$/{c++;next} c==1{print}' "$f" | grep '^updated:' | head -1 | sed 's/^updated: *//' | tr 'T' ' ' || true)
+    [ -z "$updated" ] && updated="0000-00-00"
+    # ISO-T normalized to space so ISO-T and space-separated updated values
+    # compare consistently. Full-line lexicographic compare (no field-splitting
+    # sort -k) keeps the tie-break deterministic.
+    candidates="${candidates}${updated}"$'\t'"${f}"$'\n'
+  done
+  ACTIVE_CYCLE=$(printf '%s' "$candidates" | sort | tail -1 | cut -f2)
+  if [ -z "$ACTIVE_CYCLE" ]; then
+    echo "BLOCK: No active Cycle doc found (all DONE or none exist). Run spec first."
+    exit 1
+  fi
+  echo "Active Cycle: $ACTIVE_CYCLE"
+else
+  echo "BLOCK: invalid argument '$ARG' (expected project root dir or cycle doc .md path)"
   exit 1
 fi
 

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Write, Edit, Bash
 ## Workflow
 
 ### Cycle Doc Gate
-`grep -L 'phase: DONE' docs/cycles/*.md | head -1` → found: continue / not found: BLOCK(run spec)
+`for f in docs/cycles/*.md; do [ -f "$f" ] || continue; fm=$(awk '/^---$/{c++;next} c==1{print}' "$f"); echo "$fm" | grep -q '^phase:' || continue; echo "$fm" | grep -q 'phase: DONE' && continue; printf '%s\t%s\n' "$(echo "$fm" | awk 'sub(/^updated: */,""){gsub(/T/," ");print;exit}')" "$f"; done | sort | tail -1 | cut -f2` → found: continue / not found: BLOCK(run spec)
 
 **Phase Ordering Gate**: Progress Log に `REVIEW` の `Phase completed` 記録があるか確認。なければ BLOCK: 「先に review を実行してください」
 

--- a/skills/green/SKILL.md
+++ b/skills/green/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob
 ## Workflow
 
 ### Cycle Doc Gate
-`grep -L 'phase: DONE' docs/cycles/*.md | head -1` → found: continue / not found: BLOCK(run spec)
+`for f in docs/cycles/*.md; do [ -f "$f" ] || continue; fm=$(awk '/^---$/{c++;next} c==1{print}' "$f"); echo "$fm" | grep -q '^phase:' || continue; echo "$fm" | grep -q 'phase: DONE' && continue; printf '%s\t%s\n' "$(echo "$fm" | awk 'sub(/^updated: */,""){gsub(/T/," ");print;exit}')" "$f"; done | sort | tail -1 | cut -f2` → found: continue / not found: BLOCK(run spec)
 
 WIPのテストケースを抽出。
 

--- a/skills/orchestrate/steps-subagent.md
+++ b/skills/orchestrate/steps-subagent.md
@@ -39,7 +39,7 @@ planファイルに `## TDD Context` セクションがあるか確認する。
 frontmatter のみを対象に `phase: DONE` でないファイルを抽出（本文中の文字列に影響されない）:
 
 ```bash
-for f in docs/cycles/*.md; do awk '/^---$/{c++;next} c==1{print}' "$f" | grep -q 'phase: DONE' || echo "$f"; done 2>/dev/null | head -1
+for f in docs/cycles/*.md; do [ -f "$f" ] || continue; fm=$(awk '/^---$/{c++;next} c==1{print}' "$f"); echo "$fm" | grep -q '^phase:' || continue; echo "$fm" | grep -q 'phase: DONE' && continue; printf '%s\t%s\n' "$(echo "$fm" | awk 'sub(/^updated: */,""){gsub(/T/," ");print;exit}')" "$f"; done 2>/dev/null | sort | tail -1 | cut -f2
 ```
 
 - **未完了 cycle doc あり** →

--- a/skills/orchestrate/steps-teams.md
+++ b/skills/orchestrate/steps-teams.md
@@ -32,7 +32,7 @@ planファイルに `## TDD Context` セクションがあるか確認する。
 frontmatter のみを対象に `phase: DONE` でないファイルを抽出（本文中の文字列に影響されない）:
 
 ```bash
-for f in docs/cycles/*.md; do awk '/^---$/{c++;next} c==1{print}' "$f" | grep -q 'phase: DONE' || echo "$f"; done 2>/dev/null | head -1
+for f in docs/cycles/*.md; do [ -f "$f" ] || continue; fm=$(awk '/^---$/{c++;next} c==1{print}' "$f"); echo "$fm" | grep -q '^phase:' || continue; echo "$fm" | grep -q 'phase: DONE' && continue; printf '%s\t%s\n' "$(echo "$fm" | awk 'sub(/^updated: */,""){gsub(/T/," ");print;exit}')" "$f"; done 2>/dev/null | sort | tail -1 | cut -f2
 ```
 
 - **未完了 cycle doc あり** →

--- a/skills/red/SKILL.md
+++ b/skills/red/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob
 ## Workflow
 
 ### Cycle Doc Gate
-`grep -L 'phase: DONE' docs/cycles/*.md | head -1` → found: continue / not found: BLOCK(run spec)
+`for f in docs/cycles/*.md; do [ -f "$f" ] || continue; fm=$(awk '/^---$/{c++;next} c==1{print}' "$f"); echo "$fm" | grep -q '^phase:' || continue; echo "$fm" | grep -q 'phase: DONE' && continue; printf '%s\t%s\n' "$(echo "$fm" | awk 'sub(/^updated: */,""){gsub(/T/," ");print;exit}')" "$f"; done | sort | tail -1 | cut -f2` → found: continue / not found: BLOCK(run spec)
 
 ### Pre-RED Gate (deterministic)
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 ## Workflow
 
 ### Cycle Doc Gate
-`grep -L 'phase: DONE' docs/cycles/*.md | head -1` → found: continue / not found: BLOCK(run spec)
+`for f in docs/cycles/*.md; do [ -f "$f" ] || continue; fm=$(awk '/^---$/{c++;next} c==1{print}' "$f"); echo "$fm" | grep -q '^phase:' || continue; echo "$fm" | grep -q 'phase: DONE' && continue; printf '%s\t%s\n' "$(echo "$fm" | awk 'sub(/^updated: */,""){gsub(/T/," ");print;exit}')" "$f"; done | sort | tail -1 | cut -f2` → found: continue / not found: BLOCK(run spec)
 
 ### Step 2: テスト確認
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -19,7 +19,7 @@ allowed-tools: Task, Read, Edit, Bash, Grep, Glob
 **plan mode**: planファイルの存在確認。なければ BLOCK: 「先に spec を実行してください」
 
 **code mode only**:
-- Cycle Doc Gate (frontmatter のみ): `for f in docs/cycles/*.md; do awk '/^---$/{c++;next} c==1{print}' "$f" | grep -q 'phase: DONE' || echo "$f"; done | head -1` → found: continue / not found: BLOCK(run spec)
+- Cycle Doc Gate (frontmatter のみ): `for f in docs/cycles/*.md; do [ -f "$f" ] || continue; fm=$(awk '/^---$/{c++;next} c==1{print}' "$f"); echo "$fm" | grep -q '^phase:' || continue; echo "$fm" | grep -q 'phase: DONE' && continue; printf '%s\t%s\n' "$(echo "$fm" | awk 'sub(/^updated: */,""){gsub(/T/," ");print;exit}')" "$f"; done | sort | tail -1 | cut -f2` → found: continue / not found: BLOCK(run spec)
 - Phase Ordering Gate: Progress Log に `REFACTOR` の `Phase completed` 記録があるか確認。なければ BLOCK: 「先に refactor を実行してください」
 - **Repo-state pre-check** (cycle 20260424_1119 #3): review 実行前に `git status --short` を先に確認し、`??` (untracked) or ` D` (unstaged deletion) を検出したら WARN + 対応案内。新規 test file / Cycle doc 等が未 staged のまま review されるのを防ぐ。
 

--- a/tests/test-phase-gate.sh
+++ b/tests/test-phase-gate.sh
@@ -11,13 +11,15 @@ REFACTOR="$BASE_DIR/skills/refactor/SKILL.md"
 REVIEW="$BASE_DIR/skills/review/SKILL.md"
 COMMIT="$BASE_DIR/skills/commit/SKILL.md"
 CYCLE_TMPL="$BASE_DIR/skills/spec/templates/cycle.md"
+STEPS_SUBAGENT="$BASE_DIR/skills/orchestrate/steps-subagent.md"
+STEPS_TEAMS="$BASE_DIR/skills/orchestrate/steps-teams.md"
 PASS=0
 FAIL=0
 
 pass() { PASS=$((PASS + 1)); printf "  \033[32mPASS\033[0m %s\n" "$1"; }
 fail() { FAIL=$((FAIL + 1)); printf "  \033[31mFAIL\033[0m %s\n" "$1"; }
 
-for f in "$RED" "$GREEN" "$REFACTOR" "$REVIEW" "$COMMIT" "$CYCLE_TMPL"; do
+for f in "$RED" "$GREEN" "$REFACTOR" "$REVIEW" "$COMMIT" "$CYCLE_TMPL" "$STEPS_SUBAGENT" "$STEPS_TEAMS"; do
   [ -f "$f" ] || { echo "FATAL: $f not found"; exit 1; }
 done
 
@@ -292,6 +294,57 @@ if grep -q "Progress Log Completeness" "$COMMIT_REF" && grep -q "RED" "$COMMIT_R
   pass "commit/reference.md has Progress Log Completeness Gate details"
 else
   fail "commit/reference.md missing Progress Log Completeness Gate details"
+fi
+
+########################################
+# Selection Snippet Consistency (TC-09, gate-active-cycle-fix sweep)
+########################################
+
+echo ""
+echo "--- Selection Snippet Consistency ---"
+
+# TC-09: 7 ファイルの cycle 探索行 (docs/cycles/*.md を参照し phase: DONE で
+# フィルタする行) が新スニペット (contiguous phrase "sort | tail -1 | cut -f2") を
+# 使い、旧 first-match 型の "| head -1" が残存しないことを assert する。
+# 探索行の特定は「docs/cycles/*.md」+「phase: DONE」の両方を含む行に限定し、
+# 無関係な head -1 (例: red/green SKILL.md の Current State 表示行、
+# orchestrate の retro_status codify-gate ループ) を誤検出しないようにする。
+echo ""
+echo "TC-09: cycle selection lines use new sort|tail|cut-f2 snippet (no head -1 remnant)"
+
+ALL_SNIPPETS_OK=true
+check_selection_snippet() {
+  local file="$1"
+  local label="$2"
+  local target
+  target=$(grep -F 'docs/cycles/*.md' "$file" | grep -F 'phase: DONE' || true)
+  local line_count
+  line_count=$(printf '%s\n' "$target" | grep -c '.' || true)
+  if [ "$line_count" -ne 1 ]; then
+    echo "    - $label: expected exactly 1 phase:DONE selection line referencing docs/cycles/*.md, found $line_count"
+    ALL_SNIPPETS_OK=false
+    return
+  fi
+  if echo "$target" | grep -qF 'sort | tail -1 | cut -f2' && ! echo "$target" | grep -qF 'head -1'; then
+    :
+  else
+    echo "    - $label: selection line missing new snippet or still has head -1: $target"
+    ALL_SNIPPETS_OK=false
+  fi
+}
+
+check_selection_snippet "$RED" "red/SKILL.md"
+check_selection_snippet "$GREEN" "green/SKILL.md"
+check_selection_snippet "$REFACTOR" "refactor/SKILL.md"
+check_selection_snippet "$COMMIT" "commit/SKILL.md"
+check_selection_snippet "$REVIEW" "review/SKILL.md"
+check_selection_snippet "$STEPS_SUBAGENT" "orchestrate/steps-subagent.md"
+check_selection_snippet "$STEPS_TEAMS" "orchestrate/steps-teams.md"
+
+if $ALL_SNIPPETS_OK; then
+  pass "All 7 files use new sort|tail|cut-f2 selection snippet, no head -1 remnant"
+else
+  fail "One or more files still use old head -1 first-match snippet (see details above)"
 fi
 
 # Summary

--- a/tests/test-pre-commit-gate.sh
+++ b/tests/test-pre-commit-gate.sh
@@ -235,6 +235,308 @@ else
   fail "TC-07: Expected PASS (exit 0), got BLOCK (exit $rc): $output"
 fi
 
+########################################
+# $1 polymorphic selection contract (TC-08 ~ TC-14)
+# Each TC uses an isolated fixture subdirectory under $TMPDIR
+########################################
+
+# TC-08: Given multiple non-DONE Cycle docs (old: updated 早い + REVIEW完了 + retro_status
+# resolved = 単独なら gate PASS 条件充足, new: updated 遅い + REVIEW未完了),
+# When gate をディレクトリモードで実行, Then updated 最新の new doc が選択され
+# REVIEW 未完了で BLOCK する（現行実装は glob 先頭の old を選び PASS するため FAIL = RED）
+echo ""
+echo "TC-08: dir mode selects latest-updated non-DONE doc (new) over old, BLOCKs on missing REVIEW"
+
+FIXTURE_08="$TMPDIR/tc08"
+mkdir -p "$FIXTURE_08/docs/cycles"
+
+cat > "$FIXTURE_08/docs/cycles/20260101_0000_old.md" <<'CYCLE'
+---
+phase: COMMIT
+retro_status: resolved
+updated: 2026-01-02 10:00
+---
+# Old cycle
+
+## Progress Log
+
+### 2026-01-01 00:00 - RED
+- Tests created
+- Phase completed
+
+### 2026-01-01 00:00 - GREEN
+- Implementation done
+- Phase completed
+
+### 2026-01-01 00:00 - REFACTOR
+- Code quality improved
+- Phase completed
+
+### 2026-01-01 00:00 - REVIEW
+- Code review passed
+- Codex review: Accept 2, Reject 0
+- Phase completed
+CYCLE
+
+cat > "$FIXTURE_08/docs/cycles/20260601_0000_new.md" <<'CYCLE'
+---
+phase: REVIEW
+retro_status: none
+updated: 2026-06-02 10:00
+---
+# New cycle
+
+## Progress Log
+
+### 2026-06-01 00:00 - RED
+- Tests created
+- Phase completed
+
+### 2026-06-01 00:00 - GREEN
+- Implementation done
+- Phase completed
+
+### 2026-06-01 00:00 - REFACTOR
+- Code quality improved
+- Phase completed
+CYCLE
+
+output_08=$(bash "$SCRIPT" "$FIXTURE_08" 2>&1) && rc_08=$? || rc_08=$?
+if [ "$rc_08" -eq 1 ] && echo "$output_08" | grep -qF "20260601_0000_new"; then
+  pass "TC-08: dir mode selects newest-updated doc (new) and BLOCKs (rc=$rc_08)"
+else
+  fail "TC-08: expected BLOCK (rc=1) selecting new doc, got rc=$rc_08 output: $output_08"
+fi
+
+# TC-09: Given 明示指定モード ($1 = 直接 doc パス), When 新 doc パスを指定,
+# Then その doc のみ検査され BLOCK。When old doc パスを指定, Then PASS
+# （現行実装は $1 をディレクトリ扱いするため両方 BLOCK「No active Cycle doc found」に
+# なり old=PASS の期待が崩れるため FAIL = RED）
+echo ""
+echo "TC-09: explicit \$1 doc path mode inspects only the specified doc"
+
+FIXTURE_09="$TMPDIR/tc09"
+mkdir -p "$FIXTURE_09/docs/cycles"
+
+cat > "$FIXTURE_09/docs/cycles/20260101_0000_old.md" <<'CYCLE'
+---
+phase: COMMIT
+retro_status: resolved
+updated: 2026-01-02 10:00
+---
+# Old cycle
+
+## Progress Log
+
+### 2026-01-01 00:00 - RED
+- Tests created
+- Phase completed
+
+### 2026-01-01 00:00 - GREEN
+- Implementation done
+- Phase completed
+
+### 2026-01-01 00:00 - REFACTOR
+- Code quality improved
+- Phase completed
+
+### 2026-01-01 00:00 - REVIEW
+- Code review passed
+- Codex review: Accept 2, Reject 0
+- Phase completed
+CYCLE
+
+cat > "$FIXTURE_09/docs/cycles/20260601_0000_new.md" <<'CYCLE'
+---
+phase: REVIEW
+retro_status: none
+updated: 2026-06-02 10:00
+---
+# New cycle
+
+## Progress Log
+
+### 2026-06-01 00:00 - RED
+- Tests created
+- Phase completed
+CYCLE
+
+output_09a=$(bash "$SCRIPT" "$FIXTURE_09/docs/cycles/20260601_0000_new.md" 2>&1) && rc_09a=$? || rc_09a=$?
+output_09b=$(bash "$SCRIPT" "$FIXTURE_09/docs/cycles/20260101_0000_old.md" 2>&1) && rc_09b=$? || rc_09b=$?
+
+if [ "$rc_09a" -eq 1 ] && [ "$rc_09b" -eq 0 ]; then
+  pass "TC-09: explicit new doc BLOCKs (rc=$rc_09a), explicit old doc PASSes (rc=$rc_09b)"
+else
+  fail "TC-09: expected new=BLOCK(1)/old=PASS(0), got new rc=$rc_09a output: $output_09a / old rc=$rc_09b output: $output_09b"
+fi
+
+# TC-10: Given $1 が実在しないパス, When gate 実行, Then BLOCK (exit 1) し
+# メッセージに "invalid" を含む（現行実装も exit 1 だが「No active Cycle doc found」
+# であり "invalid" を含まないため FAIL = RED）
+echo ""
+echo "TC-10: nonexistent \$1 path BLOCKs with invalid argument message"
+
+output_10=$(bash "$SCRIPT" "/nonexistent/path/xyz-tc10-does-not-exist" 2>&1) && rc_10=$? || rc_10=$?
+if [ "$rc_10" -eq 1 ] && echo "$output_10" | grep -qi "invalid"; then
+  pass "TC-10: BLOCK on nonexistent path with 'invalid' message (rc=$rc_10)"
+else
+  fail "TC-10: expected BLOCK (rc=1) with 'invalid' message, got rc=$rc_10 output: $output_10"
+fi
+
+# TC-11: Given updated 同値の 2 non-DONE doc (a, b; b が filename 昇順 sort の tail),
+# When dir mode 実行, Then filename tail の b が選ばれ BLOCK メッセージに b のファイル名
+# を含む（現行実装は glob 先頭の a を選ぶため b のファイル名を出力しない = FAIL = RED）
+echo ""
+echo "TC-11: dir mode tie-break on equal updated selects filename-tail doc (b)"
+
+FIXTURE_11="$TMPDIR/tc11"
+mkdir -p "$FIXTURE_11/docs/cycles"
+
+cat > "$FIXTURE_11/docs/cycles/20260101_0000_a.md" <<'CYCLE'
+---
+phase: REVIEW
+retro_status: none
+updated: 2026-03-01 09:00
+---
+# Doc A
+
+## Progress Log
+
+### 2026-03-01 00:00 - RED
+- Tests created
+- Phase completed
+CYCLE
+
+cat > "$FIXTURE_11/docs/cycles/20260601_0000_b.md" <<'CYCLE'
+---
+phase: REVIEW
+retro_status: none
+updated: 2026-03-01 09:00
+---
+# Doc B
+
+## Progress Log
+
+### 2026-03-01 00:00 - RED
+- Tests created
+- Phase completed
+CYCLE
+
+output_11=$(bash "$SCRIPT" "$FIXTURE_11" 2>&1) && rc_11=$? || rc_11=$?
+if [ "$rc_11" -eq 1 ] && echo "$output_11" | grep -qF "20260601_0000_b"; then
+  pass "TC-11: tie-break selects filename-tail doc (b) on equal updated (rc=$rc_11)"
+else
+  fail "TC-11: expected BLOCK selecting doc b, got rc=$rc_11 output: $output_11"
+fi
+
+# TC-12: Given 明示指定 doc の phase が DONE, When gate 実行, Then BLOCK (exit 1) し
+# 対象 doc 名が出力に含まれる（現行実装も rc=1 だが $1 を dir 扱いした
+# 「No active Cycle doc found」という無関係な fallback メッセージで doc 名を含まない
+# ため FAIL = RED）
+echo ""
+echo "TC-12: explicit \$1 doc path with phase: DONE BLOCKs"
+
+FIXTURE_12="$TMPDIR/tc12"
+mkdir -p "$FIXTURE_12/docs/cycles"
+
+cat > "$FIXTURE_12/docs/cycles/20260101_0000_done.md" <<'CYCLE'
+---
+phase: DONE
+retro_status: resolved
+updated: 2026-01-01 10:00
+---
+# Done cycle
+
+## Progress Log
+
+### 2026-01-01 00:00 - REVIEW
+- Code review passed
+- Codex review: Accept 2, Reject 0
+- Phase completed
+CYCLE
+
+output_12=$(bash "$SCRIPT" "$FIXTURE_12/docs/cycles/20260101_0000_done.md" 2>&1) && rc_12=$? || rc_12=$?
+if [ "$rc_12" -eq 1 ] && echo "$output_12" | grep -qF "20260101_0000_done"; then
+  pass "TC-12: explicit DONE doc BLOCKs and output identifies the doc (rc=$rc_12)"
+else
+  fail "TC-12: expected BLOCK identifying done doc, got rc=$rc_12 output: $output_12"
+fi
+
+# TC-13: Given 明示指定 doc が docs/cycles/ 配下に存在しない偽造 .md（phase: REVIEW +
+# REVIEW 記録 + retro_status: resolved 完備、docs/cycles 制約さえ無ければ他チェックは
+# 全て PASS 条件を満たす）, When gate 実行, Then BLOCK (exit 1) し出力に "docs/cycles"
+# を含む
+echo ""
+echo "TC-13: explicit \$1 doc path outside docs/cycles/ BLOCKs"
+
+FIXTURE_13="$TMPDIR/tc13"
+mkdir -p "$FIXTURE_13"
+
+cat > "$FIXTURE_13/forged.md" <<'CYCLE'
+---
+phase: REVIEW
+retro_status: resolved
+updated: 2026-01-01 10:00
+---
+# Forged cycle (outside docs/cycles/)
+
+## Progress Log
+
+### 2026-01-01 00:00 - REVIEW
+- Code review passed
+- Codex review: Accept 2, Reject 0
+- Phase completed
+CYCLE
+
+output_13=$(bash "$SCRIPT" "$FIXTURE_13/forged.md" 2>&1) && rc_13=$? || rc_13=$?
+if [ "$rc_13" -eq 1 ] && echo "$output_13" | grep -qF "docs/cycles"; then
+  pass "TC-13: explicit doc outside docs/cycles/ BLOCKs (rc=$rc_13)"
+else
+  fail "TC-13: expected BLOCK mentioning docs/cycles, got rc=$rc_13 output: $output_13"
+fi
+
+# TC-14: Given 明示指定 doc の PROJECT_ROOT に STATUS.md 不一致 count が存在,
+# When gate 実行, Then STATUS.md test script count mismatch の WARN が出力される
+# （明示指定モードの PROJECT_ROOT 導出が正しく fixture root を指すことを確認）
+echo ""
+echo "TC-14: explicit \$1 doc path resolves PROJECT_ROOT for STATUS.md warning"
+
+FIXTURE_14="$TMPDIR/tc14"
+mkdir -p "$FIXTURE_14/docs/cycles" "$FIXTURE_14/tests"
+
+cat > "$FIXTURE_14/docs/STATUS.md" <<'STATUS'
+# Status
+
+| Metric | Value |
+|--------|-------|
+| Test Scripts | 99 |
+STATUS
+
+touch "$FIXTURE_14/tests/test-foo.sh"
+
+cat > "$FIXTURE_14/docs/cycles/20260101_0000_active.md" <<'CYCLE'
+---
+phase: COMMIT
+retro_status: resolved
+updated: 2026-01-01 10:00
+---
+# Active cycle
+
+## Progress Log
+
+### 2026-01-01 00:00 - REVIEW
+- Code review passed
+- Codex review: Accept 2, Reject 0
+- Phase completed
+CYCLE
+
+output_14=$(bash "$SCRIPT" "$FIXTURE_14/docs/cycles/20260101_0000_active.md" 2>&1) && rc_14=$? || rc_14=$?
+if echo "$output_14" | grep -qF "WARN: STATUS.md test script count mismatch"; then
+  pass "TC-14: explicit doc path resolves PROJECT_ROOT and emits STATUS.md WARN (rc=$rc_14)"
+else
+  fail "TC-14: expected STATUS.md count mismatch WARN, got rc=$rc_14 output: $output_14"
+fi
+
 # Summary
 echo ""
 echo "=== Summary ==="

--- a/tests/test-pre-red-gate.sh
+++ b/tests/test-pre-red-gate.sh
@@ -177,6 +177,112 @@ else
   fail "Expected BLOCK (exit 1) on no-frontmatter doc, got rc=$rc output: $output"
 fi
 
+########################################
+# $1 polymorphic selection contract (T-08 ~ T-09)
+# Each TC uses an isolated fixture subdirectory under $TMPDIR
+########################################
+
+# T-08: Given multiple non-DONE Cycle docs (old: updated 早い + sync-plan/Plan Review
+# 完了 = 単独なら PASS 条件充足, new: updated 遅い + Plan Review 未完了),
+# When gate をディレクトリモードで実行, Then updated 最新の new doc が選択され
+# Plan Review 未完了で BLOCK する（現行実装は glob 先頭の old を選び PASS するため
+# FAIL = RED）
+echo ""
+echo "T-08: dir mode selects latest-updated non-DONE doc (new) over old"
+
+FIXTURE_T08="$TMPDIR/t08"
+mkdir -p "$FIXTURE_T08/docs/cycles"
+
+cat > "$FIXTURE_T08/docs/cycles/20260101_0000_old.md" <<'CYCLE'
+---
+phase: RED
+updated: 2026-01-02 10:00
+---
+# Old cycle
+
+## Progress Log
+
+### 2026-01-01 00:00 - SYNC-PLAN
+- Cycle doc generated
+- Phase completed
+
+### 2026-01-01 00:00 - Plan Review
+- Design review passed
+- Phase completed
+CYCLE
+
+cat > "$FIXTURE_T08/docs/cycles/20260601_0000_new.md" <<'CYCLE'
+---
+phase: SPEC
+updated: 2026-06-02 10:00
+---
+# New cycle
+
+## Progress Log
+
+### 2026-06-01 00:00 - SYNC-PLAN
+- Cycle doc generated
+- Phase completed
+CYCLE
+
+output_t08=$(bash "$SCRIPT" "$FIXTURE_T08" 2>&1) && rc_t08=$? || rc_t08=$?
+if [ "$rc_t08" -eq 1 ]; then
+  pass "T-08: dir mode selects newest-updated doc (new) and BLOCKs on missing Plan Review (rc=$rc_t08)"
+else
+  fail "T-08: expected BLOCK (rc=1) selecting new doc, got rc=$rc_t08 output: $output_t08"
+fi
+
+# T-09: Given 明示指定モード ($1 = 直接 doc パス), When 新 doc パスを指定,
+# Then その doc のみ検査され BLOCK。When old doc パスを指定, Then PASS
+# （現行実装は $1 をディレクトリ扱いするため両方 BLOCK になり old=PASS の期待が
+# 崩れるため FAIL = RED）
+echo ""
+echo "T-09: explicit \$1 doc path mode inspects only the specified doc"
+
+FIXTURE_T09="$TMPDIR/t09"
+mkdir -p "$FIXTURE_T09/docs/cycles"
+
+cat > "$FIXTURE_T09/docs/cycles/20260101_0000_old.md" <<'CYCLE'
+---
+phase: RED
+updated: 2026-01-02 10:00
+---
+# Old cycle
+
+## Progress Log
+
+### 2026-01-01 00:00 - SYNC-PLAN
+- Cycle doc generated
+- Phase completed
+
+### 2026-01-01 00:00 - Plan Review
+- Design review passed
+- Phase completed
+CYCLE
+
+cat > "$FIXTURE_T09/docs/cycles/20260601_0000_new.md" <<'CYCLE'
+---
+phase: SPEC
+updated: 2026-06-02 10:00
+---
+# New cycle
+
+## Progress Log
+
+### 2026-06-01 00:00 - SYNC-PLAN
+- Cycle doc generated
+- Phase completed
+CYCLE
+
+output_t09a=$(bash "$SCRIPT" "$FIXTURE_T09/docs/cycles/20260601_0000_new.md" 2>&1) && rc_t09a=$? || rc_t09a=$?
+output_t09b=$(bash "$SCRIPT" "$FIXTURE_T09/docs/cycles/20260101_0000_old.md" 2>&1) && rc_t09b=$? || rc_t09b=$?
+
+if [ "$rc_t09a" -eq 1 ] && [ "$rc_t09b" -eq 0 ]; then
+  pass "T-09: explicit new doc BLOCKs (rc=$rc_t09a), explicit old doc PASSes (rc=$rc_t09b)"
+else
+  fail "T-09: expected new=BLOCK(1)/old=PASS(0), got new rc=$rc_t09a output: $output_t09a / old rc=$rc_t09b output: $output_t09b"
+fi
+
 # Summary
 echo ""
 echo "=== Summary ==="


### PR DESCRIPTION
#149 の再作成（stack 元 #146 マージ時の base ブランチ削除で自動 close されたため）。内容・検証は #149 の記載通り。

- pre-commit/pre-red gate の first-non-DONE 選択バグ修正（closes #145）
- $1 polymorphic 契約（.md 明示指定 + docs/cycles/ 境界必須 / dir = updated 最新 non-DONE / else reject）
- skill 文書 7 ファイルの同型探索を canonical one-liner に統一
- REVIEW 4系統の findings を red-first pin TC 付きで全適用（偽造 doc 通過の security HIGH 含む）
- full suite 112/112 rc=0、snapshot baseline diff 空
- DISCOVERED: #147 #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)