### PR TITLE
chore: release v2.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "dev-crew",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "source": "./",
       "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-crew",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction.",
   "author": {
     "name": "morodomi"


### PR DESCRIPTION
Version bump to 2.11.0

スキル棚卸し（32→28）+ gate 修復 + 品質規律の自動契約化。詳細は CHANGELOG [2.11.0] 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)