### PR TITLE
chore: release v2.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "dev-crew",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "source": "./",
       "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-crew",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction.",
   "author": {
     "name": "morodomi"


### PR DESCRIPTION
Version bump to 2.12.0（marketplace.json + plugin.json）。CHANGELOG [2.12.0] / ROADMAP は #174 でマージ済み。