### PR TITLE
docs: 文書ドリフト解消 — stale hook 記述・外部サポート文言・ROADMAP 現在地 + 再発ガード TC 3件

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Cycle docs: `docs/cycles/YYYYMMDD_HHMM_<topic>.md`
 
 ### Post-Approve Action
 
-Plan mode を抜けたら `/orchestrate` を起動する。Edit/Write は hook でブロックされる。
+Plan mode を抜けたら `/orchestrate` を起動する。Edit/Write は直接行わず、必ず /orchestrate に委譲する（プロンプトベースの規律。hook による強制ブロックではない）。
 
 ## Quality Standards
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dev-crew
 
-> **Not Maintained.** This repository is published as-is for reference. No issues, PRs, or feature requests will be addressed.
+> **No external support.** This repository is developed for personal use and published as-is for reference. No issues, PRs, or feature requests will be addressed.
 
 AI development team environment for Claude Code. Install once, use across all projects.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@
 
 ## 現在地
 
-v2.11.0 リリース済み（2026-07-06）。main には v2.12.0（本リリース）向けに4サイクル（#148/#165、codified rule/#166、#164/#169、reviewer-policy v1/#173）が蓄積済み。全完了済みバージョン:
+v2.12.0 リリース済み（2026-07-15）。全完了済みバージョン:
 - v2 (Phase 11-13): Claude + Codex 統合開発フロー
 - v2.4 (Phase 14-17): Review Taxonomy 体系化 (33→40 agents)
 - v2.5 (Phase 18): Constitution-Driven Enforcement
@@ -18,6 +18,7 @@ v2.11.0 リリース済み（2026-07-06）。main には v2.12.0（本リリー�
 - v2.9.0: rules path-scoping (#139)
 - v2.10.0: plan-discipline GREEN 検証の逆向き契約 sweep 規律 (#140)
 - v2.11.0: スキル棚卸し + 品質規律強化 (2026-07-06)
+- v2.12.0: reviewer モデル設定機構 (reviewer-policy v1) + codified rule 群 + gate drift guard + risk-classifier 精度改善 (2026-07-15)
 - v3-pre (Phase 1-8, archive label): Constitution-Driven Development
 
 次候補（v2.12.0 リリース後）: codify 実装2件 / #156 legacy 正規化 / reviewer-policy follow-up #170-172 / #144 flaky / Agile Loop 1.5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-This repository is published as-is for reference and is **not maintained**.
+This repository is published as-is for reference with **no external support**.
 
 - Security vulnerabilities will not be patched.
 - No security advisories will be issued.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,18 +5,19 @@
 | Metric | Value |
 |--------|-------|
 | In-Progress Cycles | 0 |
-| Done (unarchived) | 68 |
+| Done (unarchived) | 69 |
 | Archived Cycles | 37 |
 | Skills | 28 |
 | Agents | 41 |
 | Test Scripts | 113 |
 
-Last updated: 2026-07-15
+Last updated: 2026-07-16
 
 ## Completed (Recent)
 
 | Date | Cycle | Type |
 |------|-------|------|
+| 2026-07-16 | 20260716_1328: doc-drift-fix (stale hook 記述3箇所 + 外部サポート文言 No external support 化 + ROADMAP 現在地 v2.12.0 + 再発ガード TC-07/08/19。#176/#177 起票) | docs |
 | 2026-07-15 | 20260715_1346: v2.12-docs-alignment (CHANGELOG [2.12.0] + ROADMAP 現在地更新 + phase 図 COMMIT→DONE 終端、#157。v2.12.0 リリース準備) | docs |
 | 2026-07-13 | 20260709_1313: reviewer-model-policy-v1 (review_policy で reviewer モデルを設定可能に。self=orchestrator 現モデル明示、HIGH escalation、NON-NEGOTIABLE floor 初契約化) | feat |
 | 2026-07-09 | 20260709_1125: risk-classifier-doc-diff-fix (content signal を code hunk 限定化し doc-diff FP 解消、#164。SIGPIPE bug も修正) | fix |

--- a/docs/cycles/20260715_1346_v2.12-docs-alignment.md
+++ b/docs/cycles/20260715_1346_v2.12-docs-alignment.md
@@ -5,10 +5,10 @@ phase: DONE
 complexity: standard
 test_count: 2
 risk_level: low
-retro_status: captured
+retro_status: resolved
 codex_session_id: "019f641d-8914-76c1-8e68-d0abf37bbdd2"
 created: 2026-07-15 13:46
-updated: 2026-07-15 14:29
+updated: 2026-07-16 13:26
 ---
 
 # v2.12.0 リリース準備: docs 整合（CHANGELOG + ROADMAP + #157 phase 図 DONE 終端）
@@ -257,3 +257,30 @@ grep -c "DONE" docs/workflow.md docs/architecture.md   # 各 >=1 期待
 - #157 close。feature branch → PR → --admin merge
 - **本 cycle merge 後、release-skill で v2.12.0 を切る**（marketplace.json + plugin.json bump + tag）
 - Phase completed
+
+## Codify Decisions
+
+triage 実施: 2026-07-16 13:26（後続 cycle doc-drift-fix の orchestrate Block 0 codify gate で処理）。recurrence pre-triage による autonomous triage、質問 0 件。実装は次の codify 実装 cycle。
+
+### Insight 1（図/フローの構造契約 TC は特異ノードトークン + 隣接ノード位置で pin する）
+- **Decision**: codified
+- **Destination**: rule (rules/test-patterns.md + .claude/rules/ mirror)
+- **Reason**: 「pin は実体を狙う」family の3回目再発（20260701_1120 #1 contiguous phrase / 20260703_2035 #2 section_grep fixed-string / 本件 diagram ノードトークン）→ pre-triage の 2+ 再発基準で自動昇格。散文にも現れる部分文字列（DONE 等）での grep は偽 PASS する実害 evidence（#157 TC が plan/code review で2度指摘）あり。追記内容: (a) diagram/flow/table の契約 TC は実ノードのトークン（`DONE (cycle` 等）で grep、(b) 隣接ノードとの行位置関係を pin
+- **Decided**: 2026-07-16 13:26
+
+### Insight 2（「現在地/current state」節の更新は doc 全体を旧状態記述で sweep してから閉じる）
+- **Decision**: codified
+- **Destination**: rule (rules/doc-mutations.md + .claude/rules/ mirror)
+- **Reason**: 2回目の再発を実測確認 — 本 insight の元 failure（ROADMAP 現在地更新時に下部節の旧状態記述を放置）に加え、後続 cycle doc-drift-fix の spec 探索（2026-07-16）で ROADMAP 現在地が再び stale（v2.12.0 リリース済みなのに「本リリース向けに蓄積済み」のまま）と判明。2-strike rule（20260703_1215 #2）により自動昇格。追記内容: current-state 節の更新は同 doc 内の他節（release 計画・残タスク・schedule）を grep sweep し全節整合させてから閉じる。frontmatter 区間限定編集（doc-mutations #1）の narrative 版
+- **Decided**: 2026-07-16 13:26
+
+### 成功事例（observation: doc-only cycle でも adversarial review が 8 findings を捕捉）
+- **Decision**: no-codify
+- **Reason**: 既存 competitive review pipeline の追認（Retrospective 内で no-codify と明記済み）。新規 rule 化は不要
+- **Decided**: 2026-07-16 13:26
+
+### Addendum to Insight 2（2026-07-16 14:40、後続 cycle doc-drift-fix の code review Codex WARN を受けた訂正）
+
+- **訂正**: Reason に記載した「2回目の再発を実測確認」は撤回する。本 Insight の元 failure は「現在地更新時に同 doc 内他節の sweep 漏れ」（update-triggered・intra-doc）だが、doc-drift-fix cycle で発見された ROADMAP 現在地 stale は「リリースイベント時に ROADMAP を更新するプロセス自体が存在しない」（process gap・更新が起動されない）であり発生機序が異なる。whole-doc sweep 規則は後者を防げない
+- **Decision への影響**: codified は維持。autonomous triage の「次 cycle の TDD をすぐ harden できる」基準により、元 failure 単独で rule 化は成立する（2-strike は不要な過剰根拠だった）
+- **新機序の扱い**: リリース時同期契約（例: ROADMAP 現在地の版数を .claude-plugin/plugin.json の version と突合する契約テスト、または release-skill への ROADMAP 更新 step 追加）は doc-drift-fix cycle の DISCOVERED として別途起票

--- a/docs/cycles/20260716_1328_doc-drift-fix.md
+++ b/docs/cycles/20260716_1328_doc-drift-fix.md
@@ -1,0 +1,352 @@
+---
+feature: doc-drift-fix
+cycle: 20260716_1328
+phase: DONE
+complexity: standard
+test_count: 3
+risk_level: low
+retro_status: captured
+codex_session_id: "019f6935-a649-7452-8ee2-c6f5db13c062"
+created: 2026-07-16 13:28
+updated: 2026-07-16 14:51
+---
+
+# doc-drift-fix — stale hook 記述・外部サポート文言・ROADMAP 現在地のドリフト解消
+
+## Scope Definition
+
+### In Scope
+- [ ] AGENTS.md L40 の stale hook 記述を修正
+- [ ] skills/spec/reference.md L494 の stale hook 記述を修正
+- [ ] skills/onboard/reference.md L429 の stale hook 記述を修正
+- [ ] tests/test-post-approve-ordering.sh L2-3 のヘッダコメントを assert 実態に一致させる
+- [ ] README.md L3 の「Not Maintained」文言を「No external support」に修正
+- [ ] SECURITY.md の「not maintained」文言を「no external support」系に修正
+- [ ] ROADMAP.md 現在地を v2.12.0 リリース済みに更新
+- [ ] tests/test-post-approve-gate-removal.sh へ TC-07/TC-08 追加（ヘッダの TC 一覧も更新）
+- [ ] tests/test-doc-consistency.sh へ TC-16 追加（サポート文言ガード）
+
+### Out of Scope
+- 承認と plan-review の順序変更（approval-reorder）(Reason: 別 cycle で実施。本 cycle は文書修正のみ)
+
+### Files to Change (target: 10 or less)
+1. `AGENTS.md` L40 — 「Edit/Write は hook でブロックされる」→「Edit/Write は直接行わず /orchestrate に委譲する（プロンプトベースの規律。hook による強制ブロックではない）」（Holdings 側 AGENTS.md の既存表現と統一）
+2. `skills/spec/reference.md` L494 — 同趣旨に置換（plan テンプレート内の文。post-approve-gate.sh への言及を除去）
+3. `skills/onboard/reference.md` L429 — 同趣旨に置換
+4. `tests/test-post-approve-ordering.sh` L2-3 — ヘッダコメントを assert 実態に一致させる: 「sync-plan (Cycle doc) MUST come before plan review (v2.8 orchestrate integration)」
+5. `README.md` L3 — 「**No external support.** This repository is developed for personal use and published as-is for reference. No issues, PRs, or feature requests will be addressed.」
+6. `SECURITY.md` — 「not maintained」→「no external support」系へ。外部報告は triage しない・advisory は出さない、の2点は維持
+7. `ROADMAP.md` 現在地 — 先頭文を「v2.12.0 リリース済み（2026-07-15）」に更新し、全完了済みバージョン一覧へ v2.12.0 を追加（「本リリース向けに蓄積済み」の記述を除去）
+8. `tests/test-post-approve-gate-removal.sh` — ドリフト再発ガード TC-07/TC-08 追加（ヘッダの TC 一覧も更新）
+9. `tests/test-doc-consistency.sh` — TC-16 追加（サポート文言ガード）
+
+※ 5-7 は当初合意 scope 外から探索で発見した同種ドリフト。AskUserQuestion は無応答（AFK）のため推奨案で plan に含めた。承認時に除外可。
+※ 新規テストファイルなし → STATUS.md の Test Scripts=113 は不変。
+
+## Environment
+
+### Scope
+- Layer: Docs / Tests (実装コードなし)
+- Plugin: bash (dev-crew tests/*.sh)
+- Risk: low（docs + test のみ。認証・決済・外部 API なし。Risk Score: PASS 帯）
+
+### Runtime
+- Language: bash 3.2+ (macOS zsh)
+
+### Dependencies (key packages)
+- なし（純粋な docs/test 修正）
+
+### Risk Interview (BLOCK only)
+- 該当なし（risk_level: low、BLOCK 帯ではないためインタビュー不要）
+
+## Context & Dependencies
+
+### Reference Documents
+- `AGENTS.md` L40 — stale hook 記述の修正対象
+- `skills/spec/reference.md` L494 — stale hook 記述の修正対象
+- `skills/onboard/reference.md` L423-433 — stale hook 記述の修正対象
+- `tests/test-post-approve-ordering.sh` L1-60 — ヘッダコメントと assert の逆転を修正
+- `README.md` L1-6 — 外部サポート文言の修正対象
+- `SECURITY.md` L1-10 — 外部サポート文言の修正対象
+- `ROADMAP.md` L1-20 — 現在地 stale 記述の修正対象
+- `.claude/rules/doc-mutations.md` — 歴史的記録（ROADMAP.md L14 / CHANGELOG.md 等）は APPEND-ONLY 契約により除外対象と判断する根拠
+
+### Dependent Features
+- なし（他フィーチャーへの依存なし。文書修正のみで実装コードへの影響なし）
+
+### Related Issues/PRs
+- 外部レビュー（Codex、2026-07-15〜16 の対話で合意）起点のユーザー指示 cycle。ROADMAP.md 次候補リストには未掲載
+
+## Design Review Gate 結果（architect 実施済み）
+
+- **判定: WARN**（スコア 55/100）
+- 実施内容: AGENTS.md L40, skills/spec/reference.md L494, skills/onboard/reference.md L423-433, tests/test-post-approve-ordering.sh L1-60, README.md L1-6, SECURITY.md L1-10, ROADMAP.md L1-20 を実読し、plan の baseline grep 結果（stale hook 記述3件、Not Maintained系2件）と実ファイル内容が一致することを確認した。tests/test-post-approve-ordering.sh は header comment（L3「Plan review MUST come before Cycle doc」）と実際の assert 実装（sync_line < review_line、つまり sync-plan が先）が矛盾していることを実測確認し、plan の Files to Change #4 の記述の正当性を検証した。
+- **Scope**: Files to Change 9件（<=10 OK）、各項目に具体的な行番号・置換文言が明記されており YAGNI 違反なし。PASS 相当。
+- **Architecture**: Design Approach は具体的（verbatim 置換文言を指定）。既存コードとの整合性は3ファイル実読で確認済み、齟齬なし。PASS 相当。
+- **Test List**: TC-07/TC-08/TC-16 は非空・Given/When/Then 形式で検証可能。ただし Files to Change の #4（test-post-approve-ordering.sh ヘッダコメント修正）と #7（ROADMAP.md 現在地更新）には専用 TC がなく、plan 自身も「テスト対象外のため GREEN で同時適用し REVIEW で検証」と明記している。#7 に至っては Verification セクションの bash ブロックにも ROADMAP.md 用の grep が含まれておらず、自動検証が一切ない。risk_level low・純粋な記述修正のため BLOCK 相当ではないが、REVIEW phase で明示的に diff 差分を確認すべき事項として WARN の根拠とする。
+- **Risk**: risk_level: low の申告は内容（docs + test のみ、認証・決済・外部API非関与）と整合。PASS相当。
+- **総合**: Scope/Architecture/Risk は良好だが Test List のカバレッジ gap（#4, #7 の自動検証欠如）により WARN 判定とした。BLOCK には該当しない（機能的リスクなし、REVIEW phase で人手検証可能な軽微な gap）。
+
+### REVIEW phase 申し送り事項（WARN 由来、必読）
+
+以下2点は自動検証（テスト・grep）が存在しないため、REVIEW phase 担当者は **diff を目視で確認すること**:
+
+1. **Files to Change #4** (`tests/test-post-approve-ordering.sh` L2-3): ヘッダコメント「sync-plan (Cycle doc) MUST come before plan review (v2.8 orchestrate integration)」への置換が verbatim で適用されているか。専用 TC なし。
+2. **Files to Change #7** (`ROADMAP.md` 現在地): 「v2.12.0 リリース済み（2026-07-15）」への更新および完了済みバージョン一覧への v2.12.0 追加、「本リリース向けに蓄積済み」記述の除去。Verification bash ブロックに ROADMAP.md 用の grep が含まれておらず、自動検証が一切ない。
+
+## Baseline 実測（2026-07-16、隔離 snapshot 上）
+
+- 全 113 テスト実行: **113/113 rc=0（ALL PASS）**。evidence: scratchpad/baseline.txt（隔離 snapshot 上で実測、並行プロセスから隔離）
+- 逆向き契約 sweep（grep literal 貼付）:
+
+```
+# 現在形の stale hook 記述（修正対象、3件）
+AGENTS.md:40:Plan mode を抜けたら `/orchestrate` を起動する。Edit/Write は hook でブロックされる。
+skills/spec/reference.md:494:Edit/Write は orchestrate 起動まで hook (post-approve-gate.sh) でブロックされる。
+skills/onboard/reference.md:429:Edit/Write は orchestrate 起動まで hook でブロックされる。
+
+# 外部サポート文言（修正対象、2件）
+README.md:3:> **Not Maintained.** ...
+SECURITY.md:3:... is **not maintained**.
+
+# 歴史的記録（除外。category: historical reference。doc-mutations.md の APPEND-ONLY 契約
+# および「来歴は git log / PR で追える」原則により、廃止イベント自体の記録は正当）
+ROADMAP.md:14 / CHANGELOG.md:111,115 / docs/STATUS.md:39,50,100 /
+docs/archive/roadmap-v2-v3-completed.md:146 の「post-approve-gate廃止」等
+
+# tests/ 内の "post-approve-gate" 言及（除外。category: 不在を assert する逆向き契約そのもの）
+test-post-approve-gate-removal.sh / test-no-verify-guard.sh TC-11 /
+test-plugin-data-paths.sh T-03 / test-orchestrate-a2b.sh
+
+# skills/ 内の "post-approve-gate"（修正で 0 件になる）
+skills/spec/reference.md:494 のみ
+
+# STATUS.md Test Scripts=113 を pin する契約: tests/test-codify-insight.sh TC-19
+# → 本 plan は新規テストファイルを作らない（既存ファイルへ TC 追加）ため 113 のまま。TC-19 影響なし
+```
+
+## Test List
+
+### TODO
+(none)
+
+テスト実装は rules/test-patterns.md 準拠（case-sensitive grep、`grep -E "a|b"` 非エスケープ alternation、rc 直後取得、`|| true` での count 取得）。
+
+### WIP
+(none)
+
+### DISCOVERED
+- approval-reorder cycle（次 cycle、合意済み）→ **issue #176 起票済み**: plan-review を人間承認前へ移動。test-post-approve-ordering.sh の assert 反転・workflow.md・orchestrate SKILL + steps-*.md 3種・rules/post-approve.md の sweep を伴う
+- リリース時 ROADMAP 同期契約（code review Codex WARN 2 起点）→ **issue #177 起票済み**: ROADMAP「現在地」の stale はリリースイベント時に更新プロセスが存在しないことが機序（whole-doc sweep 規則では防げない別クラス）。対策案: ROADMAP 現在地の版数を `.claude-plugin/plugin.json` の version と突合する契約テスト、または release-skill への ROADMAP 更新 step 追加
+
+### DONE
+- [x] TC-07 (test-post-approve-gate-removal.sh): Given post-approve-gate は v2.6.6 で廃止済み / When `docs/cycles/`・`docs/archive/` を除く全 `*.md` を `grep -rE 'hook.*でブロックされる'` で sweep + AGENTS.md/skills/spec/reference.md/skills/onboard/reference.md の「プロンプトベースの規律」存在を検査 / Then stale 0 件・新文言 3 ファイルとも 1 件以上。PASS 確認済み（PLAN REVIEW F2/F4 の superseded 仕様で実装。旧 plan の `grep -rn "hook でブロック|hookでブロック"` パターンは BRE 欠陥のため不採用）
+- [x] TC-08 (test-post-approve-gate-removal.sh): Given 同上 / When `skills/` 配下を `grep -r "post-approve-gate"` で sweep / Then 0 件。PASS 確認済み
+- [x] TC-19 (test-doc-consistency.sh、旧称 TC-16 を supersede — PLAN REVIEW F1 により TC 番号衝突回避のため TC-19 へ変更): Given 本リポジトリは内部開発継続中・外部サポートなし / When README.md と SECURITY.md を `grep -F "Not Maintained"` / `grep -F "not maintained"`（case-sensitive）で検査、README.md に「No external support」・SECURITY.md に「no external support」の存在を検査 / Then stale 0 件・新文言各 1 件以上。PASS 確認済み（PLAN REVIEW F5 の SECURITY.md 置換文確定仕様で実装）
+
+## Implementation Notes
+
+### Goal
+リポジトリの説明文書と実装の乖離（stale hook 記述・外部サポート文言の誤解・ROADMAP 現在地の陳腐化）を解消し、文書が実態を正しく語る状態にする。
+
+### Background
+外部レビュー（Codex、2026-07-15〜16 の対話で合意）により、リポジトリの説明文書と実装の乖離が3クラス確認された:
+
+1. **廃止済み hook の現在形記述**: post-approve-gate.sh / plan-exit-flag.sh は v2.6.6 (cycle dc89b17) で廃止され、`tests/test-post-approve-gate-removal.sh` が不在を保証している。しかし3箇所の文書が「Edit/Write は hook でブロックされる」と現在形で主張しており、実態（プロンプトベースの規律）と矛盾する。
+2. **テストのヘッダコメントと assert の逆転**: `tests/test-post-approve-ordering.sh` はヘッダで「Plan review MUST come before Cycle doc」と書きながら、assert は逆（sync-plan が先）を検証している。v2.8 で順序を反転した際にコメントの更新が漏れた。
+3. **外部サポート文言の誤解**: README「Not Maintained」は活発な内部開発（v2.12.0 を 2026-07-15 リリース）と矛盾して読める。実態は「外部サポートなし」。SECURITY.md にも同種文言。
+
+さらに本 spec の探索で ROADMAP.md「現在地」が stale（v2.12.0 リリース済みなのに「本リリース向けに蓄積済み」のまま）であることを実測確認した。
+
+本 cycle は文書修正のみ。**承認と plan-review の順序変更（approval-reorder）は別 cycle** で行う。
+
+### Design Approach
+Files to Change（上記9件）の各行に verbatim 置換文言を指定し、RED で TC-07/TC-08/TC-16 の FAIL を確認後、GREEN で7ファイルを一括修正して PASS を確認する。コメント逆転修正（#4）と ROADMAP 現在地更新（#7）はテスト対象外のため GREEN で同時適用し、REVIEW phase で diff 目視確認する（上記「REVIEW phase 申し送り事項」参照）。
+
+## Verification
+
+```bash
+bash tests/test-post-approve-gate-removal.sh
+bash tests/test-doc-consistency.sh
+bash tests/test-post-approve-ordering.sh
+bash tests/test-plugin-structure.sh
+grep -rn "hook でブロック\|hookでブロック" --include="*.md" . | grep -v docs/cycles/ | grep -v docs/archive/ || echo "sweep clean"
+grep -rin "not maintained" README.md SECURITY.md || echo "wording clean"
+```
+
+最後に隔離 snapshot 上で全 113 テストを再実行し、baseline との差分ゼロ（修正対象テストの TC 増加のみ）を確認する。
+
+Evidence: (orchestrate が自動記入)
+
+## Progress Log
+
+### 2026-07-16 13:28 - KICKOFF
+- Cycle doc created
+- Scope definition ready
+- Design Review Gate 結果を転記: 判定 WARN、スコア 55/100。根拠: Scope/Architecture/Risk は PASS 相当だが、Test List に Files to Change #4（test-post-approve-ordering.sh ヘッダコメント修正）・#7（ROADMAP.md 現在地更新）に対応する専用 TC が存在せず、#7 は Verification bash ブロックにも grep が含まれず自動検証が皆無。risk_level low かつ機能的リスクなしのため BLOCK には該当しないが、REVIEW phase での diff 目視確認を申し送り事項とした（詳細は上記「REVIEW phase 申し送り事項」参照）
+
+---
+
+## Next Steps
+
+1. [Done] KICKOFF <- Current
+2. [Next] RED
+3. [ ] GREEN
+4. [ ] REFACTOR
+5. [ ] REVIEW
+6. [ ] COMMIT
+7. [ ] DONE
+
+### 2026-07-16 13:39 - PLAN REVIEW (Codex competitive) — BLOCK 3 / WARN 4 / PASS 3、全件 accept-apply で解消
+
+**判定: BLOCK**（codex_session_id: 019f6935-a649-7452-8ee2-c6f5db13c062）。plan は IMMUTABLE のため、以下を本 Cycle doc の superseding correction として記録し SSOT とする（rules/doc-mutations.md 準拠）。全 findings を PdM が実測検証してから裁定（検証 grep は本エントリ内に記載）。
+
+- **F1 BLOCK（TC 番号衝突）**: accept-apply。test-doc-consistency.sh には既に TC-16〜18 が存在（L144/L187 実測確認。ヘッダ L3「TC-01 ~ TC-15」自体が stale — 本 cycle と同種の drift）。**新 TC は TC-19 に変更**し、ヘッダを「TC-01 ~ TC-19」へ更新。本 doc 内の既出「TC-16」言及は全て TC-19 に読み替える（supersede）。test_count: 3 は不変
+- **F2 BLOCK（TC-07 grep パターン欠陥）**: accept-apply（パターンは Codex 案を修正採用）。plan の `grep -rn "hook でブロック|hookでブロック"` は BRE で `|` がリテラル化し、かつ spec/reference.md の「hook (post-approve-gate.sh) でブロックされる」を拾えない（「現状3件」は当該パターンでは 2 件で誤り）。Codex 提案 `Edit/Write.*hook.*ブロック` は**置換後の新文言（…hook による強制ブロックではない）にも match する false positive 欠陥**があるため不採用。**採用パターン: `grep -rE 'hook.*でブロックされる'`** — oracle 実測: 現状 3 件を正確に検出、置換文は rc=1（不一致）。test-patterns.md の ERE 非エスケープ規則にも適合
+- **F3 BLOCK（ordering test の stale コメント残存）**: accept-apply。L3 に加え L48「# TC-01: reference.md - Plan review before Cycle doc」/ L55（TC-02 同様）を実測確認。Files #4 を **L3 + L48 + L55 の3箇所修正**に拡張（ファイル数は不変）
+- **F4 WARN（削除のみで新文言を保証しない）**: accept-apply。TC-07 に positive assert を追加: AGENTS.md / skills/spec/reference.md / skills/onboard/reference.md それぞれに contiguous phrase **「プロンプトベースの規律」** が存在すること（pre-existing count 3 ファイルとも 0 を実測済み — false-pass なし、test-patterns 準拠）
+- **F5 WARN（SECURITY 置換文言未確定 + grep -i 違反）**: accept-apply。SECURITY.md L3 置換文を verbatim 確定: 「This repository is published as-is for reference with **no external support**.」（既存 bullet 2 件「will not be patched」「No security advisories」は無変更で維持 — plan の「triage しない」表現は不正確だったため本記述で supersede）。TC-19 は **case-sensitive** で実施: negative = README.md/SECURITY.md に `Not Maintained` と `not maintained` の両 literal が 0 件、positive = README.md に `No external support`（大文字 N）・SECURITY.md に `no external support`（小文字 n）が各 1 件以上（pre-existing 0 実測済み）
+- **F6 WARN（Verification の ROADMAP 検証欠如 + rc=2 混同）**: accept-apply。Verification を以下で supersede（rc=1 と rc≥2 を区別、ROADMAP/ordering コメントの明示検査を追加）:
+
+```bash
+bash tests/test-post-approve-gate-removal.sh
+bash tests/test-doc-consistency.sh
+bash tests/test-post-approve-ordering.sh
+bash tests/test-plugin-structure.sh
+out=$(grep -rE 'hook.*でブロックされる' --include="*.md" . | grep -v docs/cycles/ | grep -v docs/archive/); rc=$?
+[ "$rc" -eq 1 ] && echo "hook sweep clean" || { echo "hook sweep NG rc=$rc: $out"; }
+grep -F "v2.12.0 リリース済み（2026-07-15）" ROADMAP.md && echo "roadmap head OK"
+c=$(grep -cF "本リリース向けに蓄積済み" ROADMAP.md || true); [ "$c" = "0" ] && echo "roadmap stale phrase gone"
+c=$(grep -cF "Plan review before Cycle doc" tests/test-post-approve-ordering.sh || true); [ "$c" = "0" ] && echo "ordering comments clean"
+c=$(grep -cF "Not Maintained" README.md SECURITY.md | awk -F: '{s+=$2} END{print s}'); [ "$c" = "0" ] && echo "wording clean"
+```
+
+- **F7 WARN（除外根拠のパス誤りと過大主張）**: accept-apply。歴史的記録（ROADMAP/CHANGELOG/STATUS の「post-approve-gate廃止」等）の除外根拠を訂正: 正しくは **plan-discipline.md の「baseline 実測の除外 category 明記」要件に基づく historical reference category としての除外**（来歴は git log / PR で追える原則）。doc-mutations.md の APPEND-ONLY 契約は Cycle doc body 用であり ROADMAP 等の直接根拠ではない。参照パスは `rules/doc-mutations.md`（`.claude/rules/` は mirror）
+- **F8/F9/F10 PASS**: baseline 113/113・前提事実・Version Gate 一致を Codex も追認
+
+**RED への引き渡し（superseded Test List、これを実装契約とする）**:
+- **TC-07** (test-post-approve-gate-removal.sh): negative = `grep -rE 'hook.*でブロックされる'` が docs/cycles/・docs/archive/ 除外で 0 件（現状 3 件で FAIL）。positive = AGENTS.md / skills/spec/reference.md / skills/onboard/reference.md に「プロンプトベースの規律」が各 1 件以上（現状 0 で FAIL）
+- **TC-08** (test-post-approve-gate-removal.sh): `grep -r "post-approve-gate" skills/` が 0 件（現状 1 件で FAIL）
+- **TC-19** (test-doc-consistency.sh、旧称 TC-16 を supersede): negative = README.md/SECURITY.md に `Not Maintained`・`not maintained` が 0 件（現状 各1 で FAIL）。positive = README.md に `No external support`・SECURITY.md に `no external support` が各 1 件以上（現状 0 で FAIL）。ヘッダ L3 を「TC-01 ~ TC-19」へ更新
+
+**判定: BLOCK 全解消（correction 記録済み）。Block 2a (RED) へ。**
+
+### 2026-07-16 13:48 - RED
+
+superseded Test List（PLAN REVIEW エントリの TC-07/TC-08/TC-19、旧 TC-16 は TC-19 に読み替え）に基づき、担当2ファイルへテストを追加。
+
+**追加 TC**:
+- TC-07 (`tests/test-post-approve-gate-removal.sh`): negative = `grep -rE 'hook.*でブロックされる'` を `--include="*.md"` で `docs/cycles/`・`docs/archive/` 除外の全リポジトリ sweep → 0 件を assert。positive = AGENTS.md / skills/spec/reference.md / skills/onboard/reference.md それぞれに「プロンプトベースの規律」が1件以上存在することを assert
+- TC-08 (`tests/test-post-approve-gate-removal.sh`): `grep -r "post-approve-gate" skills/` が 0 件を assert
+- TC-19 (`tests/test-doc-consistency.sh`、旧称 TC-16 を supersede）: negative = README.md/SECURITY.md に literal `Not Maintained`・`not maintained`（case-sensitive、grep -F）が合計0件。positive = README.md に `No external support`、SECURITY.md に `no external support` が各1件以上。ヘッダ L3 を「TC-01 ~ TC-15」→「TC-01 ~ TC-19」に更新
+
+**FAIL 確認結果（RED state 検証、rc とともに実測）**:
+- `bash tests/test-post-approve-gate-removal.sh` → rc=1（PASS: 6 / FAIL: 2）。TC-01~06 は全 PASS（回帰なし）。TC-07 FAIL（stale hook 記述 3 件検出: AGENTS.md / skills/spec/reference.md / skills/onboard/reference.md、かつ「プロンプトベースの規律」が3ファイルとも count=0 で欠落）。TC-08 FAIL（skills/spec/reference.md に post-approve-gate 参照1件検出）
+- `bash tests/test-doc-consistency.sh` → rc=1（PASS: 11 / FAIL: 3 / TOTAL: 14）。TC-01/02/04/05/11/12/14/15/16/17/18 は全 PASS（回帰なし）。TC-19 FAIL（stale=2件: Not Maintained=1（README.md）, not maintained=1（SECURITY.md）／ README new=0 ／ SECURITY new=0）。TC-13（Regression: 全 test-*.sh 実行）も FAIL だが、これは TC-07/TC-08 が RED 状態の test-post-approve-gate-removal.sh を再帰実行した結果のカスケードであり新規バグではない（test-factory-model-adaptation.sh の TC-14 も同一原因で同様にカスケード FAIL することを確認済み）
+- 実装（AGENTS.md 等7ファイルの文言修正）は未着手のため、上記 FAIL は GREEN phase で解消される想定通りの RED 状態
+
+**red_state_verified: true**（新 TC のみ FAIL、既存 TC は全 PASS。カスケード FAIL の原因も特定済み）
+
+### 2026-07-16 14:11 - GREEN
+
+PLAN REVIEW エントリの superseded 仕様（F1〜F7 accept-apply）を実装契約として、7ファイルへ verbatim 置換を適用。
+
+**修正ファイル（7件、全て verbatim 置換）**:
+1. `AGENTS.md` L40 — stale hook 記述 → プロンプトベースの規律 文言
+2. `skills/spec/reference.md` L494 — 同上（post-approve-gate.sh 言及も除去）
+3. `skills/onboard/reference.md` L429 — 同上
+4. `tests/test-post-approve-ordering.sh` L3, L48, L55 — ヘッダコメント3箇所を assert 実態（sync-plan が先）に一致させる（コード変更なし、コメントのみ）
+5. `README.md` L3 — 「Not Maintained」→「No external support」
+6. `SECURITY.md` L3 — 「not maintained」→「no external support」（bullet 2行・fork 案内は無変更）
+7. `ROADMAP.md` 現在地 — 「v2.11.0 リリース済み...本リリース向けに蓄積済み」→「v2.12.0 リリース済み（2026-07-15）」。完了済みバージョン一覧に v2.12.0 行を追加
+
+**テスト結果**:
+- `bash tests/test-post-approve-gate-removal.sh` → rc=0（PASS: 8 / FAIL: 0。TC-07/TC-08 含め全 PASS）
+- `bash tests/test-doc-consistency.sh` → rc=0（PASS: 13 / FAIL: 0 / TOTAL: 13。TC-19 含め全 PASS、TC-13 Regression も PASS）
+- `bash tests/test-post-approve-ordering.sh` → rc=0（PASS: 6 / FAIL: 0。コメント変更後も TC-01/TC-02 の assert 実態と一致し回帰なし）
+- full suite 直列実行 `for f in tests/test-*.sh; do ... done` → FAIL 0 件（stdout に FAIL 行なし、`done` のみ出力）
+
+**ROADMAP.md whole-doc sweep 結果**（PdM 指示の current-state 更新規律に基づく）:
+- `grep -n "2\.12" ROADMAP.md`: 現在地見出し・完了済みリスト・「次候補（v2.12.0 リリース後）」・v2.11.0/v2.12.0 リリース済みセクション見出し・詳細説明・Agile Loop 候補欄の計6箇所がヒット。全て「リリース済み」前提の記述で整合、v2.12.0 未リリース前提の残存記述なし
+- `grep -n "リリース済み\|リリース予定\|レビュー中" ROADMAP.md`: 2箇所ヒット（現在地文、v2.11.0/v2.12.0 セクション見出し）。いずれも「リリース済み」の正しい状態を示しており stale 記述なし
+- 結論: ROADMAP.md 内に v2.12.0 未リリース前提の旧状態記述は残存しない
+
+### 2026-07-16 14:18 - REFACTOR
+
+- チェックリスト7項目を今 cycle 変更ファイル（docs 7 + tests 2）に適用: 重複コード/定数化/未使用import/let→const/メソッド分割/N+1/命名一貫性 — いずれも改善不要（テスト追加分は既存ファイルの pass/fail ヘルパー・rc ガード・`|| true` count パターンに整合済み、docs は verbatim 置換のみ）
+- Verification Gate: `bash -n` 構文チェック 3 ファイル OK / test-post-approve-gate-removal.sh rc=0 / test-doc-consistency.sh rc=0 (13/13、実行約2分52秒 — TC-13 の再帰実行による既存挙動) / test-post-approve-ordering.sh rc=0
+- リファクタ変更なし（コード変更 0 件）→ 全テスト PASS 維持
+- Phase completed
+
+### 2026-07-16 14:24 - VERIFY (Block 2c.5)
+
+- superseded Verification（plan review F6 反映版）を real-path で全実行。evidence: /tmp/dev-crew-verify-20260716_1328/verify.log
+- test-post-approve-gate-removal.sh rc=0 (8/8) / test-post-approve-ordering.sh rc=0 (6/6) / test-plugin-structure.sh rc=0 (6/6) / test-doc-consistency.sh rc=0 (13/13)
+- hook sweep clean（rc=1 判定、rc>=2 区別）/ roadmap head OK / roadmap stale phrase gone / ordering comments clean / wording clean
+- Phase completed
+
+### 2026-07-16 14:37 - REVIEW findings 適用（TC-07 rc ガード修正）
+
+code review（Codex + Claude correctness、独立に同一指摘）で `tests/test-post-approve-gate-removal.sh` TC-07 に BLOCK 判定。
+
+**Finding 1（BLOCK、修正済み）**: L81 の `HOOK_HITS=$(grep -rE ... | grep -v 'docs/cycles/' | grep -v 'docs/archive/') || HOOK_HITS_RC=$?` は pipefail 下でパイプライン最右コマンドの rc が優先され、先頭 grep が rc>=2（読取失敗等）でも後段 grep -v の rc（no-match で 1）にマスクされ、L82 の `[ "$HOOK_HITS_RC" -ge 2 ]` ガードが到達不能（dead guard）だった。修正: 先頭 grep を単独実行して `HOOK_RAW` に受け rc を先取りし、フィルタ処理は捕捉後の別ステップ（`HOOK_HITS=$(echo "$HOOK_RAW" | grep -v ... | grep -v ... || true)`）に分離。
+
+**Finding 2（optional、同時適用）**: 除外フィルタをパス位置アンカー付きに変更（`grep -v 'docs/cycles/'` → `grep -v "^$BASE_DIR/docs/cycles/"`、archive も同様）。ヒット行本文に `docs/cycles/` を含む stale 行の誤除外を防止。
+
+**完了条件の確認結果**:
+1. `bash -n tests/test-post-approve-gate-removal.sh` → 構文OK。`bash tests/test-post-approve-gate-removal.sh` → rc=0（PASS: 8 / FAIL: 0、8/8 PASS）
+2. dead guard 解消の oracle 確認（リポジトリ非改変、scratchpad 上の隔離フィクスチャで検証）: 権限拒否サブディレクトリ（chmod 000）を含む一時ディレクトリを BASE_DIR として TC-07 相当ロジックを抽出実行。修正前ロジックは `HOOK_HITS_RC=1`（マスクされ dead guard 現象を再現）、修正後ロジックは `HOOK_HITS_RC=2` を正しく捕捉しガード発火（"cannot verify negative sweep" 側へ分岐）を確認。なお `BASE_DIR=/nonexistent-dir` 単体（ディレクトリ不存在）は本環境の実 grep（BSD grep、`--include` 併用時）では stat エラーを出さず静かに rc=1 を返す挙動を実測したため、rc>=2 を確実に誘発する権限拒否ディレクトリのフィクスチャを oracle に採用した
+3. 他ファイル・他 TC は無変更（`git diff -- tests/test-post-approve-gate-removal.sh` で TC-07 ブロックのみの差分を確認）
+4. 本エントリで記録
+
+**red_state_verified: true**（Finding 1/2 適用後、TC-07 含め全 TC が意図通りの GREEN 状態で PASS）
+
+### 2026-07-16 14:39 - REVIEW (competitive: Claude panel + Codex)
+
+- **Risk Classification（決定論的）**: risk-classifier.sh → **LOW score:0** → floor 構成（Codex + security + correctness、NON-NEGOTIABLE）。review_policy: reviewer_model=self → 両 reviewer を orchestrator 現行モデル（fable）で起動
+- **Repo-state pre-check**: untracked は本 Cycle doc のみ（新規 doc、COMMIT で stage 予定）→ 想定内 WARN として続行
+- **判定内訳**: security blocking_score 5（PASS、findings 0）/ correctness blocking_score 25（PASS 帯、important 1 + optional 2）/ Codex **BLOCK 1 + WARN 1 + PASS**
+- **Findings Judgment（3-category triage）**:
+  1. **TC-07 rc>=2 ガード dead guard（Codex BLOCK 1 = Claude correctness important、独立同一指摘）**: accept-apply。pipefail 下でパイプ最右 rc が返り先頭 grep の rc=2 がマスクされる欠陥。先頭 grep 単独実行 + rc 先取りに修正、除外フィルタもパス位置アンカー化（correctness optional 1 を同時適用）。修正後 rc=0 (8/8)、権限拒否 fixture の oracle で修正前=マスク再現・修正後=rc=2 捕捉を実証（red-worker 実施、Progress Log 別エントリ参照）
+  2. **Codify Insight 2 の機序不一致（Codex WARN 2）**: accept-apply + accept-defer。「2回目再発」主張を撤回する Addendum を 20260715_1346 Codify Decisions に追記（codified 判定自体は元 failure 単独で維持）。新機序（リリース時 ROADMAP 更新プロセス不在）は DISCOVERED に起票
+  3. **AGENTS.md L40 の「、必ず」挿入（correctness optional 2）**: reject（変更なし）。plan 文言に対し 2 文字の非 verbatim だが、rules/post-approve.md の既存表現「必ず /orchestrate に委譲」と整合する方向の deviation であり、契約 phrase「プロンプトベースの規律」は成立。本エントリでの記録をもって処理
+- **Design Review WARN 申し送り（#4/#7 の目視確認）**: 実施済み。#4 = ordering コメント 3 行の verbatim 適用を diff で確認 + VERIFY「ordering comments clean」。#7 = ROADMAP 現在地は VERIFY で「roadmap head OK / stale phrase gone」を grep 実証（F6 の Verification 強化で自動検証化済み — 申し送りの「自動検証なし」は superseded Verification により解消）
+- **統合判定**: BLOCK は修正完了で解消、Claude 両 reviewer PASS → **合意 PASS** → auto-COMMIT 進行（steps-codex REVIEW 後の判断）
+- Phase completed
+
+## Retrospective
+
+抽出時刻: 2026-07-16 14:41
+抽出方法: Cycle doc 全体（plan review BLOCK 3 件の解消経緯 / code review の TC-07 dead guard 指摘 / red-worker の oracle 実測）からの失敗→最終解→insight ペア抽出
+
+### Insight 1: 多段 pipe の rc ガードは先頭コマンドの rc を単独実行で先取りする。エラー経路の oracle は「不在 dir」でなく「読取拒否」で誘発する
+- **Failure**: TC-07 の `grep -rE ... | grep -v ... | grep -v ...) || RC=$?` は pipefail 下で最右 grep -v の rc=1 が返り、先頭 grep の rc=2 がマスクされ rc>=2 ガードが到達不能（dead guard）。REFACTOR の Verification Gate・VERIFY をすり抜け、code review で Codex BLOCK + Claude correctness が独立に同一指摘して初めて発覚
+- **Final fix**: 先頭 grep を単独実行して rc を先取り → その後 `echo "$RAW" | grep -v ... || true` でフィルタ分離。修正検証では `BASE_DIR=/nonexistent-dir` が本環境の grep（--include 併用時）で silent rc=1 になることを実測し、chmod 000 の権限拒否 fixture で rc=2 経路を誘発して修正前=マスク再現・修正後=捕捉を実証
+- **Insight**: **(a) rc を検査したいコマンドは pipe に入れない — pipefail は「最右の非ゼロ」であり先頭の rc を保証しない。ガード付き多段 pipe は「単独実行 + rc 先取り → フィルタ分離」に分解する。(b) エラー経路（rc>=2）の oracle は「存在しないパス」では誘発できない場合がある（GNU/BSD grep の -r --include は不在 dir で silent rc=1）— 「読める境界の内側にある読めないもの」（権限拒否 fixture）で誘発する**。既存 rule の pipe masking 禁止（`bash subject | grep -q`）の rc-guard 版
+- **一般化**: rules/test-patterns.md 追記候補（多段 pipe rc ガード分解 + エラー経路 oracle の fixture 選定）
+
+### Insight 2: TC 番号・カウント等の「次の値」は当該ファイルの実装 grep で実測する。ヘッダコメントの一覧は drift しているものとして扱う
+- **Failure**: plan が新 TC を「TC-16」と指定したが、test-doc-consistency.sh には既に TC-16〜18 が実在（ヘッダ L3「TC-01 ~ TC-15」自体が stale だった）。spec 時にヘッダコメントを信じて実装 grep を怠り、Codex plan review F1 で BLOCK。doc drift を直す cycle 自身が doc drift（stale ヘッダ）に騙された再帰事例
+- **Final fix**: TC-19 へ改番 + ヘッダを「TC-01 ~ TC-19」に更新（ヘッダ drift も同時解消）
+- **Insight**: **識別子の「次の値」（TC 番号・count・連番）を plan に書く前に、`grep -n "TC-1[0-9]"` 等で当該ファイルの実装から最大値を実測する。ヘッダ・目次・一覧コメントは実装から drift する前提で扱い、根拠にしない**。plan-discipline の「narrative な baseline 記述禁止」の識別子版
+- **一般化**: rules/plan-discipline.md 追記候補（連番採番の実装実測）
+
+### Insight 3: negative sweep パターンは「置換後の新文言」への不一致も oracle で確認してから採用する。reviewer の修正案も同じ実測を通す
+- **Failure**: plan の TC-07 パターンは BRE alternation 欠陥 + 対象 1 件を拾えない誤り（Codex F2 が検出）。一方 Codex の修正案 `Edit/Write.*hook.*ブロック` も、置換後の新文言「…hook による強制ブロックではない」に match する false-positive 欠陥があった（PdM が oracle 実測で検出し不採用）
+- **Final fix**: `hook.*でブロックされる` を採用。旧 3 件に match・新文言に不一致（rc=1）を printf oracle で確認してから RED に引き渡し
+- **Insight**: **negative sweep（0 件契約）のパターンは「現状の違反例に match する」だけでなく「fix 後に導入される新文言に match しない」ことを RED 前に oracle 実測する。reviewer の提案パターンも無検証で採用しない — 指摘が正しくても対案が正しいとは限らない**
+- **一般化**: rules/test-patterns.md 追記候補（negative contract の replacement oracle）
+
+### 成功事例（observation: informed approval 路線の初回適用で competitive review が全層で機能）
+- plan review が RED 前に実害 3 件（TC 番号衝突・grep 欠陥・コメント残存）を BLOCK で捕捉し、code review では Codex と Claude correctness が独立に同一の dead guard を検出（cross-confirm）。orchestrator の codify 判定（2-strike 主張）にも Codex WARN が入り Addendum で訂正 — reviewer が orchestrator 自身の記録も検証する構造が機能した。既存 pipeline の追認であり no-codify
+
+### 2026-07-16 14:51 - COMMIT
+
+- 最終 full suite（隔離 snapshot、直列、review-fix 反映後）: **113/113 全 rc=0、baseline との diff 空（回帰ゼロ）**（scratchpad/final.txt）
+- pre-commit-gate（明示指定）rc=0 PASS（retro_status: captured で通過）
+- STATUS.md: Done (unarchived) 68→69 + Completed 行追加 + Last updated 2026-07-16。Test Scripts 113 不変（実測一致）。Done count を pin する test なし（grep 実測 0 件）
+- README/AGENTS/CLAUDE の skill 一覧更新: SKIP（skills/ 変更は reference.md の文言修正のみで skill 数 28・構成不変）
+- commit 同梱: AGENTS.md / README.md / ROADMAP.md / SECURITY.md / skills/spec/reference.md / skills/onboard/reference.md / tests/test-post-approve-gate-removal.sh / tests/test-doc-consistency.sh / tests/test-post-approve-ordering.sh / docs/STATUS.md / 本 cycle doc / docs/cycles/20260715_1346（Block 0 codify gate 出力 + Insight 2 Addendum）
+- issue: #176（approval-reorder、次 cycle）/ #177（リリース時 ROADMAP 同期契約）起票済み
+- feature/doc-drift-fix → PR → merge
+- Phase completed

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -426,7 +426,7 @@ orchestrate が以下を全て内部で管理する:
 - RED → GREEN → REFACTOR → REVIEW → COMMIT
 
 sync-plan や review --plan を直接呼ばないこと（orchestrate 経由で呼ばれる）。
-Edit/Write は orchestrate 起動まで hook でブロックされる。
+Edit/Write は直接行わず、必ず /orchestrate に委譲する（プロンプトベースの規律。hook による強制ではない）。
 ```
 
 ### CLAUDE.md 必須セクション

--- a/skills/spec/reference.md
+++ b/skills/spec/reference.md
@@ -491,7 +491,7 @@ approve後は `/orchestrate` を起動する。orchestrate が全フェーズを
 - Codex plan review (codex exec --full-auto, 委譲確認不要)
 - plan-review (Claude)
 
-Edit/Write は orchestrate 起動まで hook (post-approve-gate.sh) でブロックされる。
+Edit/Write は直接行わず、必ず /orchestrate に委譲する（プロンプトベースの規律。hook による強制ではない）。
 ```
 
 この後、plan mode内で探索・設計・Test List定義・QAチェックを続行する。

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # test-doc-consistency.sh - Document consistency validation
-# TC-01 ~ TC-15（欠番: 03, 06-10 — 削除済みTC）
+# TC-01 ~ TC-19（欠番: 03, 06-10 — 削除済みTC）
 
 set -euo pipefail
 
@@ -254,6 +254,36 @@ else
     fail "TC-18: non-DONE doc count ($NON_DONE_COUNT) > 1"
     printf '%s\n' "${NON_DONE_DOCS[@]}"
   fi
+fi
+
+########################################
+# External Support Wording (stale support-status wording inverse contract)
+########################################
+
+echo ""
+echo "--- External Support Wording ---"
+
+# TC-19: README.md/SECURITY.md の外部サポート文言が新表現（No external support /
+# no external support）に統一され、旧表現（Not Maintained / not maintained）が
+# 残っていないことを保証する逆向き契約。case-sensitive literal（grep -F）で
+# 大文字/小文字の両形を個別に検査する (rules/test-patterns.md: case-insensitive grep 禁止)
+echo ""
+echo "TC-19: README.md/SECURITY.md の外部サポート文言が更新済み（stale 0件・新文言各1件以上）"
+stale_upper=$(grep -cF "Not Maintained" "$BASE_DIR/README.md" "$BASE_DIR/SECURITY.md" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}' || true)
+stale_lower=$(grep -cF "not maintained" "$BASE_DIR/README.md" "$BASE_DIR/SECURITY.md" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}' || true)
+[ -z "$stale_upper" ] && stale_upper=0
+[ -z "$stale_lower" ] && stale_lower=0
+stale_total=$((stale_upper + stale_lower))
+
+readme_new=$(grep -cF "No external support" "$BASE_DIR/README.md" 2>/dev/null || true)
+[ -z "$readme_new" ] && readme_new=0
+security_new=$(grep -cF "no external support" "$BASE_DIR/SECURITY.md" 2>/dev/null || true)
+[ -z "$security_new" ] && security_new=0
+
+if [ "$stale_total" -eq 0 ] && [ "$readme_new" -ge 1 ] && [ "$security_new" -ge 1 ]; then
+  pass "TC-19: stale 外部サポート文言 0 件 かつ README/SECURITY 新文言 各1件以上"
+else
+  fail "TC-19: stale=${stale_total} 件（Not Maintained=${stale_upper}, not maintained=${stale_lower}）/ README new=${readme_new} / SECURITY new=${security_new}"
 fi
 
 ########################################

--- a/tests/test-post-approve-gate-removal.sh
+++ b/tests/test-post-approve-gate-removal.sh
@@ -6,6 +6,8 @@
 # TC-04: post-approve-gate.sh が存在しない
 # TC-05: orchestrate SKILL.md に TaskCreate 指示がある
 # TC-06: test-hooks-structure.sh に TC-11/TC-12 がない（回帰防止）
+# TC-07: stale hook 記述の逆向き契約（docs/cycles・docs/archive 除外で0件）+ 「プロンプトベースの規律」の存在確認
+# TC-08: skills/ 配下に post-approve-gate 参照が0件
 
 set -euo pipefail
 
@@ -70,6 +72,47 @@ if grep -q 'TC-11\|TC-12' "$BASE_DIR/tests/test-hooks-structure.sh"; then
   fail "TC-06: test-hooks-structure.sh still has TC-11/TC-12"
 else
   pass "TC-06: test-hooks-structure.sh has no TC-11/TC-12"
+fi
+
+# TC-07: stale hook 記述の逆向き契約（0件）+ 新文言の存在確認
+echo ""
+echo "TC-07: stale hook 記述 0 件（docs/cycles・docs/archive 除外）かつ「プロンプトベースの規律」が3ファイルに存在"
+HOOK_HITS_RC=0
+HOOK_RAW=$(grep -rE 'hook.*でブロックされる' --include="*.md" "$BASE_DIR" 2>/dev/null) || HOOK_HITS_RC=$?
+if [ "$HOOK_HITS_RC" -ge 2 ]; then
+  fail "TC-07: grep failed with rc=$HOOK_HITS_RC — cannot verify negative sweep"
+else
+  HOOK_HITS=$(echo "$HOOK_RAW" | grep -v "^$BASE_DIR/docs/cycles/" | grep -v "^$BASE_DIR/docs/archive/" || true)
+  HOOK_HIT_COUNT=$(echo "$HOOK_HITS" | grep -c . || true)
+  PROMPT_PHRASE_FAIL=0
+  for rel_file in AGENTS.md skills/spec/reference.md skills/onboard/reference.md; do
+    phrase_count=$(grep -cF "プロンプトベースの規律" "$BASE_DIR/$rel_file" 2>/dev/null || true)
+    [ -z "$phrase_count" ] && phrase_count=0
+    if [ "$phrase_count" -lt 1 ]; then
+      PROMPT_PHRASE_FAIL=1
+      echo "    missing in $rel_file (count=$phrase_count)"
+    fi
+  done
+  if [ "$HOOK_HIT_COUNT" -eq 0 ] && [ "$PROMPT_PHRASE_FAIL" -eq 0 ]; then
+    pass "TC-07: stale hook 記述 0 件 かつ プロンプトベースの規律 が3ファイルに存在"
+  else
+    fail "TC-07: stale hook 記述 ${HOOK_HIT_COUNT} 件 / プロンプトベースの規律 欠落フラグ=${PROMPT_PHRASE_FAIL}"
+    [ "$HOOK_HIT_COUNT" -gt 0 ] && echo "$HOOK_HITS"
+  fi
+fi
+
+# TC-08: skills/ 配下に post-approve-gate 参照が0件
+echo ""
+echo "TC-08: skills/ 配下に post-approve-gate 参照が0件"
+PAG_RC=0
+PAG_HITS=$(grep -r "post-approve-gate" "$BASE_DIR/skills/" 2>/dev/null) || PAG_RC=$?
+if [ "$PAG_RC" -ge 2 ]; then
+  fail "TC-08: grep failed with rc=$PAG_RC — cannot verify"
+elif [ "$PAG_RC" -eq 1 ]; then
+  pass "TC-08: skills/ has no post-approve-gate reference"
+else
+  fail "TC-08: skills/ still references post-approve-gate"
+  echo "$PAG_HITS"
 fi
 
 # Summary

--- a/tests/test-post-approve-ordering.sh
+++ b/tests/test-post-approve-ordering.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test: Post-Approve Action ordering matches workflow.md
-# Plan review MUST come before Cycle doc (sync-plan)
+# sync-plan (Cycle doc) MUST come before plan review (v2.8 orchestrate integration)
 
 set -euo pipefail
 PASS=0; FAIL=0
@@ -45,14 +45,14 @@ check_three_steps() {
   fi
 }
 
-# TC-01: reference.md - Plan review before Cycle doc
+# TC-01: reference.md - sync-plan before plan review
 if check_ordering "$BASE/skills/spec/reference.md"; then
   pass "TC-01: reference.md sync-plan before plan-review"
 else
   fail "TC-01: reference.md sync-plan should be before plan-review"
 fi
 
-# TC-02: reference.ja.md - Plan review before Cycle doc
+# TC-02: reference.ja.md - sync-plan before plan review
 if check_ordering "$BASE/skills/spec/reference.ja.md"; then
   pass "TC-02: reference.ja.md sync-plan before plan-review"
 else


### PR DESCRIPTION
## Summary

外部レビュー（Codex）で確認された文書と実装の乖離3クラスを解消する doc-drift-fix cycle（20260716_1328）。

- 廃止済み post-approve-gate hook の現在形記述3箇所を修正（AGENTS.md / skills/spec/reference.md / skills/onboard/reference.md）
- test-post-approve-ordering.sh のヘッダコメントと assert の逆転を解消（3行）
- README/SECURITY「Not Maintained」→「No external support」（内部開発は継続中、外部サポートなしの明確化）
- ROADMAP 現在地を v2.12.0 リリース済みに更新
- 再発ガード: TC-07/TC-08/TC-19 追加（新規テストファイルなし、Test Scripts 113 不変）

## Review

- Design Review: WARN 55（申し送り2件は Verification 強化で解消）
- Codex plan review: BLOCK 3 / WARN 4 → 全件 accept-apply（Cycle doc superseding correction 記録）
- Code review（competitive）: Codex BLOCK 1（TC-07 pipefail dead guard、Claude correctness と独立同一指摘）→ 修正済み、oracle で実証
- 最終 full suite 113/113 PASS、baseline diff 空

## Follow-up

- #176 approval-reorder（次 cycle）
- #177 リリース時 ROADMAP 同期契約

🤖 Generated with [Claude Code](https://claude.com/claude-code)