### PR TITLE
chore: release v2.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "dev-crew",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "source": "./",
       "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-crew",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction.",
   "author": {
     "name": "morodomi"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [Unreleased]
+## [2.13.0] - 2026-07-21
 
 ### Breaking
-- 承認ゲートの意味論変更（approval-reorder、#176）: plan review の実行タイミングが人間承認の前（plan mode 内、spec Step 8）へ変更。新形式の（`plan_file` を持つ）cycle doc では pre-red-gate が `plan_file` と Plan Review Record の存在を要求するようになった（plan_file 不在の legacy cycle doc は従来通り弱い fallback で通過）。version bump/tag は本 cycle scope 外（release-skill 委譲）
+- 承認ゲートの意味論変更（approval-reorder、#176）: plan review の実行タイミングが人間承認の前（plan mode 内、spec Step 8）へ変更。新形式の（`plan_file` を持つ）cycle doc では pre-red-gate が `plan_file` と Plan Review Record の存在を要求するようになった（plan_file 不在の legacy cycle doc は従来通り弱い fallback で通過）
 
 ### Added
 - approval-reorder（#176/#179）: spec に Step 8（承認前 plan review）を追加。Cycle 1（PR #182）で機構・実行時 memory・権威 doc（AGENTS/CLAUDE/workflow/README/architecture）を新順序へ更新。Cycle 2 で残る narrative doc（usability.md フロー図・ROADMAP.md 現在地）と onboard 生成テンプレート（AGENTS.md TDD Workflow / Post-Approve Action / Codex セッション作成の read-only 化）を新順序へ伝播

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -371,42 +371,44 @@ else
   fi
 fi
 
-# TC-C2-5: CHANGELOG.md [Unreleased] の "### Breaking" subsection 内に
+# TC-C2-5: CHANGELOG.md の先頭 version セクションの "### Breaking" subsection 内に
 # approval-reorder または #176 の言及があることを検査。
-# [Unreleased] section 全体で approval-reorder と Breaking を独立カウントすると、
-# 別機能の Breaking 項目が残っている限り approval-reorder 側の Breaking 記述を
-# 消しても PASS してしまう（両者の関連性が pin されない）ため、
-# Breaking subsection を先に抽出しその中限定で言及有無を判定する
+# 先頭 version セクション（[Unreleased] があればそれ、リリースで確定後は最新 [x.y.z]）を
+# 対象にすることで、[Unreleased] → [x.y.z] の rename に追随する。
+# section 全体で approval-reorder と Breaking を独立カウントすると、別機能の Breaking 項目が
+# 残っている限り approval-reorder 側の Breaking 記述を消しても PASS してしまう
+# （両者の関連性が pin されない）ため、Breaking subsection を先に抽出しその中限定で判定する
 echo ""
-echo "TC-C2-5: CHANGELOG.md [Unreleased] '### Breaking' subsection mentions approval-reorder or #176"
+echo "TC-C2-5: CHANGELOG.md first version section '### Breaking' subsection mentions approval-reorder or #176"
 FILE="$BASE_DIR/CHANGELOG.md"
 if [ ! -f "$FILE" ]; then
   fail "TC-C2-5: CHANGELOG.md not found"
 else
-  UNRELEASED_SECTION=$(awk '
-    index($0, "## [Unreleased]") == 1 {in_sec=1; next}
+  # 最初の '## [' 見出し（version セクション）から次の '## ' 見出しまでを抽出
+  RELEASE_SECTION=$(awk '
+    /^## \[/ && !seen {seen=1; in_sec=1; next}
     in_sec && /^## /{in_sec=0}
     in_sec
   ' "$FILE")
-  if [ -z "$UNRELEASED_SECTION" ]; then
-    fail "TC-C2-5: '## [Unreleased]' section not found (extraction failed)"
+  if [ -z "$RELEASE_SECTION" ]; then
+    fail "TC-C2-5: first version section (## [...]) not found (extraction failed)"
   else
-    BREAKING_SUBSECTION=$(printf '%s\n' "$UNRELEASED_SECTION" | awk '
+    BREAKING_SUBSECTION=$(printf '%s\n' "$RELEASE_SECTION" | awk '
       index($0, "### Breaking") == 1 {in_sub=1; next}
       in_sub && /^#/{in_sub=0}
       in_sub
     ')
     if [ -z "$BREAKING_SUBSECTION" ]; then
-      fail "TC-C2-5: '### Breaking' subsection not found within [Unreleased] (extraction failed)"
+      fail "TC-C2-5: '### Breaking' subsection not found within first version section (extraction failed)"
     else
       count_approval=$(printf '%s\n' "$BREAKING_SUBSECTION" | grep -cF "approval-reorder" || true)
       count_issue176=$(printf '%s\n' "$BREAKING_SUBSECTION" | grep -cF "#176" || true)
       [ -z "$count_approval" ] && count_approval=0
       [ -z "$count_issue176" ] && count_issue176=0
       if [ "$count_approval" -ge 1 ] || [ "$count_issue176" -ge 1 ]; then
-        pass "TC-C2-5: CHANGELOG.md [Unreleased] Breaking subsection mentions approval-reorder or #176"
+        pass "TC-C2-5: CHANGELOG.md first version section Breaking subsection mentions approval-reorder or #176"
       else
-        fail "TC-C2-5: CHANGELOG.md [Unreleased] Breaking subsection missing approval-reorder/#176 reference"
+        fail "TC-C2-5: CHANGELOG.md first version section Breaking subsection missing approval-reorder/#176 reference"
       fi
     fi
   fi


### PR DESCRIPTION
## Release v2.13.0 (minor)

approval-reorder（#176/#179）を含む minor リリース。

### Breaking
- 承認ゲートの意味論変更: plan review が人間承認の前（plan mode 内、spec Step 8）へ移動。新形式の（plan_file を持つ）cycle doc では pre-red-gate が plan_file と Plan Review Record を要求（legacy cycle doc は弱い fallback で通過）

### 同梱
- marketplace.json + plugin.json → 2.13.0
- CHANGELOG [Unreleased] → [2.13.0] - 2026-07-21 確定
- TC-C2-5 を先頭 version セクション参照へ一般化（rename 追随）

full suite 113/113 PASS 済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)