### PR TITLE
chore: release v2.14.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "dev-crew",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "source": "./",
       "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-crew",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction.",
   "author": {
     "name": "morodomi"

--- a/.claude/dev-crew.json
+++ b/.claude/dev-crew.json
@@ -1,5 +1,5 @@
 {
-  "dev_crew_version": "2.12.0",
+  "dev_crew_version": "2.14.0",
   "review_policy": {
     "reviewer_model": "self",
     "escalate_high_to": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.14.0] - 2026-07-22
 
 ### Changed
 - Rules をロード契機（always / cycle-scoped / file-scoped）で分類し、TDD workflow rules を Cycle doc 操作時に限定してロードする構成へ変更


### PR DESCRIPTION
Version bump to 2.14.0

- rules ロード契機再分類（常時ロード 449→103 行、cycle-scoped 化）
- dev_crew_version 2.12.0→2.14.0 同期（Version Gate 誤 BLOCK 解消、#186 の暫定手動対応）
- CHANGELOG [Unreleased] → [2.14.0]

🤖 Generated with [Claude Code](https://claude.com/claude-code)