### PR TITLE
fix: commit 時 DONE 遷移の全モード整合 + 19 doc migration (#147)

### DIFF
--- a/.claude/rules/state-ownership.md
+++ b/.claude/rules/state-ownership.md
@@ -31,4 +31,4 @@ Cycle doc records what was done; source files define what is.
 | green | phase, updated |
 | refactor | phase, updated |
 | review | Body log only (no frontmatter changes except phase, updated) |
-| commit | phase, updated |
+| commit | phase (COMMIT→DONE 終端), updated |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,18 +5,19 @@
 | Metric | Value |
 |--------|-------|
 | In-Progress Cycles | 0 |
-| Done (unarchived) | 43 |
+| Done (unarchived) | 62 |
 | Archived Cycles | 37 |
 | Skills | 28 |
 | Agents | 41 |
 | Test Scripts | 112 |
 
-Last updated: 2026-07-03
+Last updated: 2026-07-06
 
 ## Completed (Recent)
 
 | Date | Cycle | Type |
 |------|-------|------|
+| 2026-07-06 | 20260706_1020: phase-lifecycle-completion-gate (commit 時 DONE 遷移の orchestrate 整合 + 19 doc migration、#147) | fix |
 | 2026-07-03 | 20260703_1650: parallel-skill-removal (parallel スキル削除 29→28、#142) | chore |
 | 2026-07-03 | 20260703_1215: test-hardening-rule-codify (codify 済み insight 9 件実装 + inverse contract #143) | feat |
 | 2026-07-02 | 20260702_1930: gate-active-cycle-fix (ACTIVE_CYCLE 選択修正 #145) | fix |

--- a/docs/cycles/20260421_1809_sync-plan-progress-log-format.md
+++ b/docs/cycles/20260421_1809_sync-plan-progress-log-format.md
@@ -1,14 +1,14 @@
 ---
 feature: sync-plan-progress-log-format
 cycle: 20260421_1809
-phase: COMMIT
+phase: DONE
 complexity: trivial
 test_count: 7
 risk_level: low
 retro_status: resolved
 codex_session_id: ""
 created: 2026-04-21 18:09
-updated: 2026-04-22 14:00
+updated: 2026-07-06 11:40
 ---
 
 # sync-plan Progress Log Format

--- a/docs/cycles/20260421_2342_agents-md-count-fix.md
+++ b/docs/cycles/20260421_2342_agents-md-count-fix.md
@@ -1,13 +1,13 @@
 ---
 feature: agents-md-count-fix
 cycle: 20260421_2342
-phase: COMMIT
+phase: DONE
 complexity: trivial
 risk_level: low
 test_count: 2
 retro_status: resolved
 created: 2026-04-21 23:52
-updated: 2026-04-22 12:59
+updated: 2026-07-06 11:40
 ---
 
 # Cycle: AGENTS.md agent count 整合 (eval-3)

--- a/docs/cycles/20260422_0937_advisory-terminology-fix.md
+++ b/docs/cycles/20260422_0937_advisory-terminology-fix.md
@@ -1,14 +1,14 @@
 ---
 feature: advisory-terminology-fix
 cycle: eval-4
-phase: REVIEW
+phase: DONE
 complexity: trivial
 test_count: 6
 risk_level: low
 retro_status: resolved
 codex_session_id: "019db29f-ab0e-7632-a181-e52b68ce33ac"
 created: 2026-04-22 09:37
-updated: 2026-04-22 14:00
+updated: 2026-07-06 11:40
 ---
 
 # eval-4: TC-09 "advisory" 用語置換 (Revised after Codex plan review round 1)

--- a/docs/cycles/20260422_1146_codify-insight-skill.md
+++ b/docs/cycles/20260422_1146_codify-insight-skill.md
@@ -1,14 +1,14 @@
 ---
 feature: codify-insight
 cycle: cycle-b-codify-insight
-phase: REVIEW
+phase: DONE
 complexity: standard
 test_count: 20
 risk_level: medium
 retro_status: resolved
 codex_session_id: "019db316-9c2c-74f0-b32d-0b7d92de9e17"
 created: 2026-04-22 11:46
-updated: 2026-04-22 14:00
+updated: 2026-07-06 11:40
 ---
 
 # Cycle B: codify-insight skill 新設 (ROADMAP Step 1b)

--- a/docs/cycles/20260422_1313_rule-docs-codify-followup.md
+++ b/docs/cycles/20260422_1313_rule-docs-codify-followup.md
@@ -1,14 +1,14 @@
 ---
 feature: rule-docs-codify-followup
 cycle: follow-up-codify-23-insights
-phase: REVIEW
+phase: DONE
 complexity: standard
 test_count: 10
 risk_level: low
 retro_status: resolved
 codex_session_id: "019db366-3682-7823-a9ee-978eee20bb0f"
 created: 2026-04-22 13:13
-updated: 2026-04-23 09:25
+updated: 2026-07-06 11:40
 ---
 
 # Follow-up Cycle: codify→rule 23 insights を rule document 化 + skill-maker 強化

--- a/docs/cycles/20260423_0926_discovered-followup-mirror-rules.md
+++ b/docs/cycles/20260423_0926_discovered-followup-mirror-rules.md
@@ -1,14 +1,14 @@
 ---
 feature: discovered-followup-mirror-rules
 cycle: 20260423_0926
-phase: COMMIT
+phase: DONE
 complexity: standard
 test_count: 109
 risk_level: low
 retro_status: resolved
 codex_session_id: "019db7be-8fe9-7440-9ec8-a3fabf622646"
 created: 2026-04-23 09:26
-updated: 2026-04-23 10:45
+updated: 2026-07-06 11:40
 ---
 
 # DISCOVERED 3 Items Follow-up (mirror + plan-discipline + test-patterns)

--- a/docs/cycles/20260423_1045_discovered-cycle2-followup.md
+++ b/docs/cycles/20260423_1045_discovered-cycle2-followup.md
@@ -1,14 +1,14 @@
 ---
 feature: discovered-cycle2-followup
 cycle: 20260423_1045
-phase: COMMIT
+phase: DONE
 complexity: standard
 test_count: 109
 risk_level: low
 retro_status: resolved
 codex_session_id: "019db7be-8fe9-7440-9ec8-a3fabf622646"
 created: 2026-04-23 10:45
-updated: 2026-04-24 09:00
+updated: 2026-07-06 11:40
 ---
 
 # DISCOVERED 4 Items Follow-up (cycle 20260423_0926 派生)

--- a/docs/cycles/20260424_0900_integration-verification-rule.md
+++ b/docs/cycles/20260424_0900_integration-verification-rule.md
@@ -1,14 +1,14 @@
 ---
 feature: integration-verification-rule
 cycle: 20260424_0900
-phase: COMMIT
+phase: DONE
 complexity: standard
 test_count: 109
 risk_level: low
 retro_status: resolved
 codex_session_id: "019dbcfd-b821-7de2-a8b7-980e430b767b"
 created: 2026-04-24 09:00
-updated: 2026-04-24 11:19
+updated: 2026-07-06 11:40
 ---
 
 # Integration Verification Rule — real-path invocation mandatory in Verification Gate

--- a/docs/cycles/20260424_1119_discovered-debt-cleanup.md
+++ b/docs/cycles/20260424_1119_discovered-debt-cleanup.md
@@ -1,14 +1,14 @@
 ---
 feature: discovered-debt-cleanup
 cycle: 20260424_1119
-phase: COMMIT
+phase: DONE
 complexity: standard
 test_count: 6
 risk_level: low
 retro_status: resolved
 codex_session_id: "019dbd4e-b160-7450-b3cf-141978b8217a"
 created: 2026-04-24 11:19
-updated: 2026-04-24 13:56
+updated: 2026-07-06 11:40
 ---
 
 # DISCOVERED 3 項目 debt 解消 cycle

--- a/docs/cycles/20260424_1356_small-debt-cleanup.md
+++ b/docs/cycles/20260424_1356_small-debt-cleanup.md
@@ -1,14 +1,14 @@
 ---
 feature: small-debt-cleanup
 cycle: 20260424_1356
-phase: COMMIT
+phase: DONE
 complexity: trivial
 risk_level: low
 test_count: 6
 retro_status: resolved
 codex_session_id: "019dbddb-4d06-7460-b81a-25d2f0c179d9"
 created: 2026-04-24 13:56
-updated: 2026-04-24 15:37
+updated: 2026-07-06 11:40
 ---
 
 # Cycle: small debt cleanup (B + C + E)

--- a/docs/cycles/20260424_1537_prior-codify-implementation.md
+++ b/docs/cycles/20260424_1537_prior-codify-implementation.md
@@ -1,14 +1,14 @@
 ---
 feature: prior-codify-implementation
 cycle: 20260424_1537
-phase: COMMIT
+phase: DONE
 complexity: standard
 test_count: 13
 risk_level: low
 retro_status: resolved
 codex_session_id: "019dbe38-13af-7e43-a998-d8394fb2d681"
 created: 2026-04-24 15:37
-updated: 2026-04-27 09:30
+updated: 2026-07-06 11:40
 ---
 
 # Cycle B: prior-codify implementation (F)

--- a/docs/cycles/20260427_0930_pre-existing-fail-cleanup.md
+++ b/docs/cycles/20260427_0930_pre-existing-fail-cleanup.md
@@ -1,14 +1,14 @@
 ---
 feature: pre-existing-fail-cleanup
 cycle: 20260427_0930
-phase: COMMIT
+phase: DONE
 complexity: standard
 test_count: 7
 risk_level: low
 retro_status: resolved
 codex_session_id: "019dcc56-067f-7022-a019-3be9ea7718c3"
 created: 2026-04-27 09:26
-updated: 2026-05-25 10:25
+updated: 2026-07-06 11:40
 plan_file: /Users/morodomi/.claude/plans/1-precious-hammock.md
 ---
 

--- a/docs/cycles/20260625_1101_rules-path-scoping.md
+++ b/docs/cycles/20260625_1101_rules-path-scoping.md
@@ -1,14 +1,14 @@
 ---
 feature: rules-path-scoping
 cycle: 20260625_1101
-phase: COMMIT
+phase: DONE
 complexity: standard
 test_count: 4
 risk_level: LOW
 retro_status: resolved
 codex_session_id: "019efc89-e96b-7bc3-9d00-4004e6987657"
 created: 2026-06-25
-updated: 2026-07-01
+updated: 2026-07-06 11:40
 ---
 
 # Rules Path Scoping

--- a/docs/cycles/20260701_1120_plan-discipline-green-sweep.md
+++ b/docs/cycles/20260701_1120_plan-discipline-green-sweep.md
@@ -1,14 +1,14 @@
 ---
 feature: plan-discipline-green-sweep
 cycle: 20260701_1120
-phase: COMMIT
+phase: DONE
 complexity: simple
 test_count: 1
 risk_level: LOW
 retro_status: resolved
 codex_session_id: "019f1b7c-a332-7493-a31c-384e3e05a4b0"
 created: 2026-07-01 11:21
-updated: 2026-07-02 12:00
+updated: 2026-07-06 11:40
 ---
 
 # Plan Discipline — GREEN 検証 sweep ルール codify

--- a/docs/cycles/20260702_1200_skill-inventory-cleanup.md
+++ b/docs/cycles/20260702_1200_skill-inventory-cleanup.md
@@ -1,14 +1,14 @@
 ---
 feature: skill-inventory-cleanup
 cycle: 20260702_1200
-phase: COMMIT
+phase: DONE
 complexity: standard
 test_count: 6
 risk_level: medium
 retro_status: resolved
 codex_session_id: "019f2131-5169-75e1-a43b-c2efa87040f0"
 created: 2026-07-02 12:00
-updated: 2026-07-02 19:20
+updated: 2026-07-06 11:40
 ---
 
 # Skill Inventory Cleanup — phase-compact/reload/strategy 削除 + quality description 修正

--- a/docs/cycles/20260702_1930_gate-active-cycle-fix.md
+++ b/docs/cycles/20260702_1930_gate-active-cycle-fix.md
@@ -1,14 +1,14 @@
 ---
 feature: gate-active-cycle-fix
 cycle: 20260702_1930
-phase: COMMIT
+phase: DONE
 complexity: standard
 test_count: 9
 risk_level: medium
 retro_status: resolved
 codex_session_id: ""
 created: 2026-07-02 19:30
-updated: 2026-07-03 12:10
+updated: 2026-07-06 11:40
 ---
 
 # Gate Active Cycle Fix — pre-commit/pre-red gate の ACTIVE_CYCLE 選択修正（issue #145）

--- a/docs/cycles/20260703_1215_test-hardening-rule-codify.md
+++ b/docs/cycles/20260703_1215_test-hardening-rule-codify.md
@@ -1,14 +1,14 @@
 ---
 feature: test-hardening-rule-codify
 cycle: 20260703_1215
-phase: COMMIT
+phase: DONE
 complexity: complex
 test_count: 10
 risk_level: medium
 retro_status: resolved
 codex_session_id: ""
 created: 2026-07-03 12:15
-updated: 2026-07-03 16:40
+updated: 2026-07-06 11:40
 ---
 
 # test hardening — codify 済み insight 9 件の rule/skill 実装 + inverse contract（#143）

--- a/docs/cycles/20260703_1650_parallel-skill-removal.md
+++ b/docs/cycles/20260703_1650_parallel-skill-removal.md
@@ -1,14 +1,14 @@
 ---
 feature: parallel-skill-removal
 cycle: 20260703_1650
-phase: COMMIT
+phase: DONE
 complexity: standard
 test_count: 6
 risk_level: medium
 retro_status: resolved
 codex_session_id: ""
 created: 2026-07-03 16:50
-updated: 2026-07-03 20:30
+updated: 2026-07-06 11:40
 ---
 
 # parallel スキル削除（issue #142、29→28）

--- a/docs/cycles/20260703_2035_tracking-label-contract.md
+++ b/docs/cycles/20260703_2035_tracking-label-contract.md
@@ -1,14 +1,14 @@
 ---
 feature: tracking-label-contract
 cycle: 20260703_2035
-phase: COMMIT
+phase: DONE
 complexity: standard
 test_count: 8
 risk_level: medium
-retro_status: captured
+retro_status: resolved
 codex_session_id: ""
 created: 2026-07-03 20:35
-updated: 2026-07-04 00:20
+updated: 2026-07-06 11:40
 ---
 
 # codify 実装 (2) — #151 追跡ラベル自動契約 + codified/captured insight 5 件の rule 実装
@@ -371,3 +371,24 @@ diff -q rules/{test-patterns,plan-discipline,integration-verification,agent-prom
 
 ### 成功事例（observation）: 新契約を書く worker の自己違反を Stage 3.5 が即検出
 - TC-17（追跡ラベル禁止契約）を実装する red-worker 自身のコメントが TC-17 に違反する 2 箇所を、Stage 3.5（False-pass 自己証明）の実行過程で自主検出・修正。前 cycle で追加した red skill step と 2-strike rule が設計通り機能した実証。「契約を書く者が最初の違反者になる」パターンは自動契約の即時自己適用でのみ防げる
+
+## Codify Decisions
+
+triage 実施: 2026-07-06 10:10（後続 cycle phase-lifecycle-completion-gate の orchestrate Block 0 codify gate で処理）。autonomous triage、質問 0 件。frontmatter 遷移は行アンカー + count=1 の範囲限定編集で実施（本 doc の Insight 1 の即時適用）。
+
+### Insight 1
+- **Decision**: codified
+- **Destination**: rule (rules/doc-mutations.md + .claude/rules/ mirror)
+- **Reason**: 「frontmatter の状態遷移は frontmatter 区間限定で編集する。全文一括置換は本文中の記録的言及を巻き込む」。二重汚染 + commit 混入の実害 evidence あり。実装は次の codify 実装 cycle（本 cycle は #147 phase lifecycle が scope のため混ぜない）
+- **Decided**: 2026-07-06 10:10
+
+### Insight 2
+- **Decision**: codified
+- **Destination**: rule (rules/test-patterns.md + .claude/rules/ mirror)
+- **Reason**: 「section_grep の heading 引数は ERE 解釈される。メタ文字を含む見出しは短縮形で渡す」。silent no-match の実測 evidence あり。実装は次の codify 実装 cycle（helper の fixed-string 化は #148 と同時が効率的、と origin insight が示唆）
+- **Decided**: 2026-07-06 10:10
+
+### 成功事例（observation）
+- **Decision**: no-codify
+- **Reason**: Stage 3.5 + 2-strike rule の有効性実証は前 2 cycle で codify 済みの rule 群の追認であり、新規 rule 化は不要
+- **Decided**: 2026-07-06 10:10

--- a/docs/cycles/20260706_1020_phase-lifecycle-completion-gate.md
+++ b/docs/cycles/20260706_1020_phase-lifecycle-completion-gate.md
@@ -1,0 +1,316 @@
+---
+feature: phase-lifecycle-completion-gate
+cycle: 20260706_1020
+phase: DONE
+complexity: standard
+test_count: 5
+risk_level: medium
+retro_status: captured
+codex_session_id: ""
+created: 2026-07-06 10:20
+updated: 2026-07-06 14:10
+---
+
+# cycle doc phase lifecycle — completion gate 新設 + non-DONE 19 doc の DONE 遷移（#147）
+
+## Scope Definition
+
+### In Scope
+- [ ] orchestrate Block 0 に completion gate を新設（codify gate 直後、`phase: COMMIT` かつ `retro_status: resolved` の doc を `phase: DONE` へ遷移）
+- [ ] 完了済み 19 doc（COMMIT 16 + REVIEW 3、全て retro_status: resolved）の frontmatter migration（phase → DONE、updated 更新、行アンカー + count=1 の範囲限定編集）
+- [ ] tests/test-doc-consistency.sh に TC-18（live docs/cycles/ の non-DONE doc 数 ≤ 1 assert）追加
+- [ ] tests/test-review-plan-gate.sh に completion gate 記述を contiguous phrase で pin する新 TC 追加
+- [ ] rules/state-ownership.md + .claude/rules/state-ownership.md（byte-identical mirror）の frontmatter 権限表に completion gate 行追加
+- [ ] docs/STATUS.md: Done (unarchived) 43→62 + Completed 行 + Last updated 更新
+
+### Out of Scope
+- docs/cycles/archive/ への移動（アーカイブ運用は別テーマ）
+- #148 / #144（v2.12 以降）、CHANGELOG 補完（Task 3）
+- commit skill 側での即時 DONE 遷移（Block 0 方式を採用 — commit 後の遷移は次 commit に乗る established pattern）
+
+### Files to Change（全量、plan 承認時点。追加・削除禁止）
+
+1. `skills/orchestrate/SKILL.md` — Block 0 codify gate 直後に completion gate 2-3 行（詳細手順は reference.md へ）
+2. `skills/orchestrate/reference.md` — completion gate の手順詳細（条件・frontmatter 範囲限定編集・updated 同時更新）
+3. `rules/state-ownership.md` — frontmatter 権限表に completion gate 行を追加（byte-identical mirror）
+4. `.claude/rules/state-ownership.md` — 3 と byte-identical mirror
+5. `tests/test-doc-consistency.sh` — **TC-18**: live docs/cycles/ の non-DONE doc 数 ≤ 1 を assert（現状 19 で**実 FAIL = 本物の RED**。GREEN の migration で 1 以下に。frontmatter は awk 区間抽出で判定）
+6. `tests/test-review-plan-gate.sh` — orchestrate SKILL.md の completion gate 記述を contiguous phrase で pin する TC（次連番、pre-existing count=0 実測で literal 確定）
+7. `docs/cycles/` の完了済み 19 doc — phase: COMMIT/REVIEW → DONE（migration、各 doc の updated も更新）
+8. `docs/STATUS.md` — In-Progress 0（不変）/ Done (unarchived) 43→62 + Completed 行 + Last updated
+9. `docs/cycles/20260706_1020_phase-lifecycle-completion-gate.md` — Cycle doc（sync-plan 生成、本ファイル）
+
+count 契約: 新規テストファイルなし（112 不変）。「43」への逆向き契約なし（実測済み）。
+
+## Environment
+
+### Scope
+- Layer: Documentation / Workflow contract（実装コードなし、orchestrate workflow 定義・テスト契約・cycle doc frontmatter migration）
+- Plugin: dev-crew（bash/doc project）
+- Risk: ~45（WARN 帯）
+
+### Runtime
+- Language: Bash（テストスクリプト）、Markdown（skill/rule docs、cycle doc frontmatter）
+
+### Dependencies (key packages)
+- なし（新規依存追加なし）
+
+### Risk Interview (BLOCK only)
+- 該当なし（Risk ~45 は WARN 帯であり BLOCK 未満）
+
+## Context & Dependencies
+
+### Reference Documents
+- `skills/orchestrate/SKILL.md` L41-43 — codify gate 記述（completion gate の挿入位置の直前）
+- `rules/state-ownership.md` — frontmatter Update Permissions 表（completion gate 行の追加先）
+- `docs/STATUS.md` — Done (unarchived) カウントの更新先
+- issue #145（gate の ACTIVE_CYCLE 選択バグ、修正済み）— 本 cycle の根本原因対応の動機
+
+### Dependent Features
+- `tests/test-doc-consistency.sh`: TC-17 が最終（本 cycle で TC-18 を追加）
+- `tests/test-review-plan-gate.sh`: TC-01〜TC-13+ が既存（本 cycle で新連番 TC を追加）
+- `skills/orchestrate/SKILL.md`: 95 行（codify gate は L41-43）。completion gate 追加後も 100 行制約内（+2-3 行で 97-98 行）
+
+### Related Issues/PRs
+- issue #147（本 cycle の主目的）
+- ROADMAP v2.11 残タスク2（ユーザー承認済み実行順の2番目）
+
+## Test List（Given/When/Then）
+
+### TODO
+(none)
+
+### WIP
+
+### DISCOVERED
+(none)
+
+### DONE
+- [x] TC-01: Given docs/cycles/（live）, When 各 doc の frontmatter phase を awk 抽出し non-DONE を数える, Then ≤ 1（TC-18。RED 時点で 19 件 = 実 FAIL）
+- [x] TC-02: Given skills/orchestrate/SKILL.md Block 0, When completion gate の contiguous phrase を grep, Then 存在（review-plan-gate 新 TC。RED で FAIL）
+- [x] TC-03: Given rules/state-ownership.md 権限表, When completion gate 行を grep, Then 存在 + mirror byte-identical（test-rules-mirror 既存契約で自動）
+- [x] TC-04: Given migration 後の 19 doc, When frontmatter を検証, Then 全て phase: DONE + validate-cycle-frontmatter.sh rc=0
+- [x] TC-05: Given 全 suite, When 一括実行, Then baseline との diff 空（112/112）
+
+## Implementation Notes
+
+### Goal
+ROADMAP v2.11 残タスク2（ユーザー承認済み実行順の2番目）。gate の ACTIVE_CYCLE 選択バグ（#145、修正済み）の根本原因だった「non-DONE = active の意味論崩壊」を修復する。COMMIT 完了後に phase: DONE へ遷移させる責務が workflow に未定義のため、完了済み cycle doc 19 件（COMMIT 16 + REVIEW 3、全て main マージ済み・retro_status: resolved）が non-DONE のまま滞留している。
+
+### Background
+- 責務定義: orchestrate Block 0 に completion gate を新設。codify gate と同じ「次 cycle 開始時に前 cycle の状態を確定させる」パターン
+- タイミング: Block 0 の codify gate の直後（codify が resolved にした doc も同 run で DONE に遷移できる順序）
+- 条件: `phase: COMMIT` かつ `retro_status: resolved` の doc を `phase: DONE` へ遷移（frontmatter 範囲限定編集 — 直近 retro Insight 1 準拠、全文置換禁止）
+- 含意: 定常状態で non-DONE doc は最大 1 件（進行中 cycle または次 Block 0 待ちの直近 COMMIT doc）。abort されて中間 phase で滞留した doc は contract violation として顕在化する（意図された強制力）
+- Data migration（1回限り）: 完了済み 19 doc の frontmatter を DONE へ遷移（行アンカー + count=1 の範囲限定編集）。3 件の REVIEW 滞留 doc も retro_status: resolved 確認済みで対象
+
+### Design Approach
+RED で TC-18（non-DONE ≤ 1 assert、現状 19 件で実 FAIL）+ test-review-plan-gate.sh の新 TC（completion gate 記述 pin、SKILL.md 未編集時点で FAIL）を追加する。GREEN で SKILL.md + reference.md に completion gate を実装し、19 doc の frontmatter migration（phase/updated のみ、行アンカー + count=1 の範囲限定編集）を実施、state-ownership.md 権限表 + STATUS.md カウントを更新する。
+
+## Verification（real-path invocation — usage 実測済み形式のみ）
+
+```bash
+SCRATCH=/private/tmp/claude-501/-Users-morodomi-Projects-MorodomiHoldings-agents-dev-crew/74f3a9a9-3af1-4977-80a3-f0ee96a13dd1/scratchpad
+# 1) 単体
+bash tests/test-review-plan-gate.sh; echo "rc=$?"
+bash tests/test-rules-mirror.sh; echo "rc=$?"
+# 2) TC-18 相当の直接検査
+for f in docs/cycles/*.md; do awk '/^---$/{c++;next} c==1{print}' "$f" | grep '^phase:' | grep -v DONE; done | wc -l   # ≤1
+# 3) real-path: 修正済み gate の dir mode が「唯一の non-DONE = 本 cycle doc」を選ぶ（意味論修復の実証）
+bash scripts/gates/pre-commit-gate.sh . 2>&1 | head -2
+# 4) migration 全 doc の frontmatter validator
+for f in docs/cycles/*.md; do bash scripts/validate-cycle-frontmatter.sh "$f" >/dev/null 2>&1 || echo "INVALID: $f"; done; echo "validator sweep done"
+# 5) full suite（snapshot baseline 比較）
+for f in tests/test-*.sh; do timeout 2400 bash "$f" >/dev/null 2>&1; printf "%s rc=%d\n" "$(basename $f)" "$?"; done | sort > "$SCRATCH/after-lifecycle.txt"
+if grep -v "rc=0" "$SCRATCH/after-lifecycle.txt"; then echo "VERIFY FAIL"; false; else echo "all rc=0"; fi
+diff "$SCRATCH/baseline-lifecycle.txt" "$SCRATCH/after-lifecycle.txt" && echo "no regression"
+```
+
+Evidence: (orchestrate が自動記入)
+
+## Progress Log
+
+### 2026-07-06 10:20 - KICKOFF
+
+**Design Review Gate 実施結果: PASS**
+
+以下を Read/grep で現物追認し、plan 記載の実測事実と完全一致を確認（tests/ の実行はせず読み取りのみ、teammate 指示に基づく）:
+
+- non-DONE census: `docs/cycles/*.md` を awk frontmatter 区間抽出で走査 → **19 件**（COMMIT 16 + REVIEW 3）を確認。全 19 件が `retro_status: resolved` であることも個別に確認。plan 記載の「COMMIT 16 + REVIEW 3、全て retro_status: resolved」と完全一致
+- `docs/cycles/20260703_2035_tracking-label-contract.md` — 作業ツリーに未 staged 変更あり。`retro_status: captured → resolved` への遷移が確認でき、直近の codify gate 処理により resolved 済みであることを実証（teammate 指摘「直近の codify gate 処理で 20260703_2035 も resolved 済みのはず」と一致）。本 cycle の Files to Change には含まれず、scope 外として変更せず維持
+- `docs/STATUS.md` — `Done (unarchived) | 43`、`Test Scripts | 112` を確認。`grep -rn "\b43\b" tests/` は 0 件（逆向き契約なし、plan 記載の実測と一致）
+- `skills/orchestrate/SKILL.md` — 95 行を確認。codify gate は L41-43。completion gate 2-3 行追加後は 97-98 行で 100 行制約内
+- 挿入位置の非衝突確認（test-review-plan-gate.sh TC-01/TC-15 との整合）: TC-01 は `plan.*file` 系パターンの最初の出現行（L19、Progress Checklist）と `未完了.*cycle|phase.*DONE` 系パターンの最初の出現行（L50）の順序を比較する。completion gate を L43 直後（L45 手前）に挿入しても両パターンの最初の出現行は不変のため、TC-01 の順序判定（19 < 50+shift）は非衝突。TC-15 は RED/GREEN/REFACTOR/REVIEW/COMMIT の小文字化のみを検査対象とし、`DONE` は対象外のため completion gate 導入と非衝突
+- 「completion gate」「COMMIT→DONE」の contiguous literal 候補: `skills/orchestrate/SKILL.md`・`tests/test-review-plan-gate.sh`・`rules/state-ownership.md`・`.claude/rules/state-ownership.md` の全てで pre-existing count = 0 を実測（grep rc=1、無 hit）。plan 記載の「pre-existing count=0 実測で literal 確定」と一致
+- `rules/state-ownership.md` の Frontmatter Update Permissions 表を確認 — completion gate（COMMIT→DONE の担い手）に該当する行が存在しないことを確認。plan 記載の「gap の実証」と一致
+- `tests/test-doc-consistency.sh` の最終 TC は TC-17（L187-、追跡ラベル inverse contract）→ 本 cycle は TC-18 が正しい採番
+- `ls tests/test-*.sh | wc -l` で 112 を確認（`docs/STATUS.md` の `Test Scripts | 112` と一致、plan 記載「count 112 不変」の baseline と一致）
+
+**注記**: 作業ディレクトリに `docs/cycles/20260703_2035_tracking-label-contract.md` の未 staged 変更あり（前 cycle の codify gate 処理結果、`retro_status: captured → resolved` + `## Codify Decisions` セクション追記）。本 cycle の Files to Change には含まれず、scope 外として変更せず維持。
+
+**テスト実行**: 本 KICKOFF では tests/ の実行は行っていない（PdM が snapshot baseline を並行取得中のため、読み取りのみに限定。teammate 指示に基づく）。
+
+**判定**: Design Review Gate PASS。plan の実測事実・Files to Change・Test List・Verification の記載は全て現物と一致し、齟齬・虚偽記載なし。frontmatter 初期化完了（phase: KICKOFF、retro_status: none）。
+### 2026-07-06 10:50 - PLAN REVIEW (Socrates adversarial — Codex 不在 fallback)
+- **Codex CLI 破損**（vendor バイナリ ENOENT、node/codex 更新起因の疑い）→ orchestrate 規定の Socrates fallback で adversarial review 実施
+- Socrates 判定: **BLOCK 2 + WARN 2**。PdM 実証確認の上 triage:
+  - **BLOCK 1（中核前提の反証）→ accept**: 「COMMIT→DONE 責務が未定義」は虚偽。skills/commit/SKILL.md Step 3 が「Cycle doc | 常に | phase: DONE」を定義済み（PdM が L44-52 を実測確認）。Block 0 に新 gate を足すと二重所有の doc drift が確定
+  - **BLOCK 2（真因の未診断）→ accept**: 滞留の真因は orchestrate Block 3「COMMIT: git add & commit（PdM 直接実行）」が commit skill の Step 3 をバイパスしていたこと。直近の全 cycle で PdM 自身が再現していた
+  - **WARN 3（gate 条件と migration 範囲の非対称）/ WARN 4（TC-18 の増幅リスク）→ 設計転換で構造的に解消**（下記）
+- **ユーザー決定（AskUserQuestion）**: Block 0 completion gate 案を破棄し、**orchestrate Block 3 に DONE 遷移を組み込む**（commit skill 契約との整合、単一責務）
+- **設計改訂（Cycle doc を SSOT として Files to Change を差し替え）**:
+  1. skills/orchestrate/SKILL.md — Block 3 COMMIT 手順を「pre-commit-gate（明示指定）PASS → Cycle doc frontmatter を phase: DONE へ遷移（範囲限定編集）+ COMMIT エントリ記録 → git add & commit」に改訂（gate は phase: DONE の明示指定を reject するため、gate 検査 → 遷移 → commit の順序を明記）
+  2. rules/state-ownership.md + .claude/rules/ mirror — commit 行を「phase (COMMIT→DONE 終端), updated」に明確化
+  3. tests/test-doc-consistency.sh TC-18 — non-DONE ≤ 1 invariant（維持。commit 時 DONE 化により orchestrate 非経由の commit skill 単独実行でも invariant が保たれる — WARN 4 の構造的解消）
+  4. tests/test-review-plan-gate.sh — pin 対象を「Block 3 の DONE 遷移記述」の contiguous phrase に変更
+  5. 完了済み 19 doc の DONE migration（維持。WARN 3 の REVIEW 滞留 3 doc も migration で解消し、以後は commit 時 DONE 化で新規滞留が発生しない）
+  6. docs/STATUS.md Done (unarchived) 43→62（維持）
+  - 変更しない: skills/commit/SKILL.md（既に正しい契約を定義。むしろ本 cycle は orchestrate 側を commit skill に整合させる）、skills/orchestrate/reference.md（Block 3 改訂が SKILL.md 内 3 行で収まるため）
+- **本 cycle 自身が新手順の初適用となる**（COMMIT 時に自 doc を DONE 化してから commit — self-apply）
+- 判定: BLOCK 事由は設計転換で解消 → Block 2a (RED) へ
+
+### 2026-07-06 11:20 - RED
+
+**事前実測（test-patterns A2 + red skill Stage 3.5）**:
+- 候補 literal `phase: DONE へ遷移` の pre-existing count: `skills/orchestrate/SKILL.md` 内 `grep -c "phase: DONE へ遷移"` → rc=1（0 件、no match）を実測。`tests/test-review-plan-gate.sh` / `rules/state-ownership.md` / `.claude/rules/state-ownership.md` / `skills/commit/SKILL.md` を含む grep でも同一 literal の hit なしを確認（PLAN REVIEW 記載の「pre-existing count=0 実測」と一致）
+- `tests/test-review-plan-gate.sh` の既存 TC 最終番号: TC-13（`grep -n "^# TC-"` で確認）→ 新 TC は **TC-14** が正しい採番
+- `ls tests/test-*.sh | wc -l` → 112（不変、count 契約通り）
+- `docs/cycles/*.md` の non-DONE census 再実測: awk frontmatter 区間抽出 + `grep '^phase:' | grep -v DONE` → **20 件**（完了済み 19 + 本 cycle doc 自身が `phase: KICKOFF` 時点でカウント対象だったため。KICKOFF 時点の Progress Log 記載「19+本 doc = 20」と一致）
+
+**追加した RED テスト**:
+1. `tests/test-doc-consistency.sh` TC-18（TC-17 の後・TC-13 nested runner の前に配置）: live `docs/cycles/*.md`（非再帰 glob のため `archive/` は自動除外）の frontmatter phase を awk 区間抽出で判定し、non-DONE doc 数が 1 件以下であることを assert。phase フィールド不在の旧形式 doc は集計対象外。nullglob + 配列件数の直後検査（TC-17 方式踏襲）
+2. `tests/test-review-plan-gate.sh` TC-14: `awk '/^### Block 3/,/^## /'` で Block 3 section を抽出し、contiguous phrase `phase: DONE へ遷移` の存在を assert（PLAN REVIEW の設計改訂により、pin 対象は Block 0 completion gate ではなく **Block 3 の DONE 遷移記述** に変更済み）
+
+**自己証明**:
+- TC-14: `skills/orchestrate/SKILL.md` のコピーに GREEN で実装予定の Block 3 改訂相当の一文（`phase: DONE へ遷移` を含む）を注入した fixture で同一ロジックを実行し、PASS に反転することを確認（本体ファイルは未変更のまま検証）
+- TC-18: fixture ディレクトリで (a) `phase: DONE` × 2 + `phase: RED` × 1 → non-DONE count=1 → `<=1` 閾値を通過、(b) さらに `phase: GREEN` の doc を追加 → non-DONE count=2 → `<=1` 閾値を超過、の両分岐を実行しロジックが正しく分岐することを確認
+
+**RED 確認（個別実行、full suite 一括禁止の指示に従い個別）**:
+- `bash tests/test-review-plan-gate.sh` → rc=1、PASS: 13 / FAIL: 1（新設 TC-14 のみ FAIL、既存 TC-01〜13 は全 PASS）
+- `bash tests/test-doc-consistency.sh` → rc=1、PASS: 10 / FAIL: 3（新設 TC-18 が non-DONE count=20 > 1 で FAIL。加えて TC-13 nested runner が `test-review-plan-gate.sh` の FAIL を検知し collateral FAIL — TC-14 の意図した RED 状態が伝播した結果であり、想定内）
+- `bash -n` で両ファイルの構文検証 → 両方 OK
+- collateral FAIL の切り分け: `test-factory-model-adaptation.sh`（TC-13 経由で呼ばれる別ファイル）が同時に FAIL 表示された点を確認するため、`git stash` で本 cycle の変更を退避した baseline で同ファイルを単独実行 → rc=0（PASS）。変更を戻すと同ファイルは `test-review-plan-gate.sh` を再帰実行するため TC-14 の意図した FAIL が伝播するのみで、本 cycle の変更が同ファイル自体にリグレッションを起こしたわけではないことを確認
+
+**Test List 遷移**: 本 Cycle doc の Test List（L88-93）は sync-plan 時点で TC-01〜05 の Given/When/Then が RED 期待値込みで記述済み（`## Test List` セクションは APPEND-ONLY のため、既存記述は変更せず現状維持）。実測結果は TC-01「RED 時点で 19 件」の記載に対し実際は 20 件（本 cycle doc 自身を含む）であり、これは KICKOFF Progress Log の実測「19+本 doc」と整合する（記載の "19" は完了済み doc 数の内訳であり、doc 自体の non-DONE カウントは別途 20）。
+
+**次フェーズへの申し送り**: GREEN では (1) `skills/orchestrate/SKILL.md` Block 3 を PLAN REVIEW 設計改訂通りに改訂（pre-commit-gate PASS → phase: DONE 遷移 → COMMIT エントリ → git add & commit の順序）、(2) `rules/state-ownership.md` + mirror の commit 行更新、(3) 完了済み 19 doc の DONE migration、(4) `docs/STATUS.md` カウント更新を実施する。
+
+### 2026-07-06 11:45 - GREEN
+
+**実装（Files to Change 全量、tests/ は変更禁止で不変）**:
+1. `skills/orchestrate/SKILL.md` Block 3 の COMMIT 手順を PLAN REVIEW 設計改訂通りに改訂: `pre-commit-gate（cycle doc 明示指定）PASS → Cycle doc frontmatter を phase: DONE へ遷移（範囲限定編集）+ COMMIT エントリ記録 → git add & commit（PdM 直接実行）`。TC-14 の contiguous phrase `phase: DONE へ遷移` を一字一句含む。行数は改訂前後とも 95 行（1 行の文字数増のみ、行数変化なし）で 100 行制約内
+2. `rules/state-ownership.md` + `.claude/rules/state-ownership.md`（byte-identical mirror）の commit 行を `phase (COMMIT→DONE 終端), updated` に明確化
+3. 完了済み 19 doc の frontmatter migration: Python `re.subn(..., count=1, flags=re.MULTILINE)` で `^phase: (COMMIT|REVIEW)$` → `phase: DONE`、`^updated: .*$` → `updated: 2026-07-06 11:40` を各 doc に適用（全文 str.replace 不使用、doc-mutations 直近 insight 準拠）。対象 19 doc:
+   - 20260421_1809_sync-plan-progress-log-format.md, 20260421_2342_agents-md-count-fix.md, 20260422_0937_advisory-terminology-fix.md, 20260422_1146_codify-insight-skill.md, 20260422_1313_rule-docs-codify-followup.md, 20260423_0926_discovered-followup-mirror-rules.md, 20260423_1045_discovered-cycle2-followup.md, 20260424_0900_integration-verification-rule.md, 20260424_1119_discovered-debt-cleanup.md, 20260424_1356_small-debt-cleanup.md, 20260424_1537_prior-codify-implementation.md, 20260427_0930_pre-existing-fail-cleanup.md, 20260625_1101_rules-path-scoping.md, 20260701_1120_plan-discipline-green-sweep.md, 20260702_1200_skill-inventory-cleanup.md, 20260702_1930_gate-active-cycle-fix.md, 20260703_1215_test-hardening-rule-codify.md, 20260703_1650_parallel-skill-removal.md, 20260703_2035_tracking-label-contract.md
+   - `git diff --stat` 確認: 18 doc は各 4 行変更（phase 1 行 + updated 1 行の unified diff、-2/+2）。`20260703_2035_tracking-label-contract.md` のみ 27 行変更と表示されるが、内訳を `git diff` で確認した結果、本 GREEN が touch したのは frontmatter の `phase`/`updated` 2 行のみで、残り（`retro_status: captured→resolved` + `## Codify Decisions` セクション追記）は KICKOFF Progress Log 記載の「作業ツリーに未 staged 変更あり（前 cycle の codify gate 処理結果）」として本 GREEN 開始前から存在した pre-existing 変更であることを確認（scope 外、変更せず維持）
+4. `docs/STATUS.md`: `Done (unarchived) | 43` → `| 62 |`、`Last updated: 2026-07-03` → `2026-07-06`、Completed (Recent) 先頭に `2026-07-06 | 20260706_1020: phase-lifecycle-completion-gate (commit 時 DONE 遷移の orchestrate 整合 + 19 doc migration、#147) | fix` を追加
+
+**GREEN 確認（個別実行、全結果）**:
+- `bash tests/test-review-plan-gate.sh` → rc=0、PASS: 14 / FAIL: 0（TC-14 含め全 PASS）
+- `bash tests/test-rules-mirror.sh` → rc=0、PASS: 3 / FAIL: 0
+- TC-18 相当の直接検査 `for f in docs/cycles/*.md; do awk ...; done | wc -l` → **1**（本 cycle doc のみ、非 DONE）
+- `bash tests/test-doc-consistency.sh` → rc=0、PASS: 12 / FAIL: 0（TC-18: non-DONE count=1 <= 1、63 docs checked）
+- `bash tests/test-cross-references.sh` → rc=0、PASS: 6 / FAIL: 0
+- `bash tests/test-cycle-doc-ssot.sh` → rc=0、PASS: 5 / FAIL: 0
+- `bash tests/test-orchestrate-compact.sh` → rc=0、PASS: 17 / FAIL: 0（TC-13: SKILL.md 95 行 <= 100 を含む）
+- `wc -l skills/orchestrate/SKILL.md` → 95（制約 100 以内）
+
+**validate-cycle-frontmatter.sh 19 doc sweep — 16/19 rc=0、3 件 pre-existing FAIL（本 cycle の migration とは無関係）**:
+- rc=1: `20260424_1537_prior-codify-implementation.md`（`ERROR: state-like metadata in body: 'retro_status:'`）
+- rc=1: `20260625_1101_rules-path-scoping.md`（`ERROR: invalid risk_level value: 'LOW'`）
+- rc=1: `20260701_1120_plan-discipline-green-sweep.md`（`ERROR: invalid complexity value: 'simple'` + `ERROR: invalid risk_level value: 'LOW'`）
+- 切り分け: `git show HEAD:<path>` で本 cycle 着手前の committed 版を取得し同 validator を実行した結果、3 件とも同一エラーが HEAD 時点で既に発生することを確認（本 GREEN の phase/updated 変更が原因ではない、真の pre-existing FAIL）。該当フィールド（retro_status in body / risk_level / complexity）は本 cycle の Files to Change・scope に含まれず、また対象 doc の frontmatter 範囲限定編集は phase/updated のみに限定する契約のため、本 cycle では修正せず DISCOVERED として申し送る
+
+**申し送り（DISCOVERED 候補、Block 2e で起票判断）**: 上記 3 doc の pre-existing frontmatter validator FAIL（retro_status がbody に混入 / risk_level・complexity の不正値）は本 cycle の scope 外だが、`validate-cycle-frontmatter.sh` を CI 相当で全 doc に回す場合に顕在化する。別 cycle での修正を推奨。
+
+**次フェーズへの申し送り**: REFACTOR/REVIEW へ進む。Verification セクションの (5) full suite snapshot baseline 比較は REFACTOR 前の最終確認として実施予定。
+### 2026-07-06 12:10 - REFACTOR (PdM 検証)
+- doc/rule/migration のみの cycle のため構造的リファクタ不要（no-op）
+- Verification Gate: review-plan-gate 14/14 / rules-mirror / orchestrate-compact / cycle-doc-ssot 全 rc=0（doc-consistency は nested runner のため green-worker の rc=0 記録を採用、full suite は VERIFY で全量実行）、orchestrate SKILL.md 95 行（≤100）
+- GREEN の DISCOVERED 申し送り（validator pre-existing FAIL 3 件、HEAD 既発生を git show で確認済み）は Block 2e で起票
+- Phase completed
+### 2026-07-06 12:40 - VERIFY (Product Verification, Block 2c.5)
+- Evidence: /tmp/dev-crew-verify-20260706_1020/verify.log
+- 単体: review-plan-gate（14/14）/ rules-mirror rc=0
+- TC-18 相当: **non-DONE = 1（本 cycle doc のみ）** — migration 完了の実証
+- real-path: gate dir mode が唯一の non-DONE = 本 cycle doc を正しく選択（#145→#147 で目指した「non-DONE = active」の意味論修復を end-to-end で実証）
+- **full suite: 112/112 全 rc=0、baseline-lifecycle.txt との diff 空 = 回帰ゼロ**
+- validator 全 doc sweep: **pre-existing INVALID 15 件を検出**（legacy 形式: risk_level 大文字 / complexity 旧値 / body 内 state 文字列等。全て HEAD 既発生・本 cycle の migration 対象フィールド外）→ Block 2e で起票
+- Phase completed
+
+### 2026-07-06 13:10 - REVIEW FIX (green-worker)
+
+**契機**: REVIEW で Socrates BLOCK。teams モードの Block 3 に DONE 遷移が未伝播（raw `git add`/`git commit` のまま）、かつ SKILL.md の inline 記述が steps-subagent.md / steps-codex.md の既存委譲方式（`Skill(dev-crew:commit)`）と矛盾していたため、単一責務化（commit skill への委譲統一）を実施。GREEN 再実行 1 回目。
+
+**red-first（Fix 3 拡張契約を先に導入し FAIL を実証）**:
+- `tests/test-review-plan-gate.sh` の TC-14 を単一 assert から TC-14a/b/c の 3 assert に拡張:
+  - TC-14a: SKILL.md Block 3 に `phase: DONE へ遷移` **かつ** `Skill(dev-crew:commit)` の両方が存在すること
+  - TC-14b: steps-teams.md の COMMIT section（`awk '/^### COMMIT/,/^### Auto-Learn/'` で区間抽出）に `Skill(dev-crew:commit)` または `phase: DONE へ遷移` のいずれかが存在すること
+  - TC-14c: steps-subagent.md / steps-codex.md の Block 3 section（`awk '/^## Block 3/,/^## Fallback/'`）に `Skill(dev-crew:commit)` が存在すること（既存委譲方式の回帰 pin）
+- 拡張直後（Fix 1/2 適用前）に実行 → `bash tests/test-review-plan-gate.sh` rc≠0（pipe経由のため rc は別途 FAIL 件数で確認）、**PASS: 14 / FAIL: 2 / TOTAL: 16**。TC-14a FAIL（SKILL.md に `Skill(dev-crew:commit)` 未記載）、TC-14b FAIL（steps-teams.md が raw git commit のまま）、TC-14c は既存委譲方式のため PASS（想定通りの red 状態、fix 前に既に正しい部分の回帰 pin が機能することを確認）
+
+**Fix 1 適用（skills/orchestrate/SKILL.md Block 3）**:
+- 変更前: `pre-commit-gate（cycle doc 明示指定）PASS → Cycle doc frontmatter を phase: DONE へ遷移（範囲限定編集）+ COMMIT エントリ記録 → git add & commit（PdM 直接実行）`
+- 変更後: `` pre-commit-gate（cycle doc 明示指定）PASS → `Skill(dev-crew:commit)` へ委譲（commit skill Step 3 が Cycle doc を phase: DONE へ遷移させてから git add & commit） ``
+- 「PdM 直接実行」の文言を削除し、steps-subagent.md / steps-codex.md の委譲方式と整合。TC-14a の literal `phase: DONE へ遷移` は保持。`wc -l` で改訂前後とも 95 行（100 行制約内）を確認
+
+**Fix 2 適用（skills/orchestrate/steps-teams.md L304-312 COMMIT section）**:
+- 変更前: `PdM (Lead) が直接実行:` + raw `git add <files>` / `git commit -m "..."` コードブロック
+- 変更後: `Skill(dev-crew:commit)` への委譲 + `→ commit skill Step 3 が Cycle doc frontmatter を phase: DONE へ遷移させてから git add & commit` のコメント行。steps-subagent.md L231 / steps-codex.md L170 の既存委譲記述と文体を統一
+
+**Fix 適用後の確認（個別実行、全 PASS）**:
+- `bash tests/test-review-plan-gate.sh` → rc=0、**PASS: 16 / FAIL: 0 / TOTAL: 16**（TC-14a/b/c 全 PASS）
+- `bash tests/test-orchestrate-compact.sh` → rc=0、PASS: 17 / FAIL: 0（TC-13: SKILL.md 95 行 <=100 含む）
+- `bash tests/test-rules-mirror.sh` → rc=0、PASS: 3 / FAIL: 0
+- `bash tests/test-doc-consistency.sh`（full nested runner 経由）→ rc=0、PASS: 12 / FAIL: 0（TC-13: 全既存テスト PASS の回帰確認含む）
+- `wc -l skills/orchestrate/SKILL.md` → 95（≤100 維持）
+- `grep -n "PdM 直接実行" skills/orchestrate/SKILL.md` → 0 件（Block 3 から削除済みを確認）
+
+**適用外（PdM 判断、green-worker はそのまま維持）**:
+- Socrates WARN 2（DONE 遷移後 commit 失敗時の復旧穴）は commit skill 側に元から存在する対称的な穴であり本 cycle 起因でないため、DISCOVERED 起票は PdM が Block 2e で実施
+- maint #1（Block 3 詳細の reference.md 逃し）は Fix 1 の委譲化で記述が 1 行に短縮され実質解消
+- maint #4（workflow/architecture 図の DONE 未反映）は DISCOVERED として PdM が判断
+
+**次フェーズへの申し送り**: REVIEW 再実行へ。Fix 1/2/3 適用後の全確認 PASS 済み。
+- Phase completed
+### 2026-07-06 13:30 - REVIEW (Socrates adversarial + 3 Claude reviewers — Codex 不在 fallback)
+- 判定: Socrates **BLOCK 1 + WARN 2** / correctness **PASS**（fixture 実証・migration 純度 19/19）/ security **PASS**（旧 Block 3 の gate 暗黙スキップを本 diff が埋める「改善方向」評価）/ maintainability **PASS**（defer 2）
+- triage:
+  - **Socrates BLOCK（accept-apply）**: 修正が steps-teams.md に未伝播で teams モード（本セッションの実行モード）に元バグが残存 + SKILL.md inline 記述が steps-subagent/codex の委譲方式と矛盾。plan-discipline 既存 rule（SKILL.md + steps-* の DRY sweep、cycle 20260424_0900 #3）を PdM が怠った再発。→ **全モード commit skill 委譲に統一**（SKILL.md Block 3 委譲化 + steps-teams.md 委譲化 + TC-14 を 14a/b/c の全モード契約に拡張、red-first で 2 FAIL → 修正 → 16/16 PASS）
+  - Socrates WARN 2（DONE 遷移後 commit 失敗の復旧穴、pre-existing）→ **accept-defer**: issue #158
+  - maint #4（workflow/architecture 図の DONE 未反映）→ **accept-defer**: issue #157
+  - maint #1（Block 3 詳細の reference 逃し）→ 委譲化で記述が短縮され実質解消
+  - VERIFY の validator legacy INVALID 15 件 → **accept-defer**: issue #156
+  - Socrates 指摘 5（起票実体の未確認）→ 本エントリで解消（#156/#157/#158 起票済み）
+- 適用後: review-plan-gate 16/16 / orchestrate-compact 17/17 / rules-mirror 3/3 全 rc=0、「PdM 直接実行」残存 0 件
+- Phase completed
+
+### 2026-07-06 13:32 - DISCOVERED (Block 2e)
+- D1: validator legacy INVALID 15 件の正規化 → issue #156
+- D2: workflow/architecture 図の DONE 終端反映 + doc 一貫性 sweep → issue #157
+- D3: commit skill の DONE 遷移後 commit 失敗の復旧手順 → issue #158
+
+## Retrospective
+
+抽出時刻: 2026-07-06 13:50
+抽出方法: Cycle doc 全体（Socrates plan BLOCK 2 / code BLOCK 1 / 設計転換）からの失敗→最終解→insight ペア抽出
+
+### Insight 1: 「X が未定義」という plan 前提は、定義があるべき場所を全 grep + 発生機序を 1 件実測してから書く
+- **Failure**: plan の中核前提「COMMIT→DONE 遷移の責務が未定義」が虚偽だった（skills/commit/SKILL.md Step 3 に定義済み）。真因は orchestrate Block 3 の「PdM 直接実行」が commit skill をバイパスしていたことで、前提の誤りのまま Block 0 に第二の所有者を新設する設計を approve まで通した。Socrates が commit skill の実測で反証
+- **Final fix**: ユーザー確認の上で設計転換（Block 3 の委譲化 = バイパスの解消そのもの）
+- **Insight**: **「〜が未定義/存在しない」という否定形の plan 前提は、定義があるべき場所（skill/rule/steps/reference）の全 grep 結果を根拠として plan に貼付してから書く。加えて「なぜ現状が壊れているか」の発生機序を 1 件実測特定せずに対策を設計しない** — 機序未診断の対策は症状への回避策になる
+- **一般化**: plan-discipline.md「未確認での Problem 記述禁止」の否定形前提版。adversarial reviewer が最も価値を出すのはこの種の前提反証
+
+### Insight 2: multi-mode skill の変更は全モード doc を契約テストで pin する
+- **Failure**: Block 3 の修正を SKILL.md にのみ適用し、steps-teams.md（まさに本セッションの実行モード）に元バグが残存。plan-discipline に codified 済みの「SKILL.md + steps-* の DRY sweep」rule（cycle 20260424_0900 #3）を PdM が適用し忘れ — 「rule 参照済 ≠ rule 適用済」の再演。Socrates code review が 4 文書突き合わせで検出
+- **Final fix**: 全モード commit skill 委譲に統一 + TC-14 を 14a/b/c（SKILL.md / steps-teams / steps-subagent+codex）の全モード契約に拡張（red-first）
+- **Insight**: **multi-mode skill（SKILL.md + steps-*.md）への動作変更は、変更点をモード別 doc 全てに対する契約テストで pin する（今回の TC-14a/b/c 型）**。rule 文書による注意喚起は 2 度破られた — 契約テスト化が唯一の恒久防御（2-strike rule の適用事例）
+- **一般化**: TC-14a/b/c が同期契約の実装例として今後の multi-mode 変更の template になる
+
+### 成功事例（observation）: Socrates fallback が Codex 不在を完全に代替した
+- Codex CLI 破損時の fallback として起動した Socrates が、plan review で中核前提の反証（BLOCK 2 件）、code review でモード伝播漏れ（BLOCK 1 件）を検出。いずれも実測根拠付きで正当。実装に関与しない adversarial reviewer の「前提を疑う」役割は、実装 competitive review（Codex）と異なる互補的な検出面を持つ。Codex 復旧後も高リスク cycle では併用の価値がある
+### 2026-07-06 14:10 - COMMIT
+- 最終 full suite: 112/112 全 rc=0、baseline-lifecycle.txt との diff 空（回帰ゼロ）
+- pre-commit-gate（明示指定）PASS → **commit skill 経由で phase: DONE へ遷移してから commit（新 Block 3 手順の初 self-apply）** — 本 doc が「commit 時点で DONE」となる最初の cycle doc
+- Phase completed
+

--- a/rules/state-ownership.md
+++ b/rules/state-ownership.md
@@ -31,4 +31,4 @@ Cycle doc records what was done; source files define what is.
 | green | phase, updated |
 | refactor | phase, updated |
 | review | Body log only (no frontmatter changes except phase, updated) |
-| commit | phase, updated |
+| commit | phase (COMMIT→DONE 終端), updated |

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -85,7 +85,7 @@ Skill(dev-crew:cycle-retrospective): 失敗-成功 insight 抽出、retro_status
 
 ### Block 3: Finalization
 
-1. **COMMIT**: git add & commit（PdM 直接実行）
+1. **COMMIT**: pre-commit-gate（cycle doc 明示指定）PASS → `Skill(dev-crew:commit)` へ委譲（commit skill Step 3 が Cycle doc を phase: DONE へ遷移させてから git add & commit）
 2. **完了報告**: サイクル完了をユーザーに報告
 
 ## Mode Selection

--- a/skills/orchestrate/steps-teams.md
+++ b/skills/orchestrate/steps-teams.md
@@ -305,11 +305,9 @@ Skill(dev-crew:cycle-retrospective)
 
 ### COMMIT
 
-PdM (Lead) が直接実行:
-
 ```
-git add <files>
-git commit -m "..."
+Skill(dev-crew:commit)
+→ commit skill Step 3 が Cycle doc frontmatter を phase: DONE へ遷移させてから git add & commit
 ```
 
 ### Auto-Learn (COMMIT 後)

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -220,6 +220,43 @@ else
 fi
 
 ########################################
+# Cycle Doc Phase Lifecycle (completion invariant)
+########################################
+
+echo ""
+echo "--- Cycle Doc Phase Lifecycle ---"
+
+# TC-18: live docs/cycles/*.md（非再帰 glob のため archive/ は自動除外）の frontmatter phase を
+# awk 区間抽出で判定し、DONE でない doc が定常状態で最大 1 件（進行中 cycle）であることを保証する
+# 逆向き契約。phase フィールド自体が無い旧形式 doc は集計対象外（既存 gate と同じ扱い）。
+# glob 0 件は前提破綻のため FAIL 扱い（rules/test-patterns.md nullglob 方式、直前の契約踏襲）。
+echo ""
+echo "TC-18: live docs/cycles/ non-DONE doc count <= 1"
+shopt -s nullglob
+CYCLE_DOCS=("$BASE_DIR"/docs/cycles/*.md)
+shopt -u nullglob
+CYCLE_DOC_COUNT=${#CYCLE_DOCS[@]}
+if [ "$CYCLE_DOC_COUNT" -eq 0 ]; then
+  fail "TC-18: docs/cycles/*.md glob matched 0 files — glob likely failed, cannot verify invariant"
+else
+  NON_DONE_DOCS=()
+  for f in "${CYCLE_DOCS[@]}"; do
+    fm=$(awk '/^---$/{c++;next} c==1{print}' "$f")
+    phase_line=$(echo "$fm" | grep '^phase:' || true)
+    [ -z "$phase_line" ] && continue
+    echo "$phase_line" | grep -q 'DONE' && continue
+    NON_DONE_DOCS+=("$f")
+  done
+  NON_DONE_COUNT=${#NON_DONE_DOCS[@]}
+  if [ "$NON_DONE_COUNT" -le 1 ]; then
+    pass "TC-18: non-DONE doc count ($NON_DONE_COUNT) <= 1 ($CYCLE_DOC_COUNT docs checked)"
+  else
+    fail "TC-18: non-DONE doc count ($NON_DONE_COUNT) > 1"
+    printf '%s\n' "${NON_DONE_DOCS[@]}"
+  fi
+fi
+
+########################################
 # Regression
 ########################################
 

--- a/tests/test-review-plan-gate.sh
+++ b/tests/test-review-plan-gate.sh
@@ -190,6 +190,50 @@ else
   fi
 fi
 
+########################################
+# Block 3: COMMIT time DONE transition (commit skill 契約整合、全モード)
+########################################
+
+echo ""
+echo "--- Block 3: COMMIT time DONE transition (all modes) ---"
+
+# TC-14: orchestrate 全モード（SKILL.md / steps-teams.md / steps-subagent.md / steps-codex.md）の
+# Block 3 が commit skill への委譲（Skill(dev-crew:commit)）または Cycle doc frontmatter の
+# DONE 遷移（phase: DONE へ遷移）を明記していることを contiguous phrase で pin する。
+# commit skill 側の既存契約（phase: DONE、skills/commit/SKILL.md Step 3）に orchestrate 側の
+# 全モードの Block 3 記述を整合させる（teams モードのみ raw git commit が残存していた不整合の是正）
+STEPS_CODEX="$BASE_DIR/skills/orchestrate/steps-codex.md"
+[ -f "$STEPS_CODEX" ] || { echo "FATAL: $STEPS_CODEX not found"; exit 1; }
+
+block3_section=$(awk '/^### Block 3/,/^## /' "$ORCH_SKILL" 2>/dev/null || true)
+teams_commit_section=$(awk '/^### COMMIT/,/^### Auto-Learn/' "$ORCH_TEAMS" 2>/dev/null || true)
+subagent_block3=$(awk '/^## Block 3/,/^## Fallback/' "$ORCH_SUB" 2>/dev/null || true)
+codex_block3=$(awk '/^## Block 3/,/^## Fallback/' "$STEPS_CODEX" 2>/dev/null || true)
+
+echo ""
+echo "TC-14a: SKILL.md Block 3 describes phase: DONE transition + commit skill delegation"
+if echo "$block3_section" | grep -q "phase: DONE へ遷移" && echo "$block3_section" | grep -qF "Skill(dev-crew:commit)"; then
+  pass "TC-14a: SKILL.md Block 3 describes phase: DONE transition + delegation"
+else
+  fail "TC-14a: SKILL.md Block 3 missing phase: DONE transition and/or Skill(dev-crew:commit) delegation"
+fi
+
+echo ""
+echo "TC-14b: steps-teams.md COMMIT section delegates to commit skill or describes DONE transition"
+if echo "$teams_commit_section" | grep -qF "Skill(dev-crew:commit)" || echo "$teams_commit_section" | grep -q "phase: DONE へ遷移"; then
+  pass "TC-14b: steps-teams.md COMMIT section delegates or describes DONE transition"
+else
+  fail "TC-14b: steps-teams.md COMMIT section still uses raw git commit without delegation"
+fi
+
+echo ""
+echo "TC-14c: steps-subagent.md / steps-codex.md Block 3 use Skill(dev-crew:commit) (regression pin)"
+if echo "$subagent_block3" | grep -qF "Skill(dev-crew:commit)" && echo "$codex_block3" | grep -qF "Skill(dev-crew:commit)"; then
+  pass "TC-14c: steps-subagent.md and steps-codex.md Block 3 use Skill(dev-crew:commit)"
+else
+  fail "TC-14c: steps-subagent.md and/or steps-codex.md Block 3 missing Skill(dev-crew:commit)"
+fi
+
 # Summary
 echo ""
 echo "=== Summary ==="


### PR DESCRIPTION
## Summary
- **滞留の真因修正**（closes #147）: orchestrate Block 3 / steps-teams.md の直接 commit が commit skill Step 3（phase: DONE 遷移）をバイパス → 全モードを `Skill(dev-crew:commit)` 委譲に統一（単一責務）
- 完了済み 19 doc を DONE へ migration、STATUS.md Done 43→62
- **TC-18**: non-DONE ≤ 1 invariant / **TC-14a/b/c**: 全モード doc の契約 pin（伝播漏れ再発防止）

## Review（Codex 破損につき Socrates fallback + 3 Claude reviewer）
- Socrates が 2 段階で本質的 BLOCK: (1) plan の中核前提「責務未定義」を commit skill Step 3 の実測で反証 → ユーザー承認の設計転換、(2) 修正の teams モード未伝播（plan-discipline 既存 rule の適用漏れ）→ 全モード委譲化 + 契約テスト拡張
- correctness / security / maintainability: PASS（migration 純度 19/19、gate 順序の fail-safe 確認済み）

## Verification
- full suite **112/112 rc=0**、snapshot baseline diff 空
- 意味論修復の実証: gate dir mode が「唯一の non-DONE = 本 cycle doc」を選択
- **本 PR の commit 自身が新手順（commit 時 DONE 化）の初適用** — cycle doc は phase: DONE で commit されている

## DISCOVERED
#156（validator legacy 15 件）/ #157（workflow/architecture 図の DONE 反映）/ #158（DONE 遷移後 commit 失敗の復旧手順）

🤖 Generated with [Claude Code](https://claude.com/claude-code)