### PR TITLE
feat: codify 済み insight 9 件を rule/skill に実装 + inverse contract (#143)

### DIFF
--- a/.claude/rules/agent-prompts.md
+++ b/.claude/rules/agent-prompts.md
@@ -26,6 +26,8 @@ architect や subagent へ委譲する際のプロンプト設計規律。scope 
 
 並列度が上がるほど曖昧な prompt は曖昧な出力を増幅する。単一委譲なら「Files list 全量列挙」で足りるが、N=3+ では統合可能性まで設計する必要がある。
 
+「読み取り並列・実行直列」の原則（テストを実行するプロセスは tree 書き込み・他のテスト実行と直列化）を守り、各並列 prompt に「テスト実行可否」（full suite / 個別 / 禁止）を明示する (cycle 20260702_1200 #2)。
+
 ## 具体例
 
 ```markdown
@@ -46,3 +48,4 @@ plan v3 の Files to Change を全量尊重し、独自判断で追加・削除�
 - `docs/cycles/20260420_1752_v2.8-orchestrate-integration.md` Insight 2
 - `docs/cycles/20260421_1809_sync-plan-progress-log-format.md` Insight 1
 - 会話レビュー (2026-05-25): Kimi Agent Swarm 記事の "synthesis bottleneck" 抽象原則 (`## 並列起動時の prompt 契約` の根拠)
+- cycle 20260702_1200 #2

--- a/.claude/rules/integration-verification.md
+++ b/.claude/rules/integration-verification.md
@@ -27,6 +27,7 @@ template / skill docs だけでなく、自 cycle の Verification 実行でも 
 - **Config 変更時** (motivating bug): `python -m myapp --config new.yaml && grep "loaded_from: new.yaml" /tmp/myapp.log`
 - **Library**: `python -c "from mymod import run; run('config.yaml')"`
 - **dev-crew 内 (bash/doc project)**: gate/consumer/validator を real path で実行 — 例 `bash scripts/gates/pre-commit-gate.sh $cycle_doc`（$1 に cycle doc パスを渡すと当該 doc を直接検査。明示指定・推奨。project root を渡すと updated 最新の non-DONE を自動選択）or `bash scripts/validate-yaml-frontmatter.sh`。grep/diff のみは structural test として扱う
+- **共通 (全 project type)**: Verification に書く script 呼び出しは「usage を実測」（ヘッダコメント / --help / 実行）で確認してから記載する。引数契約を名前から推測しない (cycle 20260702_1200 #3)
 
 ## Evidence 記録
 
@@ -37,3 +38,4 @@ template / skill docs だけでなく、自 cycle の Verification 実行でも 
 - Kyotei YAML config wire-gap bug (別 repo、2026-04-24 発見)
 - `docs/cycles/20260424_0900_integration-verification-rule.md` — integration verification rule codify cycle
 - `docs/cycles/20260423_1045_discovered-cycle2-followup.md` Insight 1 (REFACTOR full-suite baseline 必須) の対称ルール
+- cycle 20260702_1200 #3

--- a/.claude/rules/multi-file-consistency.md
+++ b/.claude/rules/multi-file-consistency.md
@@ -12,6 +12,7 @@
 - N ファイル並行実装では「section A が section B より前に出現するか」を行番号比較でテスト契約化する
 - deterministic gate は case 文で期待値を enumerate し、それ以外の値は明示的に reject する
 - gate script は単体で `bash gate.sh <input>` として全検証を完了できる設計にする
+- パス引数の enumerate-and-reject は値の形式だけでなく位置 —「信頼するディレクトリ境界」— も列挙対象にする (cycle 20260702_1930 #1)
 
 ## 具体例
 
@@ -31,3 +32,4 @@ esac
 ## 出典
 
 - `docs/cycles/20260420_1752_v2.8-orchestrate-integration.md` Insights 3, 4
+- cycle 20260702_1930 #1

--- a/.claude/rules/plan-discipline.md
+++ b/.claude/rules/plan-discipline.md
@@ -30,17 +30,23 @@ plan 作成・承認・実行における規律。実測ベースの計画、逆
   の要素を本文に明記する。単一の "N 件" だけでは plan review で不明瞭扱い
   (cycle 20260424_1119 #1)
 - count/status 変更 cycle の GREEN 検証は curated 非回帰リストでなく `grep -rln "<old-value>" tests/` の逆向き契約 sweep 結果を全て実行する。curated リストは検証範囲を恣意的に狭め、test 内に hardcode された逆向き契約（count assertion 等）を見逃す (cycle 20260625_1101 #1、cycle 20260525_1249 #1 が予告)
+- baseline は「immutable snapshot 複製」上で実測し、evidence ファイルを「並行プロセスから隔離」した path に保存する (cycle 20260702_1200 #1)。live tree での baseline は並行 agent に破壊・汚染される
 
 ## 具体例
 
 ```bash
-# Block 0: baseline 実測
-for f in tests/test-*.sh; do
-  bash "$f" >/dev/null 2>&1
-  rc=$?
-  printf "%s rc=%d\n" "$(basename $f)" "$rc"
-done | sort > /tmp/baseline.txt
-cat /tmp/baseline.txt
+# Block 0: baseline 実測（immutable snapshot 複製上で実行し、evidence は隔離 path に保存）
+SNAP=$(mktemp -d)
+cp -R . "$SNAP"
+(
+  cd "$SNAP"
+  for f in tests/test-*.sh; do
+    bash "$f" >/dev/null 2>&1
+    rc=$?
+    printf "%s rc=%d\n" "$(basename "$f")" "$rc"
+  done | sort
+) > "$SCRATCH/baseline.txt"
+cat "$SCRATCH/baseline.txt"
 
 # 逆向き契約検索: STATUS.md の Test Scripts カウント変更前に
 grep -rn "107\|Test Scripts" tests/ skills/commit/
@@ -55,3 +61,4 @@ grep -rn "107\|Test Scripts" tests/ skills/commit/
 - `docs/cycles/20260422_1146_codify-insight-skill.md` Insight 2
 - cycle 20260422_1313 Insight 1 — 自動化なき規律は破綻する
 - cycle 20260625_1101 #1 — count/status 変更の GREEN 検証は逆向き契約 sweep で全実行（curated リストは hardcode contract を見逃す。実 regression 事例）
+- cycle 20260702_1200 #1 — baseline snapshot 隔離

--- a/.claude/rules/test-patterns.md
+++ b/.claude/rules/test-patterns.md
@@ -4,7 +4,7 @@ paths:
 ---
 # Test Patterns — bash 落とし穴と meta test 設計
 
-テストスクリプト作成時の再発防止パターン集。cycle 20260421_1043 〜 20260422_0937 + cycle 20260422_1146 から抽出した 8 つの insight を具体的な禁止事項と推奨実装としてまとめる。
+テストスクリプト作成時の再発防止パターン集。cycle 20260421_1043 〜 20260702_1930 の複数 cycle から抽出した insight を具体的な禁止事項と推奨実装としてまとめる。
 
 ## 禁止事項
 
@@ -20,6 +20,7 @@ paths:
 - **`grep -E "a\|b"` の escape alternation**: ERE mode では `|` が直接 alternation、
   `\|` はリテラル pipe となり alternation 無効化 (実測 rc=1 で silent no-match)
   (cycle 20260424_1119 #2)
+- **単体語で pin**: doc/rule への追記を検査する test で、section 既存項目にも出現し得る単体語を literal にしない。false-pass する (cycle 20260701_1120 #1)
 
 ## 推奨
 
@@ -37,6 +38,10 @@ paths:
 - regex alternation: `grep -E "a|b|c"` (non-escaped、ERE の標準) を使う。mode 決定時は
   `printf` oracle 実測で rc 確認 (例: `printf 'x\nb\n' | grep -E "a|b"; echo rc=$?`)
   (cycle 20260424_1119 #2)
+- 追記検査 test は追記内容にのみ現れる「contiguous phrase」を literal に使う (cycle 20260701_1120 #1)
+- literal 採用前に `section_grep` で section 内「pre-existing count」= 0 を実測してから確定する (cycle 20260701_1120 #2)
+- 「分岐 × 既存チェック」の組み合わせ経路それぞれに「出力文字列 assert」を置く。rc のみでは非ブロッキング WARN の silent skip を検出できない (cycle 20260702_1930 #2)
+- 同一セマンティクスを複数実装に要求する時は先に「挙動チェックリスト」（空入力・欠落フィールド・形式混在・異常系）を列挙し各実装に適用する (cycle 20260702_1930 #3)
 
 ## 具体例
 
@@ -69,3 +74,5 @@ echo "$output" | grep -q "expected"
 - `docs/cycles/20260422_0937_advisory-terminology-fix.md` Insight 3
 - `docs/cycles/20260422_1146_codify-insight-skill.md` Insight 1
 - cycle 20260422_1313 Insight 4 — bash $(cmd1 || cmd2) fallback pitfall
+- `docs/cycles/20260701_1120_plan-discipline-green-sweep.md` Insights 1, 2
+- `docs/cycles/20260702_1930_gate-active-cycle-fix.md` Insights 2, 3

--- a/docs/cycles/20260702_1930_gate-active-cycle-fix.md
+++ b/docs/cycles/20260702_1930_gate-active-cycle-fix.md
@@ -5,10 +5,10 @@ phase: COMMIT
 complexity: standard
 test_count: 9
 risk_level: medium
-retro_status: captured
+retro_status: resolved
 codex_session_id: ""
 created: 2026-07-02 19:30
-updated: 2026-07-02 22:40
+updated: 2026-07-03 12:10
 ---
 
 # Gate Active Cycle Fix — pre-commit/pre-red gate の ACTIVE_CYCLE 選択修正（issue #145）
@@ -346,3 +346,30 @@ Format for each phase entry (**strict, required by pre-commit-gate.sh**):
 
 ### 成功事例（observation）: perspective-diverse review の相補性
 - 4 系統が互いに排他的な欠陥を検出: security=偽造パス、correctness=dirname off-by-one、Codex=one-liner セマンティクス乖離、maintainability=追跡番号混入。重複指摘は dirname 1 件のみ。レンズ分離設計（rules/review-triage.md MED tier）の有効性を実証
+
+## Codify Decisions
+
+triage 実施: 2026-07-03 12:10（後続 cycle test-hardening-rule-codify の orchestrate Block 0 codify gate で処理）。全件 high-confidence の autonomous triage（skill 候補なし、質問 0 件）。実装は同 cycle（test-hardening-rule-codify が rule 実装 cycle そのものであるため、decision と implementation を同時に行う — 無関係 cycle の commit を汚さない慣行と矛盾しない）。
+
+### Insight 1
+- **Decision**: codified
+- **Destination**: rule (rules/multi-file-consistency.md + .claude/rules/ mirror)
+- **Reason**: enumerate-and-reject 原則の拡張 —「パス引数の enumerate は値の形式だけでなく位置（信頼するディレクトリ境界）も列挙対象」。偽造 doc で gate 通過という実害 evidence あり
+- **Decided**: 2026-07-03 12:10
+
+### Insight 2
+- **Decision**: codified
+- **Destination**: rule (rules/test-patterns.md + .claude/rules/ mirror)
+- **Reason**: 「分岐追加時は分岐 × 既存チェックの組み合わせ経路に出力文字列 assert を置く」。非ブロッキング WARN の silent skip という実害 evidence あり
+- **Decided**: 2026-07-03 12:10
+
+### Insight 3
+- **Decision**: codified
+- **Destination**: rule (rules/test-patterns.md + .claude/rules/ mirror)
+- **Reason**: 「同一セマンティクスの複数実装は挙動チェックリスト列挙後に各実装へ適用」。one-liner セマンティクス乖離の実害 evidence あり
+- **Decided**: 2026-07-03 12:10
+
+### 成功事例（observation）
+- **Decision**: no-codify
+- **Reason**: perspective-diverse review の相補性は rules/review-triage.md 既存 tier 設計の実証であり、新規 rule 化は不要
+- **Decided**: 2026-07-03 12:10

--- a/docs/cycles/20260703_1215_test-hardening-rule-codify.md
+++ b/docs/cycles/20260703_1215_test-hardening-rule-codify.md
@@ -1,0 +1,329 @@
+---
+feature: test-hardening-rule-codify
+cycle: 20260703_1215
+phase: COMMIT
+complexity: complex
+test_count: 10
+risk_level: medium
+retro_status: captured
+codex_session_id: ""
+created: 2026-07-03 12:15
+updated: 2026-07-03 16:00
+---
+
+# test hardening — codify 済み insight 9 件の rule/skill 実装 + inverse contract（#143）
+
+## Scope Definition
+
+### In Scope
+- [ ] rules/test-patterns.md + .claude/rules/test-patterns.md: 禁止事項 A1（単体語 pin 禁止）+ 推奨 A1/A2/A3/A4 の 4 項目 + 出典 20260701_1120・20260702_1930
+- [ ] rules/plan-discipline.md + .claude/rules/plan-discipline.md: 推奨 B（immutable snapshot 複製 + 並行プロセスから隔離）+ 出典 20260702_1200
+- [ ] rules/agent-prompts.md + .claude/rules/agent-prompts.md: 並列起動時の prompt 契約節に C（読み取り並列・実行直列 + テスト実行可否の明示）+ 出典 20260702_1200
+- [ ] rules/integration-verification.md + .claude/rules/integration-verification.md: 推奨に D（usage を実測確認してから記載）+ 出典 20260702_1200
+- [ ] rules/multi-file-consistency.md + .claude/rules/multi-file-consistency.md: 推奨に E（enumerate-and-reject は位置＝信頼するディレクトリ境界も列挙）+ 出典 20260702_1930
+- [ ] skills/red/SKILL.md: Stage 3 後に Stage 3.5「False-pass 自己証明」2-3 行 + reference.md link（100 行以内厳守）
+- [ ] skills/red/reference.md: Stage 3.5 の手順詳細（新規 test literal を対象から除去 → count 0 / FAIL を実証する手順、A1/A2 の適用手順）
+- [ ] tests/test-codify-rule-docs.sh: TC-28（A1+A2）、TC-29（A3+A4）、TC-30（B）、TC-31（C）、TC-32（D）、TC-33（E）— TC-27 テンプレート踏襲
+- [ ] tests/test-doc-consistency.sh: TC-16 — live tree（docs/cycles・CHANGELOG.md・docs/decisions・docs/archive 除外）で `skills/(phase-compact|reload|strategy)` が 0 hit（inverse contract、#143）
+- [ ] tests/test-phase-gate.sh: red/SKILL.md の新 step を contiguous phrase で pin する新 TC（次連番 TC-23、pre-existing count=0 を RED で実測して literal 確定）
+
+### Out of Scope
+- parallel スキルの削除/作り直し（Reason: #142、ユーザー確認待ち）
+- #147（non-DONE doc の DONE 遷移）/ #148（gate 間 drift guard）/ #144（flaky 調査）（Reason: 本 cycle の rule-codify family と無関係）
+- 20260702_1930 の成功事例 observation（perspective-diverse review）の rule 化（Reason: no-codify 判定済み。rules/review-triage.md 既存 tier 設計の実証であり新規 rule 化不要）
+
+### Files to Change (target: 10 or less — 本 cycle は 3 source cycle + issue #143 の backlog を一括実装するため 16 file。Design Review Gate で over-target を important 判定・accept 済み。詳細は Progress Log 参照)
+1. `rules/test-patterns.md` (edit)
+2. `.claude/rules/test-patterns.md` (edit, mirror)
+3. `rules/plan-discipline.md` (edit)
+4. `.claude/rules/plan-discipline.md` (edit, mirror)
+5. `rules/agent-prompts.md` (edit)
+6. `.claude/rules/agent-prompts.md` (edit, mirror)
+7. `rules/integration-verification.md` (edit)
+8. `.claude/rules/integration-verification.md` (edit, mirror)
+9. `rules/multi-file-consistency.md` (edit)
+10. `.claude/rules/multi-file-consistency.md` (edit, mirror)
+11. `skills/red/SKILL.md` (edit)
+12. `skills/red/reference.md` (edit)
+13. `tests/test-codify-rule-docs.sh` (edit, TC-28〜33 追加)
+14. `tests/test-doc-consistency.sh` (edit, TC-16 追加)
+15. `tests/test-phase-gate.sh` (edit, 新 TC 追加)
+16. `docs/cycles/20260703_1215_test-hardening-rule-codify.md` (new, Cycle doc 自身)
+
+## Environment
+
+### Scope
+- Layer: Documentation / Test contracts（実装コードなし、rule 追記・スキル定義・テストのみ）
+- Plugin: dev-crew（bash/doc project、integration-verification.md の project type 分類に準拠）
+- Risk: 40（WARN）
+
+### Runtime
+- Bash（テストスクリプト、macOS zsh 実行環境）、Markdown（rules/skills/docs）
+
+### Dependencies (key packages)
+- なし（新規依存追加なし。grep/sed/wc 等 標準 POSIX/GNU 互換ツールのみ）
+
+### Risk Interview (BLOCK only)
+- 該当なし（Risk 40 は WARN 帯であり BLOCK 帯（60+）未到達）
+
+## Context & Dependencies
+
+### Reference Documents
+- `docs/cycles/20260701_1120_plan-discipline-green-sweep.md` - A1/A2（test-patterns.md）+ F（RED false-pass 自己証明、Insight 4 deferred:new-cycle）の出典
+- `docs/cycles/20260702_1200_skill-inventory-cleanup.md` - B（plan-discipline.md）/ C（agent-prompts.md）/ D（integration-verification.md）の出典
+- `docs/cycles/20260702_1930_gate-active-cycle-fix.md` - E（multi-file-consistency.md）/ A3・A4（test-patterns.md）の出典。Codify Decisions は本 cycle 冒頭の orchestrate Block 0 codify gate で triage 済み（retro_status: captured → resolved、2026-07-03 12:10）。3 insight 全て codified→rule、Destination は plan の想定（E→multi-file-consistency.md、A3/A4→test-patterns.md）と完全一致を確認
+- `rules/test-patterns.md` / `rules/plan-discipline.md` / `rules/agent-prompts.md` / `rules/integration-verification.md` / `rules/multi-file-consistency.md` - 追記対象の既存 rule 5 件
+- `skills/red/SKILL.md` / `skills/red/reference.md` - Stage 3.5 追加対象
+
+### Dependent Features
+- なし（rule/skill doc 追記のみ、他機能への実行時依存なし）
+
+### Related Issues/PRs
+- Issue #143: 削除スキル名の inverse contract テスト追加（stale-ref 検査）。20260702_1200 Codex code review F3（accept-defer）が起点。issue 本文で「20260701_1120 Codify Decisions と同一ファミリーであり同一 cycle での実装を推奨」と明記 — 本 cycle（G destination）で対応
+
+## Test List
+
+### TODO
+- [ ] TC-09: Given rules/ と .claude/rules/, When test-rules-mirror.sh, Then byte-identical（既存 TC が自動検査。GREEN で mirror 実施後に検証）
+- [ ] TC-10: Given 全 suite, When 一括実行, Then baseline-hardening.txt と diff が空（回帰ゼロ）
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+- [x] TC-01: Given rules/test-patterns.md, When section_grep で A1/A2 の contiguous literal + 出典 20260701_1120 を検査, Then 各 count ≥1（tests/test-codify-rule-docs.sh TC-28、GREEN で rule 追記後 PASS 確認）
+- [x] TC-02: Given rules/test-patterns.md, When A3/A4 literal + 出典 20260702_1930, Then count ≥1（TC-29、PASS 確認）
+- [x] TC-03: Given rules/plan-discipline.md 推奨, When 「immutable snapshot 複製」系 literal + 出典 20260702_1200, Then count ≥1（TC-30、PASS 確認）
+- [x] TC-04: Given rules/agent-prompts.md 並列契約節, When 「読み取り並列・実行直列」「テスト実行可否」+ 出典, Then count ≥1（TC-31、PASS 確認）
+- [x] TC-05: Given rules/integration-verification.md 推奨, When 「usage を実測」系 literal + 出典, Then count ≥1（TC-32、PASS 確認）
+- [x] TC-06: Given rules/multi-file-consistency.md 推奨, When 「信頼するディレクトリ境界」+ 出典, Then count ≥1（TC-33、PASS 確認）
+- [x] TC-07: Given live tree（4 ディレクトリ/ファイル除外）, When `skills/(phase-compact|reload|strategy)` を grep, Then 0 hit（tests/test-doc-consistency.sh TC-16。git ls-files ベースの直接 grep で STALE_HITS=0 を再確認）
+- [x] TC-08: Given skills/red/SKILL.md, When 新 step の contiguous phrase を grep, Then 存在 + wc -l ≤ 100（tests/test-phase-gate.sh TC-23、85 行で PASS 確認）
+
+## Implementation Notes
+
+### Goal
+直近 3 cycle（20260701_1120 / 20260702_1200 / 20260702_1930）の retrospective で codified→rule 判定された insight 9 件（A1-A4, B, C, D, E, F）と issue #143（G）を一括実装し、rule-codify backlog を解消する。
+
+### Background
+rule-codify cycle は「retrospective で codified 判定 → 実装は次 cycle」という運用（無関係 cycle の commit を汚さない慣行）を繰り返す過程で、3 cycle 分の insight が実装待ちで積み上がった。issue #143 も同一ファミリー（20260702_1200 Codex code review F3、20260701_1120 Codify Decisions と同一テーマ）として issue 本文で同一 cycle 実装を推奨されている。本 cycle はこれらを一括で rule/skill/test に反映する。
+
+### Design Approach
+- 5 rule ファイル（test-patterns / plan-discipline / agent-prompts / integration-verification / multi-file-consistency）各々に、出典 cycle を明記した推奨（一部禁止事項）項目を追記し、`.claude/rules/` 側へ byte-identical mirror する（既存 test-rules-mirror.sh が自動検査）
+- 追記する contiguous phrase literal は全て RED 時点で pre-existing count=0 を実測済み（下記実測値参照）。false-pass（rule.md 内に既に部分一致する語が存在し、rule 追記前から TC が誤って PASS する事故）を A2 の自己適用で事前に排除
+- skills/red/SKILL.md には Stage 3（テスト失敗確認）の直後に Stage 3.5「False-pass 自己証明」を 2-3 行で追加し、詳細手順は reference.md に委譲する（SKILL.md 100 行制約を遵守）
+- tests/test-doc-consistency.sh の TC-16 は inverse contract（削除済みスキル名が live tree に再混入していないことを検査）。path-form literal（`skills/(phase-compact|reload|strategy)`）を用い、単語形式の grep が起こす false positive（例: reference.md:193 "Error handling strategy?"）を構造的に回避する
+- 新規テストファイルは作成しない（既存 3 test file への TC 追加のみ）ため、STATUS.md の Test Scripts カウントへの波及なし
+
+## Verification
+
+**Real-path invocation を最低 1 件含めること** (rules/integration-verification.md)。integration-verification.md の self-apply 要件: 本 cycle は D（usage 実測 rule）を定義する cycle であるため、以下の Verification は全て usage を実測確認済みの形式のみ使用する（rule の自己適用）。
+
+```bash
+SCRATCH=/private/tmp/claude-501/-Users-morodomi-Projects-MorodomiHoldings-agents-dev-crew/74f3a9a9-3af1-4977-80a3-f0ee96a13dd1/scratchpad
+# 1) real-path: 対象テスト単体（usage: 引数なし、実測確認済み）
+bash tests/test-codify-rule-docs.sh; echo "rc=$?"
+bash tests/test-rules-mirror.sh; echo "rc=$?"
+# test-doc-consistency.sh は TC-13 が nested full-suite runner のため単体実行しない（Codex plan review F2）。TC-16 相当の直接検査:
+cd "$(git rev-parse --show-toplevel)" && git ls-files | grep -vE "^docs/(cycles|decisions|archive)/|^CHANGELOG\.md$" | xargs grep -lE "skills/(phase-compact|reload|strategy)" || echo "inverse contract 0 hit"
+bash tests/test-phase-gate.sh; echo "rc=$?"
+# 2) real-path: pre-commit-gate 明示指定モード（usage は前 cycle で実装・実測済み）
+bash scripts/gates/pre-commit-gate.sh docs/cycles/20260703_1215_test-hardening-rule-codify.md; echo "rc=$?"
+# 3) full suite（snapshot baseline と diff、rc≠0 は FAIL 扱い）
+for f in tests/test-*.sh; do timeout 2400 bash "$f" >/dev/null 2>&1; printf "%s rc=%d\n" "$(basename $f)" "$?"; done | sort > "$SCRATCH/after-hardening.txt"
+if grep -v "rc=0" "$SCRATCH/after-hardening.txt"; then echo "VERIFY FAIL"; false; else echo "all rc=0"; fi
+diff "$SCRATCH/baseline-hardening.txt" "$SCRATCH/after-hardening.txt" && echo "no regression"
+# 4) inverse contract の実弾: 除外なし grep で歴史文書のみ hit することを目視確認
+grep -rEl "skills/(phase-compact|reload|strategy)" . --exclude-dir=.git | sort
+```
+
+Evidence: (orchestrate が自動記入)
+
+## Progress Log
+
+### 2026-07-03 12:15 - KICKOFF
+- Design Review Gate 実施（architect 相当、design-reviewer への委譲ではない軽量審査）: **PASS score 30**
+  - Scope: Files to Change 16 件（target 10 以下を超過）を **important 判定・accept**。理由: 全 16 件が「出典 cycle が確定済みの codified insight 9 件 + issue #143」への 1:1 対応で、YAGNI 違反（投機的な追加）は無し。各 rule 追記は 1-4 行、test 追記は既存 TC-27 テンプレート踏襲の TC 1 件ずつであり、新規ロジック・新規アーキテクチャ導入なし。20260701_1120（同型 rule-codify cycle、当時 4 file）の延長として、3 cycle 分の backlog を一括処理する明示的な意図が plan Context に記載されている
+  - Architecture: Design Approach は具体的（追記位置・literal 候補・mirror 検査手法まで確定済み）。既存コードとの整合性を実測で確認（下記）
+  - Test List: 10 項目、Given/When/Then 形式、正常系（TC-01〜06, TC-09）+ 逆向き契約（TC-07）+ 境界（TC-08: 100 行制約）+ 回帰確認（TC-10）でカテゴリ網羅
+  - Risk: Risk 40（WARN 帯）は「実装コードなし、rules/tests/skill doc のみ」という変更内容と整合。BLOCK 帯（60+）には未到達
+  - 判定: PASS のため sync-plan 相当（本エージェント自身）で Cycle doc 生成に進行
+- **実測による裏取り（plan 記載値との照合、全て一致）**:
+  - test-patterns.md 既存語数: 実測=2 / 分岐=1 / assert=1 / 同一=1（plan 記載と一致）。候補 6 literal（contiguous phrase / pre-existing count / 分岐 × 既存チェック / 出力文字列 assert / 同一セマンティクス / 挙動チェックリスト）は whole-file count=0 を確認 — false-pass リスクなし
+  - plan-discipline.md: baseline=7（既存）。候補 2 literal（immutable snapshot 複製 / 並行プロセスから隔離）count=0
+  - agent-prompts.md: 並列=4（既存）。候補 2 literal（読み取り並列・実行直列 / テスト実行可否）count=0
+  - integration-verification.md: script=1（既存）。候補 1 literal（usage を実測）count=0
+  - multi-file-consistency.md: enumerate=1, reject=1（既存）。候補 1 literal（信頼するディレクトリ境界）count=0
+  - mirror 5 ファイル（test-patterns / plan-discipline / agent-prompts / integration-verification / multi-file-consistency）: rules/ と .claude/rules/ 間で byte-identical を確認済み（diff -q 全て一致）
+  - skills/red/SKILL.md: 81 行（余白 19 行）を確認。構造は Stage 3（L57）→ exspec check（L62）→ Verification Gate（L68）の順で、plan 記載の「Stage 3 後・Verification Gate 前」挿入位置と一致
+  - tests/test-codify-rule-docs.sh: 最終 TC は TC-27（L547-569）で、次連番 TC-28 を確認
+  - tests/test-doc-consistency.sh: TC 一覧は TC-01/02/04/05/11-15（欠番あり、既存の連番慣行）。BASE_DIR override 対応済み（L7）を確認。次連番 TC-16 を確認
+  - tests/test-phase-gate.sh: TC-01〜22 が既存。次連番 TC-23（plan の「次連番」は数値未確定だったため本 KICKOFF で確定）
+  - live tree 逆向き契約実測: `grep -rEl "skills/(phase-compact|reload|strategy)" . --exclude-dir=.git --exclude-dir=docs/cycles --exclude-dir=docs/decisions --exclude-dir=docs/archive --exclude=CHANGELOG.md` は **0 hit**（plan 記載の「live tree 0 hit 確認済み」と一致）
+  - 20260702_1930 の Codify Decisions（本 KICKOFF 開始前に orchestrate Block 0 codify gate で処理済み、retro_status: captured → resolved、2026-07-03 12:10）: Insight 1（E→multi-file-consistency.md）/ Insight 2（A3→test-patterns.md）/ Insight 3（A4→test-patterns.md）の Destination は plan の想定と完全一致。成功事例 observation は no-codify（想定通り）
+  - 20260701_1120 / 20260702_1200 の Codify Decisions も遡って確認: A1/A2→test-patterns.md（Insight 1/2）、F→red skill deferred:new-cycle（Insight 4）、B→plan-discipline.md（Insight 1）、C→agent-prompts.md 並列契約節（Insight 2）、D→integration-verification.md（Insight 3）— 全て plan のテーブルと 1:1 一致
+  - issue #143 本文を実測確認: タイトル「削除スキル名の inverse contract テスト追加（stale-ref 検査）」、20260702_1200 Codex code review F3 起点、「20260701_1120 Codify Decisions と同一ファミリーであり同一 cycle での実装を推奨」と明記 — plan の G destination 記述と一致
+- Cycle doc created
+- Scope definition ready
+
+### 2026-07-03 12:50 - PLAN REVIEW (Codex competitive)
+- Codex plan review: **BLOCK 2 + WARN 2**。triage（全て accept-apply、reject 0）:
+- **F1 (BLOCK: TC-16 の除外 grep が false-fail) → accept-apply**: `grep --exclude-dir` は path prune として不完全で、ignored local file `.claude/settings.local.json:177` の `Skill(dev-crew:strategy)` にも hit する（Codex 実測）。TC-16 は **git ls-files ベースの tracked-live 契約**に変更: `git ls-files | grep -vE "^docs/(cycles|decisions|archive)/|^CHANGELOG\.md$" | xargs grep -lE "skills/(phase-compact|reload|strategy)"` → 0 hit。PdM 追認済み（本 tree で 0 hit）。untracked/ignored file は契約対象外となり除外列挙も 4 → 構造的に解決
+- **F2 (BLOCK: test-doc-consistency は nested full-suite runner) → accept-apply**: Verification の「単体」リストから除外し、TC-16 相当の直接 grep に置換（本エントリで Verification 改訂済み）。TC-16 の suite 内検証は full suite ステップが担う
+- **F3 (WARN: TC-28 が A1 の禁止事項を pin しない) → accept-apply**: TC-28 の契約に禁止事項 section の contiguous literal（候補「単体語」系連続句、RED で pre-existing count=0 実測後に確定）を追加。落とすと「禁止事項なしでも PASS」する穴の防止
+- **F4 (WARN: baseline snapshot の前提記載) → accept-apply**: baseline-hardening.txt の provenance を記録 — snapshot は commit 146f05c + 意図的未コミット変更 1 件（docs/cycles/20260702_1930 の codify gate 編集）を含み、本 cycle doc（untracked）は**含まない**（snapshot 取得が architect の doc 生成前）。112/112 全 rc=0
+- Codex 確認済み事項: TC-28〜33 候補 literal は section 内 0 hit / red SKILL.md 100 行余裕 / codify-rule-docs・phase-gate 単体 PASS
+- 判定: BLOCK 事由は F1/F2 の設計変更で解消 → Block 2a (RED) へ
+
+### 2026-07-03 13:20 - RED
+- **rules/test-patterns.md A2 自己適用（false-pass 事前排除）**: 全 literal 候補を `section_grep` で pre-existing count 実測。以下全て **count=0**（false-pass リスクなし）:
+  - test-patterns.md 禁止事項「単体語で pin」= 0 / 推奨「contiguous phrase」= 0 / 推奨「pre-existing count」= 0 / 出典「20260701_1120」= 0
+  - test-patterns.md 推奨「分岐 × 既存チェック」= 0 / 「出力文字列 assert」= 0 / 「挙動チェックリスト」= 0 / 出典「20260702_1930」= 0
+  - plan-discipline.md 推奨「immutable snapshot 複製」= 0 / 「並行プロセスから隔離」= 0 / 出典「20260702_1200」= 0
+  - agent-prompts.md 並列起動時の prompt 契約「読み取り並列・実行直列」= 0 / 「テスト実行可否」= 0 / 出典「20260702_1200」= 0
+  - integration-verification.md 推奨「usage を実測」= 0 / 出典「20260702_1200」= 0
+  - multi-file-consistency.md 推奨「信頼するディレクトリ境界」= 0 / 出典「20260702_1930」= 0
+  - red/SKILL.md「false-pass 不在を自己証明」= 0（TC-23 候補）
+- **tests/test-codify-rule-docs.sh**: TC-28〜33 を TC-27 テンプレート踏襲で追加（section_grep + `-ge 1` && 連結 + elif で失敗理由分離）。TC-28 は Codex plan review F3 反映で禁止事項 section の pin（「単体語で pin」）も契約に含めた
+- **tests/test-doc-consistency.sh**: TC-16 を「Regression」section（TC-13 nested full-suite runner）より前、「Terminology Consistency」section 直後に追加。Codex plan review F1/F2 反映:
+  - `grep --exclude-dir` 方式は不採用（ignored local file への hit + path prune 不全）。`git -C "$BASE_DIR" ls-files` ベースの tracked-live 契約に変更
+  - xargs 空入力対策として xargs を使わず、`while IFS= read -r f; do ...; done < <(git ls-files | grep -vE ...)` の read ループで 1 ファイルずつ判定（rules/test-patterns.md 準拠パターン）
+- **tests/test-phase-gate.sh**: TC-23 を TC-22（Commit Completion Validation）の後、既存「Selection Snippet Consistency」section（TC-09 重複番号）の前に追加。red/SKILL.md に Stage 3.5 が未実装のため FAIL
+- **RED 確認（個別実行）**:
+  - `bash tests/test-codify-rule-docs.sh`: rc=1、PASS 27 / FAIL 6 / TOTAL 33。FAIL は TC-28〜33 の 6 件のみ、TC-01〜27 は全 PASS（回帰なし）
+  - `bash tests/test-phase-gate.sh`: rc=1、PASS 23 / FAIL 1 / TOTAL 24。FAIL は TC-23 のみ、TC-01〜22 + Selection Snippet Consistency (TC-09) は全 PASS（回帰なし）
+  - `bash -n tests/test-doc-consistency.sh`: 構文 OK（このスクリプトは TC-13 が nested full-suite runner のため単体実行しない — Verification 記載の方針通り）
+  - TC-16 のロジック直接証明: `git ls-files | grep -vE "^docs/(cycles|decisions|archive)/|^CHANGELOG\.md$"` の while ループ判定で **STALE_HITS=0**（PASS 相当）。除外フィルタを外した場合は **STALE_HITS=9**（docs/archive/roadmap-v2-v3-completed.md 1件 + docs/cycles 配下 8 件、全て historical reference）。tests/test-doc-consistency.sh 自身への自己参照ヒットなし（ファイル内の `grep -E` パターン文字列はリテラル `skills/phase-compact` 等の部分文字列を含まないため、ERE 上マッチしないことを確認）
+- 想定外事象: なし。新規テストファイル作成なし（既存 3 ファイルへの TC 追加のみ、STATUS.md test count 変更なし）
+- Cycle doc frontmatter: phase → RED, updated → 2026-07-03 13:20
+- Phase completed
+
+---
+
+### 2026-07-03 14:05 - GREEN
+- **変更ファイル（12 件、全量）**:
+  1. `rules/test-patterns.md` (edit) — 禁止事項に「単体語で pin」1件、推奨に「contiguous phrase」「pre-existing count」「分岐 × 既存チェック」「出力文字列 assert」「挙動チェックリスト」5件、出典に 20260701_1120・20260702_1930 参照 1件を末尾追記
+  2. `.claude/rules/test-patterns.md` (edit, mirror) — 1 と byte-identical
+  3. `rules/plan-discipline.md` (edit) — 推奨に「immutable snapshot 複製」「並行プロセスから隔離」、出典に 20260702_1200 参照を末尾追記
+  4. `.claude/rules/plan-discipline.md` (edit, mirror) — 3 と byte-identical
+  5. `rules/agent-prompts.md` (edit) — 「並列起動時の prompt 契約」節末尾に「読み取り並列・実行直列」「テスト実行可否」、出典に 20260702_1200 参照を追記
+  6. `.claude/rules/agent-prompts.md` (edit, mirror) — 5 と byte-identical
+  7. `rules/integration-verification.md` (edit) — 「推奨 (project type 別)」節末尾に「usage を実測」、出典に 20260702_1200 参照を追記
+  8. `.claude/rules/integration-verification.md` (edit, mirror) — 7 と byte-identical
+  9. `rules/multi-file-consistency.md` (edit) — 推奨に「信頼するディレクトリ境界」、出典に 20260702_1930 参照を追記
+  10. `.claude/rules/multi-file-consistency.md` (edit, mirror) — 9 と byte-identical
+  11. `skills/red/SKILL.md` (edit) — Stage 3 後・exspec check 前に Stage 3.5「False-pass 自己証明」2行を追加（81→85行）
+  12. `skills/red/reference.md` (edit) — Test Execution 節後に `## False-pass Self-Proof {#false-pass-self-proof}` セクション（3手順 + rules/test-patterns.md 参照）を追加
+- **GREEN 確認（個別実行、全て rc=0）**:
+  - `bash tests/test-codify-rule-docs.sh` → rc=0、PASS 33 / FAIL 0 / TOTAL 33（TC-28〜33 含む全 PASS）
+  - `bash tests/test-phase-gate.sh` → rc=0、PASS 24 / FAIL 0 / TOTAL 24（TC-23 含む全 PASS、red/SKILL.md 85 行を確認）
+  - `bash tests/test-exspec-integration.sh` → rc=0、PASS 8 / FAIL 0（T-08: SKILL.md 85 行 ≤ 100 を再確認）
+  - `bash tests/test-red-complexity-gate.sh` → rc=0、PASS 6 / FAIL 0（TC-R6: SKILL.md 85 行 ≤ 100 を再確認）
+  - `test-doc-consistency.sh` は nested full-suite runner のため個別実行せず、TC-16 契約の直接 grep で確認: `git ls-files | grep -vE "^docs/(cycles|decisions|archive)/|^CHANGELOG\.md$" | while read f; do grep -lE "skills/(phase-compact|reload|strategy)" "$f"; done` → 0 hit（新規追記した rule 文面が削除済みスキル名の path-form を含まないことを確認。追記文は全て具体スキル名を含まない一般化された文言のみ）
+  - `test-rules-mirror.sh` は個別実行せず、mirror 5 ペア全て `diff rules/X.md .claude/rules/X.md` で差分ゼロを直接確認済み（cp 後 diff 実行、上記編集ログ参照）
+- 想定外事象: なし。tests/ 配下（RED 成果物）は無変更。STATUS.md の Test Scripts カウントへの波及なし（新規 test file 追加なし）
+- Cycle doc frontmatter: phase → GREEN, updated → 2026-07-03 14:05
+- Test List: TC-01〜08 を WIP → DONE に移動。TC-09（test-rules-mirror.sh）・TC-10（full suite baseline diff）は VERIFY phase 用に TODO へ残置
+- Phase completed
+
+### 2026-07-03 13:55 - REFACTOR (PdM 検証)
+- rule/skill doc + テスト追記のみの cycle のため構造的リファクタ不要（no-op）
+- Verification Gate: test-codify-rule-docs（33）/ test-phase-gate（24）/ test-rules-mirror / test-exspec-integration / test-red-complexity-gate 全 rc=0、mirror 5 ペア diff 空、red/SKILL.md 85 行（≤100）、inverse contract 直接 grep 0 hit
+- Phase completed
+
+### 2026-07-03 14:30 - VERIFY (Product Verification, Block 2c.5)
+- Evidence: /tmp/dev-crew-verify-20260703_1215/verify.log
+- 単体: codify-rule-docs / rules-mirror / phase-gate 全 rc=0
+- TC-16 相当の直接検査（git ls-files ベース）: inverse contract 0 hit
+- real-path: pre-commit-gate 明示指定 → 本 cycle doc を正しく選択し REVIEW 未完了で BLOCK（この段階の正常挙動 — 前 cycle で修正した gate が本 cycle を実際に守っている実証）
+- **full suite: 112/112 全 rc=0、baseline-hardening.txt との diff 空 = 回帰ゼロ**（snapshot 隔離 baseline、rule B の自己適用）
+- Phase completed
+
+### 2026-07-03 15:10 - REVIEW FIX (green-worker)
+- REVIEW で BLOCK（Codex 1 + maintainability 3）が出たため 6 件を修正。
+- **Fix 1 (Codex BLOCK, tests/test-doc-consistency.sh TC-16)**: `git ls-files` の失敗（non-git dir 等）が process substitution 内で空出力を生み、while ループが黙って 0 回実行され `STALE_HITS=0` のまま PASS してしまう silent false-pass を修正。
+  - **red-first 実証（修正前）**: non-git 一時ディレクトリを `BASE_DIR` に見立てた旧ロジックを再現実行 → `STALE_HITS(non-git dir, current logic)=0` → `=> PASS (BUG: silent false-pass on git failure)` を確認（バグの直接証明）
+  - 修正: `tracked=$(git -C "$BASE_DIR" ls-files 2>/dev/null)` + 直後の `rc=$?` を取得し rc≠0 なら fail。filter 後の対象ファイル数 `target_count` が 0 なら fail（filter 過剰の false-pass も防止）。その上で従来の while ループ判定を維持
+  - **修正後の再実証**: non-git dir → `FAIL: git ls-files failed (rc=128)`、実リポジトリ → `PASS (301 files checked)` を確認（両条件で意図通りの分岐を実証）
+- **Fix 2 (maintainability BLOCK×3)**: 追跡番号ラベルコメントを除去（WHY 本文は保持）
+  - `tests/test-codify-rule-docs.sh` TC-28 直前コメント: 「(Codex plan review F3 反映: ..., cycle 20260703_1215)」→「A1 の禁止事項も pin する（推奨のみだと禁止形を落としても PASS するため）」に書き換え
+  - `tests/test-doc-consistency.sh` TC-16 直前コメント: 「(Codex plan review F1, cycle 20260703_1215)。」を除去し、「ignored local file への hit / path prune 不全を避けるため git ls-files ベース」の WHY 部分を保持（Fix 1 のコメント全面改訂と合わせて実施）
+  - `tests/test-phase-gate.sh` TC-23 直前コメント: 「(TC-23, cycle 20260701_1120 Insight 4 deferred:new-cycle)」→「RED False-pass Self-proof の存在検査」の WHY 型に書き換え
+  - 追加で `tests/test-doc-consistency.sh:138` の section header 「(issue #143)」ラベルも同一 cycle 内の追加分として検出したため除去（検証コマンドの 0 件契約を満たすため必須）
+  - 検証: `grep -rnE "cycle 2026[0-9]{4}|issue #[0-9]" tests/test-codify-rule-docs.sh tests/test-doc-consistency.sh tests/test-phase-gate.sh` → rc=1（0 件、マッチなし）を確認
+- **Fix 3 (maintainability WARN, rules/plan-discipline.md 具体例)**: baseline コードブロックを新 rule（immutable snapshot 複製 + evidence 隔離）に追随。`SNAP=$(mktemp -d); cp -R . "$SNAP"` で複製→複製内 (`cd "$SNAP"`) で実行→結果は `"$SCRATCH/baseline.txt"`（隔離 path）に保存する形へ書き換え。`/tmp/baseline.txt` の非隔離例を除去。TC-27/TC-30 の literal（「GREEN 検証は curated」「immutable snapshot 複製」等）は維持されたまま変更（既存行を保持し具体例ブロックのみ改訂）。`.claude/rules/plan-discipline.md` mirror 同期
+- **Fix 4 (maintainability WARN, rules/integration-verification.md)**: 新規行を既存項目と同じ太字ラベル形式に統一 — `- **dev-crew 内 (bash/doc project)**: ...` の直後に `- **共通 (全 project type)**: Verification に書く script 呼び出しは「usage を実測」...` として追加（literal「usage を実測」は保持、TC-32 契約に影響なし）。`.claude/rules/integration-verification.md` mirror 同期
+- **Fix 5 (maintainability LOW, rules/test-patterns.md)**: 出典の新規 1 行（2 cycle 併記）を 1 行 1 cycle の 2 行に分割（`docs/cycles/20260701_1120_...` と `docs/cycles/20260702_1930_...` を別行に）。TC-28/29 の literal「20260701_1120」「20260702_1930」はどちらの行にも contiguous に残るため契約非破壊。intro 文「〜8 つの insight」の固定 count 表現を「複数 cycle から抽出した insight」の count 非依存表現に更新（pre-existing stale 解消）。`.claude/rules/test-patterns.md` mirror 同期
+- **完了確認（個別実行のみ、full suite は実行せず）**:
+  - `bash tests/test-codify-rule-docs.sh` → rc=0、PASS 33 / FAIL 0 / TOTAL 33
+  - `bash tests/test-phase-gate.sh` → rc=0、PASS 24 / FAIL 0 / TOTAL 24
+  - `bash -n tests/test-doc-consistency.sh` → syntax OK（nested full-suite runner のため単体実行せず、TC-16 部分ロジックを直接実行し正常系 PASS（301 files checked）+ git 失敗系 FAIL（rc=128）の両方を確認、上記 Fix 1 参照）
+  - `bash tests/test-rules-mirror.sh` → rc=0、PASS 3 / FAIL 0（mirror 5 ペア全て byte-identical を再確認）
+- 想定外事象: `tests/test-doc-consistency.sh:138` の section header ラベルは Fix 2 の指定 3 箇所に含まれていなかったが、同一 cycle の追加分であり検証コマンドの契約（0 件）を満たすために追加除去。ラベル除去のみで WHY 本文・機能ロジックへの影響なし
+- Cycle doc frontmatter: updated → 2026-07-03 15:10（phase は REFACTOR のまま）
+- Phase completed
+
+### 2026-07-03 15:30 - REVIEW (Codex competitive + 3 Claude reviewers, MED tier)
+- 判定: Codex **BLOCK 1** / correctness **PASS**（逆条件実証・literal byte 一致まで確認）/ security **PASS** / maintainability **BLOCK 3 + WARN 2 + LOW 2**
+- findings 3-category triage:
+  - **accept-apply（6 fix、適用・再検証済み）**:
+    1. Codex BLOCK: TC-16 の git ls-files が process substitution 内で silent fail（non-git dir で PASS を実証）→ rc 明示チェック + 対象 0 件 FAIL 化。red-first で修正前 PASS / 修正後 FAIL(rc=128 検出) を実証。**本 cycle が codify した「出力文字列 assert / silent skip 検出」rule が自 cycle のテストに刺さった dogfood**
+    2. maint BLOCK×3(+1): テストコメントの追跡ラベル（cycle 番号 / issue #）除去、WHY 本文保持。green-worker が指定外 1 件（doc-consistency:138 の issue #143）も検出し除去。検証 grep 0 件
+    3. maint WARN: plan-discipline 具体例を snapshot 隔離形式に追随更新（新 rule との矛盾解消）+ mirror
+    4. maint WARN: integration-verification 新規行を「**共通 (全 project type)**:」ラベル形式に統一 + mirror
+    5. maint LOW: test-patterns 出典の 1 行 1 cycle 分割 + intro の固定 count 表現除去 + mirror
+  - **reject**: なし
+- 適用後: codify-rule-docs 33/33 / phase-gate 24/24 / rules-mirror 3/3 全 rc=0（PdM 追認済み）、ラベル残存 0 件
+- **再発の記録（retro 候補）**: テストコメントへの追跡ラベル混入は前 cycle（20260702_1930 REVIEW maint HIGH×3）に続く 2 cycle 連続の再発。worker prompt への禁止明示だけでは防げていない — 自動 inverse contract（tests/ コメントのラベル検査 TC）が codify 候補
+- BLOCK 事由は全て解消 → Block 2e へ
+- Phase completed
+
+### 2026-07-03 15:32 - DISCOVERED (Block 2e)
+- D1: テストコメント追跡ラベルの自動 inverse contract（2 cycle 連続再発の恒久対策。正当な参照 — rule 出典 section・cycle doc 本文・fixture frontmatter — と区別する pattern 設計が必要）→ issue 起票
+- 既存 issue で追跡済みのため新規起票なし: #142（parallel）、#144（flaky）、#147（non-DONE 遷移）、#148（gate drift guard）
+- issue 起票結果: D1=#151
+
+### 2026-07-03 16:00 - COMMIT
+- REVIEW FIX 適用後の最終 full suite: **112/112 全 rc=0、baseline-hardening.txt との diff 空（回帰ゼロ）**（scratchpad/final-hardening.txt）
+- pre-commit gate は明示指定モードで dogfood 実行
+- branch feature/test-hardening-rule-codify で commit、PR を main base で作成（closes #143）
+- Phase completed
+
+---
+
+## Next Steps
+
+1. [Done] KICKOFF
+2. [Done] plan-review（Codex competitive）
+3. [Done] RED
+4. [Done] GREEN <- Current
+5. [ ] REFACTOR
+6. [ ] REVIEW
+7. [ ] COMMIT
+8. [ ] DONE
+
+## Retrospective
+
+抽出時刻: 2026-07-03 15:45
+抽出方法: Cycle doc 全体（PLAN REVIEW BLOCK×2 / REVIEW BLOCK×4 / red-first fix）からの失敗→最終解→insight ペア抽出
+
+### Insight 1: 新 rule を書く cycle は、その rule を同 cycle の成果物に checklist 適用してから REVIEW に出す
+- **Failure**: 本 cycle が codify した「分岐 × 既存チェックの出力文字列 assert / silent skip 検出」rule の違反形（TC-16 の git ls-files が process substitution 内で silent fail）を、rule を書いた同じ RED 成果物が含んでいた。Codex code review が non-git dir 実証で検出
+- **Final fix**: rc 明示チェック + 対象 0 件 FAIL 化。red-first で修正前 PASS / 修正後 FAIL を実証
+- **Insight**: **rule の codify（文章化）と rule の適用（自分の成果物への checklist 実行）は別作業。新 rule を定義する cycle は、REVIEW 前に「本 cycle の全成果物に新 rule を checklist として適用したか」を確認する**。integration-verification.md の self-apply 原則（rule cycle は自 cycle Verification に self-apply）のテスト設計版
+- **一般化**: RED worker prompt の自己検証項目に「本 cycle で codify する rule 自体への準拠」を含める運用
+
+### Insight 2: 指示で 2 回失敗した規約は 3 回目を待たず自動 inverse contract 化する（2-strike rule）
+- **Failure**: テストコメントへの追跡ラベル混入が 2 cycle 連続で再発（20260702_1930 で 3 件 → prompt に禁止を明示した本 cycle でも 4 件）。maintainability review が両回とも検出し手動除去
+- **Final fix**: ラベル除去 + #151 起票（自動 inverse contract の設計）
+- **Insight**: **prompt 指示・rule 文書で 2 回防げなかった規約違反は、3 回目を待たずに自動契約（inverse contract TC / gate）へ昇格する**。cycle 20260422_1313 #1「自動化なき規律は破綻する」の閾値付き運用形
+- **一般化**: codify-insight の recurrence pre-triage（2+ 再発 → rule 昇格）と同じ 2-strike 閾値を「rule → 自動契約」の昇格にも適用する
+
+### Insight 3: while ループへの process substitution は上流コマンドの rc を握り潰す
+- **Failure**: `while read ...; done < <(git ls-files | ...)` 構成で git 失敗（rc=128）が捕捉されず、空ループ → STALE_HITS=0 → PASS の false-pass 経路が成立
+- **Final fix**: `tracked=$(git -C "$BASE_DIR" ls-files 2>/dev/null)` で変数に受けて rc を直後検査 + filter 後の対象 0 件も FAIL 化
+- **Insight**: **外部コマンドの出力を while で消費するテストは、command substitution で変数に受けて rc を直後検査してからループする**。process substitution / pipe への直結は上流失敗を silent skip にする（rules/test-patterns.md の rc 記録パターンの while-loop 版）
+- **一般化**: test-patterns.md 追記候補（次の codify triage で判定）

--- a/rules/agent-prompts.md
+++ b/rules/agent-prompts.md
@@ -26,6 +26,8 @@ architect や subagent へ委譲する際のプロンプト設計規律。scope 
 
 並列度が上がるほど曖昧な prompt は曖昧な出力を増幅する。単一委譲なら「Files list 全量列挙」で足りるが、N=3+ では統合可能性まで設計する必要がある。
 
+「読み取り並列・実行直列」の原則（テストを実行するプロセスは tree 書き込み・他のテスト実行と直列化）を守り、各並列 prompt に「テスト実行可否」（full suite / 個別 / 禁止）を明示する (cycle 20260702_1200 #2)。
+
 ## 具体例
 
 ```markdown
@@ -46,3 +48,4 @@ plan v3 の Files to Change を全量尊重し、独自判断で追加・削除�
 - `docs/cycles/20260420_1752_v2.8-orchestrate-integration.md` Insight 2
 - `docs/cycles/20260421_1809_sync-plan-progress-log-format.md` Insight 1
 - 会話レビュー (2026-05-25): Kimi Agent Swarm 記事の "synthesis bottleneck" 抽象原則 (`## 並列起動時の prompt 契約` の根拠)
+- cycle 20260702_1200 #2

--- a/rules/integration-verification.md
+++ b/rules/integration-verification.md
@@ -27,6 +27,7 @@ template / skill docs だけでなく、自 cycle の Verification 実行でも 
 - **Config 変更時** (motivating bug): `python -m myapp --config new.yaml && grep "loaded_from: new.yaml" /tmp/myapp.log`
 - **Library**: `python -c "from mymod import run; run('config.yaml')"`
 - **dev-crew 内 (bash/doc project)**: gate/consumer/validator を real path で実行 — 例 `bash scripts/gates/pre-commit-gate.sh $cycle_doc`（$1 に cycle doc パスを渡すと当該 doc を直接検査。明示指定・推奨。project root を渡すと updated 最新の non-DONE を自動選択）or `bash scripts/validate-yaml-frontmatter.sh`。grep/diff のみは structural test として扱う
+- **共通 (全 project type)**: Verification に書く script 呼び出しは「usage を実測」（ヘッダコメント / --help / 実行）で確認してから記載する。引数契約を名前から推測しない (cycle 20260702_1200 #3)
 
 ## Evidence 記録
 
@@ -37,3 +38,4 @@ template / skill docs だけでなく、自 cycle の Verification 実行でも 
 - Kyotei YAML config wire-gap bug (別 repo、2026-04-24 発見)
 - `docs/cycles/20260424_0900_integration-verification-rule.md` — integration verification rule codify cycle
 - `docs/cycles/20260423_1045_discovered-cycle2-followup.md` Insight 1 (REFACTOR full-suite baseline 必須) の対称ルール
+- cycle 20260702_1200 #3

--- a/rules/multi-file-consistency.md
+++ b/rules/multi-file-consistency.md
@@ -12,6 +12,7 @@
 - N ファイル並行実装では「section A が section B より前に出現するか」を行番号比較でテスト契約化する
 - deterministic gate は case 文で期待値を enumerate し、それ以外の値は明示的に reject する
 - gate script は単体で `bash gate.sh <input>` として全検証を完了できる設計にする
+- パス引数の enumerate-and-reject は値の形式だけでなく位置 —「信頼するディレクトリ境界」— も列挙対象にする (cycle 20260702_1930 #1)
 
 ## 具体例
 
@@ -31,3 +32,4 @@ esac
 ## 出典
 
 - `docs/cycles/20260420_1752_v2.8-orchestrate-integration.md` Insights 3, 4
+- cycle 20260702_1930 #1

--- a/rules/plan-discipline.md
+++ b/rules/plan-discipline.md
@@ -30,17 +30,23 @@ plan 作成・承認・実行における規律。実測ベースの計画、逆
   の要素を本文に明記する。単一の "N 件" だけでは plan review で不明瞭扱い
   (cycle 20260424_1119 #1)
 - count/status 変更 cycle の GREEN 検証は curated 非回帰リストでなく `grep -rln "<old-value>" tests/` の逆向き契約 sweep 結果を全て実行する。curated リストは検証範囲を恣意的に狭め、test 内に hardcode された逆向き契約（count assertion 等）を見逃す (cycle 20260625_1101 #1、cycle 20260525_1249 #1 が予告)
+- baseline は「immutable snapshot 複製」上で実測し、evidence ファイルを「並行プロセスから隔離」した path に保存する (cycle 20260702_1200 #1)。live tree での baseline は並行 agent に破壊・汚染される
 
 ## 具体例
 
 ```bash
-# Block 0: baseline 実測
-for f in tests/test-*.sh; do
-  bash "$f" >/dev/null 2>&1
-  rc=$?
-  printf "%s rc=%d\n" "$(basename $f)" "$rc"
-done | sort > /tmp/baseline.txt
-cat /tmp/baseline.txt
+# Block 0: baseline 実測（immutable snapshot 複製上で実行し、evidence は隔離 path に保存）
+SNAP=$(mktemp -d)
+cp -R . "$SNAP"
+(
+  cd "$SNAP"
+  for f in tests/test-*.sh; do
+    bash "$f" >/dev/null 2>&1
+    rc=$?
+    printf "%s rc=%d\n" "$(basename "$f")" "$rc"
+  done | sort
+) > "$SCRATCH/baseline.txt"
+cat "$SCRATCH/baseline.txt"
 
 # 逆向き契約検索: STATUS.md の Test Scripts カウント変更前に
 grep -rn "107\|Test Scripts" tests/ skills/commit/
@@ -55,3 +61,4 @@ grep -rn "107\|Test Scripts" tests/ skills/commit/
 - `docs/cycles/20260422_1146_codify-insight-skill.md` Insight 2
 - cycle 20260422_1313 Insight 1 — 自動化なき規律は破綻する
 - cycle 20260625_1101 #1 — count/status 変更の GREEN 検証は逆向き契約 sweep で全実行（curated リストは hardcode contract を見逃す。実 regression 事例）
+- cycle 20260702_1200 #1 — baseline snapshot 隔離

--- a/rules/test-patterns.md
+++ b/rules/test-patterns.md
@@ -4,7 +4,7 @@ paths:
 ---
 # Test Patterns — bash 落とし穴と meta test 設計
 
-テストスクリプト作成時の再発防止パターン集。cycle 20260421_1043 〜 20260422_0937 + cycle 20260422_1146 から抽出した 8 つの insight を具体的な禁止事項と推奨実装としてまとめる。
+テストスクリプト作成時の再発防止パターン集。cycle 20260421_1043 〜 20260702_1930 の複数 cycle から抽出した insight を具体的な禁止事項と推奨実装としてまとめる。
 
 ## 禁止事項
 
@@ -20,6 +20,7 @@ paths:
 - **`grep -E "a\|b"` の escape alternation**: ERE mode では `|` が直接 alternation、
   `\|` はリテラル pipe となり alternation 無効化 (実測 rc=1 で silent no-match)
   (cycle 20260424_1119 #2)
+- **単体語で pin**: doc/rule への追記を検査する test で、section 既存項目にも出現し得る単体語を literal にしない。false-pass する (cycle 20260701_1120 #1)
 
 ## 推奨
 
@@ -37,6 +38,10 @@ paths:
 - regex alternation: `grep -E "a|b|c"` (non-escaped、ERE の標準) を使う。mode 決定時は
   `printf` oracle 実測で rc 確認 (例: `printf 'x\nb\n' | grep -E "a|b"; echo rc=$?`)
   (cycle 20260424_1119 #2)
+- 追記検査 test は追記内容にのみ現れる「contiguous phrase」を literal に使う (cycle 20260701_1120 #1)
+- literal 採用前に `section_grep` で section 内「pre-existing count」= 0 を実測してから確定する (cycle 20260701_1120 #2)
+- 「分岐 × 既存チェック」の組み合わせ経路それぞれに「出力文字列 assert」を置く。rc のみでは非ブロッキング WARN の silent skip を検出できない (cycle 20260702_1930 #2)
+- 同一セマンティクスを複数実装に要求する時は先に「挙動チェックリスト」（空入力・欠落フィールド・形式混在・異常系）を列挙し各実装に適用する (cycle 20260702_1930 #3)
 
 ## 具体例
 
@@ -69,3 +74,5 @@ echo "$output" | grep -q "expected"
 - `docs/cycles/20260422_0937_advisory-terminology-fix.md` Insight 3
 - `docs/cycles/20260422_1146_codify-insight-skill.md` Insight 1
 - cycle 20260422_1313 Insight 4 — bash $(cmd1 || cmd2) fallback pitfall
+- `docs/cycles/20260701_1120_plan-discipline-green-sweep.md` Insights 1, 2
+- `docs/cycles/20260702_1930_gate-active-cycle-fix.md` Insights 2, 3

--- a/skills/red/SKILL.md
+++ b/skills/red/SKILL.md
@@ -59,6 +59,10 @@ Cycle doc の Test List を Given/When/Then + 具体テストデータに展開�
 テストファイル依存関係分析 → red-worker並列起動 → 結果収集・マージ → テスト実行で**失敗**確認。
 詳細: [reference.md](reference.md#dependency-analysis)
 
+### Stage 3.5: False-pass 自己証明
+
+新規 test の literal が「false-pass 不在を自己証明」できることを確認（対象行除去 → count 0 / FAIL の実証）。手順: [reference.md](reference.md#false-pass-self-proof)
+
 ### exspec check (optional)
 
 `command -v exspec` で存在確認。インストール済みかつ対応言語なら `scripts/gates/exspec-check.sh` を実行。

--- a/skills/red/reference.md
+++ b/skills/red/reference.md
@@ -151,6 +151,16 @@ DISCOVERED項目はTest ListのTODOに追加し、次のStage 1実行で詳細�
 
 プロジェクトのテストコマンドで実行（*-quality スキル参照）。
 
+## False-pass Self-Proof {#false-pass-self-proof}
+
+新規 test の literal が false-pass しないことを自己証明する手順。
+
+1. literal 候補について、対象 section 内の pre-existing count が 0 であることを実測する（[rules/test-patterns.md](../../rules/test-patterns.md) 推奨: `section_grep` helper で section 内 count を取得）
+2. 追記対象行を一時的に除去する（または未実装状態の fixture を使う）。この状態で test を実行し、count が 0 に落ちる、または test が FAIL することを実証する
+3. 実測した count 値（除去前後）を Cycle doc の RED エントリに記録する
+
+この 3 手順により、対象文字列が既存の記述に偶然マッチして誤って PASS する false-pass を排除する。
+
 ## red-worker並列実行
 
 ### 概要

--- a/tests/test-codify-rule-docs.sh
+++ b/tests/test-codify-rule-docs.sh
@@ -568,6 +568,137 @@ else
   fi
 fi
 
+# TC-28: rules/test-patterns.md — 禁止事項 に「単体語で pin」(A1 禁止形連続句) + 推奨 に
+# 「contiguous phrase」「pre-existing count」+ 出典 に 20260701_1120
+# A1 の禁止事項も pin する（推奨のみだと禁止形を落としても PASS するため）
+echo ""
+echo "TC-28: rules/test-patterns.md 禁止事項 has '単体語で pin' + 推奨 has 'contiguous phrase'+'pre-existing count' + 出典 has '20260701_1120'"
+FILE="$RULES_DIR/test-patterns.md"
+if [ ! -f "$FILE" ]; then
+  fail "TC-28: rules/test-patterns.md does not exist"
+else
+  count_tandaigo=$(section_grep "$FILE" "禁止事項" "単体語で pin")
+  count_contiguous=$(section_grep "$FILE" "推奨" "contiguous phrase")
+  count_preexisting=$(section_grep "$FILE" "推奨" "pre-existing count")
+  count_cycle0701=$(section_grep "$FILE" "出典" "20260701_1120")
+  if [ "$count_tandaigo" -ge 1 ] && [ "$count_contiguous" -ge 1 ] && [ "$count_preexisting" -ge 1 ] && [ "$count_cycle0701" -ge 1 ]; then
+    pass "TC-28: test-patterns.md 禁止事項 has 単体語で pin + 推奨 has contiguous phrase + pre-existing count + 出典 has 20260701_1120"
+  elif [ "$count_tandaigo" -lt 1 ]; then
+    fail "TC-28: test-patterns.md 禁止事項 section missing '単体語で pin' phrase (A1 禁止形 pin 未実装)"
+  elif [ "$count_contiguous" -lt 1 ]; then
+    fail "TC-28: test-patterns.md 推奨 section missing 'contiguous phrase'"
+  elif [ "$count_preexisting" -lt 1 ]; then
+    fail "TC-28: test-patterns.md 推奨 section missing 'pre-existing count'"
+  else
+    fail "TC-28: test-patterns.md 出典 section missing '20260701_1120' reference"
+  fi
+fi
+
+# TC-29: rules/test-patterns.md — 推奨 に「分岐 × 既存チェック」「出力文字列 assert」
+# 「挙動チェックリスト」+ 出典 に 20260702_1930
+echo ""
+echo "TC-29: rules/test-patterns.md 推奨 has '分岐 × 既存チェック'+'出力文字列 assert'+'挙動チェックリスト' + 出典 has '20260702_1930'"
+FILE="$RULES_DIR/test-patterns.md"
+if [ ! -f "$FILE" ]; then
+  fail "TC-29: rules/test-patterns.md does not exist"
+else
+  count_bunki=$(section_grep "$FILE" "推奨" "分岐 × 既存チェック")
+  count_shutsuryoku=$(section_grep "$FILE" "推奨" "出力文字列 assert")
+  count_kyodo=$(section_grep "$FILE" "推奨" "挙動チェックリスト")
+  count_cycle1930=$(section_grep "$FILE" "出典" "20260702_1930")
+  if [ "$count_bunki" -ge 1 ] && [ "$count_shutsuryoku" -ge 1 ] && [ "$count_kyodo" -ge 1 ] && [ "$count_cycle1930" -ge 1 ]; then
+    pass "TC-29: test-patterns.md 推奨 has 分岐×既存チェック + 出力文字列 assert + 挙動チェックリスト + 出典 has 20260702_1930"
+  elif [ "$count_bunki" -lt 1 ]; then
+    fail "TC-29: test-patterns.md 推奨 section missing '分岐 × 既存チェック'"
+  elif [ "$count_shutsuryoku" -lt 1 ]; then
+    fail "TC-29: test-patterns.md 推奨 section missing '出力文字列 assert'"
+  elif [ "$count_kyodo" -lt 1 ]; then
+    fail "TC-29: test-patterns.md 推奨 section missing '挙動チェックリスト'"
+  else
+    fail "TC-29: test-patterns.md 出典 section missing '20260702_1930' reference"
+  fi
+fi
+
+# TC-30: rules/plan-discipline.md — 推奨 に「immutable snapshot 複製」「並行プロセスから隔離」
+# + 出典 に 20260702_1200
+echo ""
+echo "TC-30: rules/plan-discipline.md 推奨 has 'immutable snapshot 複製'+'並行プロセスから隔離' + 出典 has '20260702_1200'"
+FILE="$RULES_DIR/plan-discipline.md"
+if [ ! -f "$FILE" ]; then
+  fail "TC-30: rules/plan-discipline.md does not exist"
+else
+  count_snapshot=$(section_grep "$FILE" "推奨" "immutable snapshot 複製")
+  count_kakuri=$(section_grep "$FILE" "推奨" "並行プロセスから隔離")
+  count_cycle1200=$(section_grep "$FILE" "出典" "20260702_1200")
+  if [ "$count_snapshot" -ge 1 ] && [ "$count_kakuri" -ge 1 ] && [ "$count_cycle1200" -ge 1 ]; then
+    pass "TC-30: plan-discipline.md 推奨 has immutable snapshot 複製 + 並行プロセスから隔離 + 出典 has 20260702_1200"
+  elif [ "$count_snapshot" -lt 1 ]; then
+    fail "TC-30: plan-discipline.md 推奨 section missing 'immutable snapshot 複製'"
+  elif [ "$count_kakuri" -lt 1 ]; then
+    fail "TC-30: plan-discipline.md 推奨 section missing '並行プロセスから隔離'"
+  else
+    fail "TC-30: plan-discipline.md 出典 section missing '20260702_1200' reference"
+  fi
+fi
+
+# TC-31: rules/agent-prompts.md — 並列起動時の prompt 契約 に「読み取り並列・実行直列」
+# 「テスト実行可否」+ 出典 に 20260702_1200
+echo ""
+echo "TC-31: rules/agent-prompts.md 並列起動時の prompt 契約 has '読み取り並列・実行直列'+'テスト実行可否' + 出典 has '20260702_1200'"
+FILE="$RULES_DIR/agent-prompts.md"
+if [ ! -f "$FILE" ]; then
+  fail "TC-31: rules/agent-prompts.md does not exist"
+else
+  count_yomikaki=$(section_grep "$FILE" "並列起動時の prompt 契約" "読み取り並列・実行直列")
+  count_kahi=$(section_grep "$FILE" "並列起動時の prompt 契約" "テスト実行可否")
+  count_cycle1200=$(section_grep "$FILE" "出典" "20260702_1200")
+  if [ "$count_yomikaki" -ge 1 ] && [ "$count_kahi" -ge 1 ] && [ "$count_cycle1200" -ge 1 ]; then
+    pass "TC-31: agent-prompts.md 並列起動時の prompt 契約 has 読み取り並列・実行直列 + テスト実行可否 + 出典 has 20260702_1200"
+  elif [ "$count_yomikaki" -lt 1 ]; then
+    fail "TC-31: agent-prompts.md 並列起動時の prompt 契約 section missing '読み取り並列・実行直列'"
+  elif [ "$count_kahi" -lt 1 ]; then
+    fail "TC-31: agent-prompts.md 並列起動時の prompt 契約 section missing 'テスト実行可否'"
+  else
+    fail "TC-31: agent-prompts.md 出典 section missing '20260702_1200' reference"
+  fi
+fi
+
+# TC-32: rules/integration-verification.md — 推奨 に「usage を実測」+ 出典 に 20260702_1200
+echo ""
+echo "TC-32: rules/integration-verification.md 推奨 has 'usage を実測' + 出典 has '20260702_1200'"
+FILE="$RULES_DIR/integration-verification.md"
+if [ ! -f "$FILE" ]; then
+  fail "TC-32: rules/integration-verification.md does not exist"
+else
+  count_usage=$(section_grep "$FILE" "推奨" "usage を実測")
+  count_cycle1200=$(section_grep "$FILE" "出典" "20260702_1200")
+  if [ "$count_usage" -ge 1 ] && [ "$count_cycle1200" -ge 1 ]; then
+    pass "TC-32: integration-verification.md 推奨 has usage を実測 + 出典 has 20260702_1200"
+  elif [ "$count_usage" -lt 1 ]; then
+    fail "TC-32: integration-verification.md 推奨 section missing 'usage を実測'"
+  else
+    fail "TC-32: integration-verification.md 出典 section missing '20260702_1200' reference"
+  fi
+fi
+
+# TC-33: rules/multi-file-consistency.md — 推奨 に「信頼するディレクトリ境界」+ 出典 に 20260702_1930
+echo ""
+echo "TC-33: rules/multi-file-consistency.md 推奨 has '信頼するディレクトリ境界' + 出典 has '20260702_1930'"
+FILE="$RULES_DIR/multi-file-consistency.md"
+if [ ! -f "$FILE" ]; then
+  fail "TC-33: rules/multi-file-consistency.md does not exist"
+else
+  count_kyokai=$(section_grep "$FILE" "推奨" "信頼するディレクトリ境界")
+  count_cycle1930=$(section_grep "$FILE" "出典" "20260702_1930")
+  if [ "$count_kyokai" -ge 1 ] && [ "$count_cycle1930" -ge 1 ]; then
+    pass "TC-33: multi-file-consistency.md 推奨 has 信頼するディレクトリ境界 + 出典 has 20260702_1930"
+  elif [ "$count_kyokai" -lt 1 ]; then
+    fail "TC-33: multi-file-consistency.md 推奨 section missing '信頼するディレクトリ境界'"
+  else
+    fail "TC-33: multi-file-consistency.md 出典 section missing '20260702_1930' reference"
+  fi
+fi
+
 # Summary
 echo ""
 echo "=== Summary ==="

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -135,6 +135,49 @@ if [ "$PHASE_FAIL" -eq 0 ]; then
 fi
 
 ########################################
+# Inverse Contract — deleted skill stale-ref check
+########################################
+
+echo ""
+echo "--- Inverse Contract: Deleted Skill Stale-ref ---"
+
+# TC-16: tracked live files (git ls-files, excluding docs/cycles|decisions|archive +
+# CHANGELOG.md — historical/changelog references to deleted skills are expected there)
+# have zero path-form references to deleted skills phase-compact/reload/strategy.
+# git ls-files ベース: grep --exclude-dir 方式は ignored local file
+# (.claude/settings.local.json 等) にも hit し、path prune が不完全なため使わない。
+# xargs は空入力時の macOS 挙動が不安定なため使わず、while ループで1ファイルずつ
+# 判定する (rules/test-patterns.md 準拠)。git ls-files 自体の失敗（non-git dir 等）が
+# 空出力を生み while ループが黙って 0 回実行され false-pass する経路を防ぐため、
+# git 呼び出しの rc と filter 後の対象ファイル数を先に検証してから判定する
+echo ""
+echo "TC-16: tracked live files have 0 hits for 'skills/(phase-compact|reload|strategy)'"
+tracked=$(git -C "$BASE_DIR" ls-files 2>/dev/null)
+tracked_rc=$?
+if [ "$tracked_rc" -ne 0 ]; then
+  fail "TC-16: git ls-files failed (rc=$tracked_rc) — cannot verify inverse contract"
+else
+  targets=$(echo "$tracked" | grep -vE "^docs/(cycles|decisions|archive)/|^CHANGELOG\.md$")
+  target_count=$(echo "$targets" | grep -c . || true)
+  if [ "$target_count" -eq 0 ]; then
+    fail "TC-16: filtered target file list is empty — filter likely over-excludes (0 files to check)"
+  else
+    STALE_HITS=0
+    while IFS= read -r f; do
+      [ -f "$BASE_DIR/$f" ] || continue
+      if grep -qE "skills/(phase-compact|reload|strategy)" "$BASE_DIR/$f" 2>/dev/null; then
+        STALE_HITS=$((STALE_HITS + 1))
+      fi
+    done < <(echo "$targets")
+    if [ "$STALE_HITS" -eq 0 ]; then
+      pass "No tracked live file references deleted skills phase-compact/reload/strategy ($target_count files checked)"
+    else
+      fail "$STALE_HITS tracked live file(s) reference deleted skills phase-compact/reload/strategy"
+    fi
+  fi
+fi
+
+########################################
 # Regression
 ########################################
 

--- a/tests/test-phase-gate.sh
+++ b/tests/test-phase-gate.sh
@@ -297,6 +297,30 @@ else
 fi
 
 ########################################
+# RED False-pass Self-proof
+########################################
+
+echo ""
+echo "--- RED False-pass Self-proof ---"
+
+# TC-23: red/SKILL.md has Stage 3.5 "False-pass 自己証明" step as a contiguous phrase
+# (RED False-pass Self-proof の存在検査。単体語 pin では section 既存項目にも
+# 出現しうるため contiguous phrase で pin する、rules/test-patterns.md 準拠) +
+# SKILL.md stays within the 100-line hard limit (rules/skill-authoring.md)
+echo ""
+echo "TC-23: red/SKILL.md has 'false-pass 不在を自己証明' step + wc -l <= 100"
+if grep -qF "false-pass 不在を自己証明" "$RED"; then
+  RED_LINES=$(wc -l < "$RED")
+  if [ "$RED_LINES" -le 100 ]; then
+    pass "red/SKILL.md has false-pass self-proof step + $RED_LINES lines (<= 100)"
+  else
+    fail "red/SKILL.md has false-pass self-proof step but exceeds 100 lines ($RED_LINES)"
+  fi
+else
+  fail "red/SKILL.md missing 'false-pass 不在を自己証明' step (Stage 3.5 未実装)"
+fi
+
+########################################
 # Selection Snippet Consistency (TC-09, gate-active-cycle-fix sweep)
 ########################################
 


### PR DESCRIPTION
## Summary
- 直近 3 cycle（20260701_1120 / 20260702_1200 / 20260702_1930）で codified→rule 判定された insight 9 件を一括実装（deferral の積み上げ解消）
- **rules 5 ファイル + mirror**: test-patterns（contiguous phrase pin / pre-existing count / 出力文字列 assert / 挙動チェックリスト）、plan-discipline（baseline snapshot 隔離）、agent-prompts（読み取り並列・実行直列）、integration-verification（usage 実測）、multi-file-consistency（信頼ディレクトリ境界）
- **skills/red**: Stage 3.5「False-pass 自己証明」step 追加（85/100 行）
- **tests**: rule pin TC-28〜33、削除スキル名の git ls-files ベース inverse contract TC-16（**closes #143**）、red step pin TC-23。新規ファイルなし・count 112 不変

## Review（MED tier）
- Codex BLOCK: TC-16 の process substitution silent fail（non-git dir で実証）→ rc 検査 + 0 件 FAIL 化。**本 cycle が codify した silent-skip 検出 rule が自 cycle のテストに刺さった dogfood**
- maintainability BLOCK×3: 追跡ラベルコメント（2 cycle 連続再発 → #151 で自動契約化を起票）
- correctness / security: PASS（逆条件実証・literal byte 一致まで確認）

## Verification
- full suite **112/112 rc=0**、snapshot baseline との **diff 空（回帰ゼロ）**
- Cycle doc: `docs/cycles/20260703_1215_test-hardening-rule-codify.md`

## DISCOVERED
#151（テストコメント追跡ラベルの自動 inverse contract）

🤖 Generated with [Claude Code](https://claude.com/claude-code)