### PR TITLE
feat: Cycle-Doc トレーラー自動付与 + 想起漏れ計測設問（強制想起 先行実装）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- コミットメッセージに `Cycle-Doc: <path>` トレーラーを付与（commit スキル）: feature コミットと cycle doc を機械可読なリンクで結ぶ。値は Cycle Doc Gate が解決した主サイクル 1 件の repo-relative パス。commit スキル以外の経路（release-skill・手動コミット）には付与しない
+- cycle-retrospective に想起漏れ設問を追加: 「今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか」を全正常終了経路で `### 想起漏れ` 固定 2 行スキーマ（回答 `該当なし` or `docs/cycles/<file>.md`）に記録し、機械集計可能にする
+
 ## [2.14.0] - 2026-07-22
 
 ### Changed

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,18 +5,19 @@
 | Metric | Value |
 |--------|-------|
 | In-Progress Cycles | 0 |
-| Done (unarchived) | 72 |
+| Done (unarchived) | 73 |
 | Archived Cycles | 37 |
 | Skills | 28 |
 | Agents | 41 |
-| Test Scripts | 113 |
+| Test Scripts | 114 |
 
-Last updated: 2026-07-21
+Last updated: 2026-07-23
 
 ## Completed (Recent)
 
 | Date | Cycle | Type |
 |------|-------|------|
+| 2026-07-23 | 20260723_1103: cycle-doc-trailer-and-recall-miss-question (強制想起 #187 先行実装。commit スキルに Cycle-Doc トレーラー自動付与 + cycle-retrospective に想起漏れ設問・固定 2 行スキーマ・二段回収契約。Test Scripts 113→114) | feat |
 | 2026-07-21 | 20260721_1503: rules-load-trigger-reclassification (rules ロード契機 4 分類。7 workflow rules を cycle-scoped 化し常時ロード 449→103 行 77% 減。フェーズ入口 Read 契約 pin TC-05〜11、codify tier 仕様。#185/#186/#187 起票) | feat |
 | 2026-07-17 | 20260717_1605: approval-reorder-cycle2 (narrative doc + onboard 配布テンプレートを新順序へ。onboard L521 security 修正、CHANGELOG [Unreleased]+Breaking、#179 close) | docs |
 | 2026-07-17 | 20260717_1126: approval-reorder (Codex plan review を承認前へ移動。spec Step 8 + Plan Review Record 転記 + hash 同一性保証 + pre-red-gate 硬化。#176 実装、#179/#180/#181 起票) | feat |

--- a/docs/cycles/20260721_1503_rules-load-trigger-reclassification.md
+++ b/docs/cycles/20260721_1503_rules-load-trigger-reclassification.md
@@ -5,12 +5,12 @@ phase: DONE
 complexity: standard
 test_count: 9
 risk_level: medium
-retro_status: captured
+retro_status: resolved
 codex_session_id: "019f8326-5cce-7070-abc9-aac63d1f669a"
 codex_mode: full
 plan_file: /Users/morodomi/.claude/plans/hashed-tickling-honey.md
 created: 2026-07-21 15:04
-updated: 2026-07-21 16:46
+updated: 2026-07-23 11:03
 ---
 
 # v2.14.0 rules ロード契機再分類（常時層ダイエット）
@@ -383,3 +383,22 @@ reject（2 件、理由付き）:
 - 起票: #185（テスト強度）/#186（version gate 自動化）/#187（強制想起 v2.15）
 - feature/rules-load-trigger-reclassification → PR → merge
 - Phase completed
+
+## Codify Decisions
+
+### Insight 1
+- **Decision**: codified
+- **Destination**: rule
+- **Reason**: 「相対参照でなく絶対識別子」原則は doc-mutations の cycle 参照 format（cycle 20260422_1313 #5）に続く 2 例目（対象が CHANGELOG 契約アンカーへ拡張）。rules/test-patterns.md へ「逆向き契約の相対アンカー（first/latest/先頭）禁止 + 契約駆動 workaround の検出シグナル」を追記（follow-up 実装、#185 と同時対応可）
+- **Decided**: 2026-07-23 11:03
+
+### Insight 2
+- **Decision**: codified
+- **Destination**: rule
+- **Reason**: timestamp 推定生成は cycle 20260706_1216 #3（委譲 prompt の timestamp 契約）で rule 化済みだが orchestrator 自身の追記は防御外で、同一セッション内 2 回再発。2-strike rule により rules/agent-prompts.md の timestamp 契約を「Progress Log 追記全般（date 実測 → 変数埋め込みの同一ステップ機械化）」へ拡張（follow-up 実装）
+- **Decided**: 2026-07-23 11:03
+
+### Insight 3
+- **Decision**: no-codify
+- **Reason**: insight 自身の判定通り運用 tip（再帰 runner の timeout 設定 + 孤児 sweep）。初出のため rule 化は保留、再発時に rules/test-patterns.md の bash 落とし穴へ昇格
+- **Decided**: 2026-07-23 11:03

--- a/docs/cycles/20260723_1103_cycle-doc-trailer-and-recall-miss-question.md
+++ b/docs/cycles/20260723_1103_cycle-doc-trailer-and-recall-miss-question.md
@@ -1,0 +1,332 @@
+---
+feature: cycle-doc-trailer-and-recall-miss-question
+cycle: 20260723_1103
+phase: DONE
+complexity: simple
+test_count: 7
+risk_level: low
+retro_status: captured
+codex_session_id: "019f8879-bbcc-7120-b707-867068837504"
+codex_mode: no
+plan_file: /Users/morodomi/.claude/plans/hashed-tickling-honey.md
+created: 2026-07-23 11:04
+updated: 2026-07-23 12:06
+---
+
+# v2.15 強制想起 先行 cycle: Cycle-Doc トレーラー + 想起漏れ計測設問
+
+## Scope Definition
+
+### In Scope
+- [ ] R1: Cycle-Doc トレーラー（commit スキル） — コミットメッセージに `Cycle-Doc: <path>` トレーラーを付与
+- [ ] R3: 想起漏れ設問（cycle-retrospective スキル） — 「今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか」を全正常終了経路で記録
+
+### Out of Scope
+- R2（spec 時強制想起本体） (Reason: 次 cycle。ユーザー決定 2026-07-22)
+- R4（10 サイクル計測） (Reason: R2 稼働後に開始)
+
+### Files to Change（全量。追加・削除禁止）
+1. skills/commit/SKILL.md — Step 4 にトレーラー指示 1-2 行（91→≤100 行厳守）
+2. skills/commit/reference.md — トレーラー仕様 + 例の更新（コミットメッセージ詳細セクション）
+3. skills/cycle-retrospective/SKILL.md — Extraction に設問 1 行（40→≤100）
+4. skills/cycle-retrospective/reference.md — 第 4 設問 + `### 想起漏れ` テンプレート
+5. tests/test-commit-cycle-doc-trailer.sh — 新規テストファイル（下記 Test List）
+6. docs/STATUS.md — Test Scripts 113→114
+7. tests/test-codify-insight.sh — TC-19 の 113→114（regex + echo + bump 履歴コメント 1 行追記）
+8. CHANGELOG.md — [Unreleased] 新設 + Added 記載
+
+**scope 同梱注記**: docs/cycles/20260721_1503_rules-load-trigger-reclassification.md — orchestrate Block 0 codify gate 出力（retro_status: resolved + Codify Decisions 追記、2026-07-23 11:03）。本 cycle commit に同梱する（内容編集はしない）。
+
+## Environment
+
+### Scope
+- Layer: Plugin 全体（doc/bash プロジェクトのため Backend/Frontend 区分は非該当）
+- Plugin: bash + markdown（テストは tests/test-*.sh）
+- Risk: 20 (PASS — commit/cycle-retrospective スキルの doc 変更 + 新規テスト。security/external/DB 該当なし)
+
+### Runtime
+- Language: bash 3.2.57, git 2.49.0
+
+### Dependencies (key packages)
+- なし（shell テストのみ）
+
+### Risk Interview (BLOCK only)
+- 該当なし（Risk 20 は PASS。BLOCK 閾値未達のためインタビュー未実施）
+
+## Context & Dependencies
+
+### Reference Documents
+- 要求仕様書（2026-07-17 ドラフト、ユーザー保有） - issue #187 強制想起の元仕様。R1 受入条件「サイクル外の単発コミットに付与しない」の根拠
+- ROADMAP.md - 次候補（codify 実装 / #156 / #170-172 / #144）と異なる: v2.15 着手はユーザー決定（2026-07-22、v2.14.0 リリース後）。codify 実装 cycle は #185 と同時対応の効率案を維持したままバックログ
+
+### Dependent Features
+- commit スキル（skills/commit/）: Cycle Doc Gate による active cycle 解決ロジックにトレーラー機能が依存
+- cycle-retrospective スキル（skills/cycle-retrospective/）: 通常テンプレート・no-lesson 経路・override-proceed 経路の 3 経路全てに想起漏れセクションが依存
+
+### Related Issues/PRs
+- Issue #187: 強制想起（本 cycle は R1+R3 の先行実装）
+
+## Ambiguity Resolution（plan からの転記）
+
+- 「サイクルに紐づくコミット」の判定: **commit スキル経由か否か**で判定する。探索実測: commit スキルは Cycle Doc Gate（skills/commit/SKILL.md:10）で active cycle 不在時 BLOCK するため、スキル経由のコミットは構造的に cycle-bound。単発コミット（release-skill・手動）はスキルを通らないためトレーラーは付かない — 受入条件「サイクル外コミットに付与しない」は分岐追加ではなくこの構造で満たす（reference.md に明文化）
+- トレーラー対象は commit スキルが作る feature コミットのみ。PR マージコミット（gh 生成）は対象外（仕様の「コミット作成時」= スキル自身の git commit）
+- 想起漏れ設問の回答形式: `## Retrospective` 内の独立サブセクション `### 想起漏れ` に固定 2 行（設問 + 回答。回答は `docs/cycles/<file>` への参照 or `該当なし`）
+- トレーラーの**有無**は commit スキル構造で保証するが、**値**（どの cycle doc を指すか）は Cycle Doc Gate の選択（updated 最新の non-DONE、`sort | tail -1`）に依存する。複数 cycle 同時 IN_PROGRESS 時の値誤りは既存 Gate 由来の制約であり本 cycle の対応範囲外（design review 指摘の明記）
+
+### Baseline 実測（2026-07-22）
+
+- skills/commit/SKILL.md = 91 行（≤100、+2 行余地）/ skills/cycle-retrospective/SKILL.md = 40 行
+- コミットメッセージ形式を pin する既存テスト: **ゼロ**（`grep -rn "Cycle-Doc" tests/` 0 件・`grep -rn "Co-Authored" tests/` **0 件（rc=1、2026-07-22 再実測。design review 指摘で当初の「fixture あり」記載を訂正）**・`git log` 言及は test-dynamic-content.sh TC-07f の無関係 pin のみ）→ 新 TC は純追加
+- `git log --grep='Cycle-Doc'` → 空（既存トレーラーなし）。実コミット形状（git log 実測、例 ea15abe）: `<type>: <subject>` / body / `Refs #185 #186 #187` / `Co-Authored-By:` が最終行。reference.md の例（L27）は `Closes #123` — issue 参照行の表記は Closes/Refs の 2 系が実在
+- 関連スイート baseline: test-cycle-retrospective / test-phase-gate / test-commit-auto-learn / test-rules-mirror 全て rc=0
+- **count 逆向き契約（grep literal 貼付）**: 新規テストファイル追加により Test Scripts 113→114。pin は 2 箇所 — `docs/STATUS.md:12` (`| Test Scripts | 113 |`) と `tests/test-codify-insight.sh:386-401` TC-19（`grep -qE "Test Scripts[[:space:]]*\|[[:space:]]*113"` + bump 履歴コメント行を追記）。test-orchestrate-a2b.sh TC-15 / test-v2-release.sh TC-04 は STATUS==実数の動的比較のため数値更新不要
+- cycle-retrospective の固定文字列契約（reference.md L89-99、TC-09 pin: `Extraction skipped by override` / `Extraction failed after N retries` / `No reusable lesson this cycle`）は**変更禁止 — 追加のみ**
+- spec/templates/cycle.md に `## Retrospective` placeholder を追加してはならない（test-frontmatter-retro-status.sh TC-02 の negative pin）
+
+## Test List
+
+新規 tests/test-commit-cycle-doc-trailer.sh（**全 TC で見出し区間先行抽出 → 区間内 grep** を使う。whole-file grep 禁止 — 20260717_1605 Insight 1 の codified 済み原則を RED 時点で self-apply）:
+
+### TODO
+(none)
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+- [x] TC-T1: Given skills/commit/SKILL.md / When Step 4 を grep / Then Cycle-Doc トレーラー付与の指示が存在し、全体 ≤100 行
+- [x] TC-T2: Given skills/commit/reference.md / When コミットメッセージ詳細を検査 / Then (a) `Cycle-Doc:` トレーラー行を含む例 (b) 「commit スキル以外の経路では付与しない」条項 (c) 複数 cycle doc 同梱時は主サイクル 1 件のみの条項 が存在
+- [x] TC-T3: Given skills/cycle-retrospective/reference.md / When 抽出アルゴリズム・出力テンプレート・no-lesson 経路・override 経路の各見出し区間を検査 / Then (a) 想起漏れ設問（「どの cycle doc を最初に読んでいれば防げたか」）が抽出アルゴリズム区間に存在 (b) `### 想起漏れ` の固定 2 行スキーマ（設問行 literal + 回答行 `- **回答**: (該当なし|docs/cycles/…)` の形式規定）がテンプレート区間に存在 (c) no-lesson 区間と override 区間の**両方**に `### 想起漏れ` 必須の記載が存在
+- [x] TC-T4: Given skills/cycle-retrospective/SKILL.md / When Extraction・Output 区間を grep / Then 想起漏れ設問への言及 + 全正常終了経路での記録指示が存在し、既存固定文字列 3 件（TC-09 契約）が不変
+- [x] TC-T5（順序契約）: Given skills/commit/reference.md の例 / When 行番号比較 / Then `Cycle-Doc:` 行が `<type>:` 行より後・Co-Authored-By 近傍のトレーラーブロック内に出現（multi-file-consistency の順序検証原則）
+- [x] TC-R1（回帰）: bash tests/test-cycle-retrospective.sh 全 PASS（固定文字列・テンプレート非破壊）
+- [x] TC-R2（回帰）: bash tests/test-commit-auto-learn.sh / tests/test-phase-gate.sh 全 PASS（commit SKILL 既存 pin 非破壊）
+
+## Implementation Notes
+
+### Goal
+R2（spec 時強制想起本体）導入前に、遡及不能な来歴記録（R1: コミット↔cycle doc トレーラー）と想起漏れの観測点（R3: retrospective 設問）を先行稼働させる。
+
+### Background
+強制想起（issue #187、要求仕様書 2026-07-17 ドラフト）の先行 cycle。R2（spec 時想起本体）に先立ち、遡及不能な来歴記録（R1: コミット↔cycle doc リンク）と想起漏れの観測点（R3: retrospective 設問)を先に稼働させる。R1 を即時開始する理由は仕様書の設計原則 4「決定時に捕捉しなかった情報は消滅する」— トレーラーなしで積まれたコミットは後から共変更推定でしか紐づけられない。R3 は「提示されなかったが必要だった過去知識」の唯一の観測点で、R2 導入前から回答を蓄積することで R4（10 サイクル計測）の比較基準にもなる。
+
+- ユーザー決定（2026-07-22）: 本 cycle スコープ = R1+R3。R2 は次 cycle。v2.14.0 リリース済み・プラグイン更新済み（Version Gate PASS: recorded=installed=2.14.0)
+- 用語注意: 「R1/R3」は会話・plan 内の参照であり、成果物（skill/rule/test コメント）には書かない（tracking-label 契約 TC-17）
+
+### Design Approach
+
+**R1: Cycle-Doc トレーラー（commit スキル）**
+
+- skills/commit/SKILL.md Step 4（L60-66）に 1-2 行追加: コミットメッセージ末尾トレーラー部に `Cycle-Doc: <Cycle Doc Gate で解決済みの active cycle doc パス>` を必ず含める。詳細は reference.md 参照のまま
+- skills/commit/reference.md `## コミットメッセージ詳細`（L5-32）を拡張: (a) 「良いコミットメッセージ」例にトレーラー行を追加（配置: issue 参照行（Closes/Refs）の後・`Co-Authored-By:` と同じトレーラーブロック内） (b) トレーラー仕様の明文化 — 値は repo-relative パス 1 件（主サイクル）、複数 cycle doc 同梱時も Cycle Doc Gate が選択した主サイクル 1 件のみ、commit スキル以外の経路（release-skill・手動コミット）ではトレーラーを書かない（誤リンク防止）
+- **rules/git-conventions.md には触れない**: always 層は凍結値 76 行ちょうど（v2.14 TC-07 契約）で、追記は交換条件を要する。トレーラーは commit スキルの実装詳細として reference.md を SSOT とする
+
+**R3: 想起漏れ設問（cycle-retrospective スキル）**
+
+- skills/cycle-retrospective/reference.md: (a) 抽出アルゴリズム（L9-11）に第 4 の設問を追加: 「今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか（該当なし可）」 (b) 出力テンプレート（L26-41）に `### 想起漏れ` サブセクションを追加
+- **記録スキーマ（固定 2 行、機械抽出可能 — Codex Finding 2 対応）**:
+  ```markdown
+  ### 想起漏れ
+  - **設問**: 今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか
+  - **回答**: 該当なし
+  ```
+  回答行の許容値は `該当なし` または `docs/cycles/<filename>.md`（複数時はカンマ区切り）のみ。10 サイクル計測（R4）で `grep -A2 "### 想起漏れ"` により機械集計する前提の契約
+- **全正常終了経路で必須（Codex Finding 1 対応）**: 通常テンプレート（L26-41）だけでなく、no-lesson 経路（L43-55、`No reusable lesson this cycle` 時も `### 想起漏れ` + 回答 `該当なし` を併記）と override-proceed 経路（L69-87 の 2 固定文字列出力時）にも `### 想起漏れ` を必須化する。abort（ファイル非変更）のみ対象外。既存固定文字列 3 件は不変（追記のみ）
+- skills/cycle-retrospective/SKILL.md Extraction（L22-27）に 1 行追加（terse mirror）+ Output 節（L28-36）に「全正常終了経路で想起漏れを記録」の 1 行
+- 手戻りゼロの cycle でも「該当なし」を明示記録する（沈黙しない — 仕様書 R2 の「該当なしも情報」原則と整合）
+
+## Verification
+
+```bash
+# 契約テスト（本 cycle の主対象）
+bash tests/test-commit-cycle-doc-trailer.sh
+bash tests/test-cycle-retrospective.sh
+bash tests/test-commit-auto-learn.sh
+bash tests/test-phase-gate.sh
+bash tests/test-codify-insight.sh
+# real-path invocation（integration-verification 準拠）: 本 cycle の COMMIT フェーズ自体が
+# トレーラー付与の初回実運用となる（commit skill 経由）。
+# Codex Finding 3 対応（re-review 指摘含む）: 期待値は commit **前**（Gate 解決直後、
+# cycle doc が DONE 遷移する前）に EXPECTED_CYCLE_DOC として捕捉し、commit 後に比較する。
+# commit 後の gate 再実行は別 cycle を解決するため比較対象にしない。
+EXPECTED_CYCLE_DOC="$CYCLE_DOC"  # commit skill 内で Gate 解決直後に保持
+TRAILERS=$(git log -1 --format='%B' | git interpret-trailers --parse)
+TRAILER=$(printf '%s\n' "$TRAILERS" | awk -F': ' '$1 == "Cycle-Doc" { print $2 }')
+COUNT=$(printf '%s\n' "$TRAILERS" | grep -c '^Cycle-Doc:' || true)
+echo "trailer=$TRAILER count=$COUNT expected=$EXPECTED_CYCLE_DOC"
+[ "$COUNT" -eq 1 ] && [ "$TRAILER" = "$EXPECTED_CYCLE_DOC" ] && echo "TRAILER MATCH"
+# full suite（Block 0 baseline は隔離 snapshot 上で実測）
+for f in tests/test-*.sh; do bash "$f" >/dev/null 2>&1; echo "$f rc=$?"; done
+```
+
+Evidence: (orchestrate が自動記入)
+
+## DISCOVERED（本 cycle 対象外の記録。plan からの転記）
+
+- R2（spec 時強制想起本体）: 次 cycle。設計済み論点 — git log 共変更 + ハブファイル重み付け（IDF 相当、STATUS.md 49件/orchestrate 33件 vs 葉ファイル 4-6件の実測差）、発火は spec の Files 確定後 Step 8 前、助言者形式 3 点セット、R1 トレーラー優先・なければ共変更推定
+- R4（10 サイクル計測）: R2 稼働後に開始。「有用」の行動基準 = 提示 doc への参照が plan 本文に残存
+- 過去 348 コミット（トレーラーなし）への遡及は恒久的に不可 — R2 の当初精度は共変更推定依存（仕様書と整合、既知）
+
+## Plan Review Record（plan `## Plan Review Record` の verbatim 転記）
+
+- codex_session_id: 019f8879-bbcc-7120-b707-867068837504
+- verdict: BLOCK-overridden
+- reviewed_plan_hash: 7f898a7c60fb7af5293f0fa534264351591c6e5b9126c701fdc380850f9e2650
+- findings 要約:
+  - Claude design review（Step 7、blocking_score 35）: baseline 誤記 2 件（Co-Authored grep — accept・実測訂正済み / Refs# — 根拠付き reject、git log 実測 ea15abe に実在）+ INFO 2 件（section-anchored grep 明記・トレーラー値の Gate 依存明記）→ 全て反映
+  - Codex attempt 1 (REQUEST_CHANGES 3件): (1)[P1] 想起漏れの no-lesson/override 経路欠落 (2)[P2] 固定 2 行スキーマ未 pin (3)[P2] トレーラー検証の緩さ → 全件反映
+  - Codex attempt 2 (REQUEST_CHANGES 1件残): Finding 3 の検証タイミング — commit 後の gate 再実行は別 cycle を解決するため、期待値は commit 前に EXPECTED_CYCLE_DOC として捕捉せよ → Codex 提示スニペットをそのまま反映済み（反映後の最終版は再レビュー回数上限により Codex 未検証）
+- review_attempts:
+  - {started: 2026-07-22 15:18, completed: 2026-07-22 15:2x, verdict: REQUEST_CHANGES}
+  - {started: 2026-07-22 15:32, completed: 2026-07-22 15:3x, verdict: REQUEST_CHANGES (Finding 1/2 解消確認、Finding 3 タイミングのみ)}
+- plan_presented: 2026-07-23 10:58
+- unresolved_blocks: attempt-2 の Finding 3 タイミング指摘は Codex 自身の提示スニペットで反映済みだが、反映後の最終版は再レビュー回数上限（1回）により Codex 未検証。承認は「未検証反映」への人間 override を含む
+- override: 2026-07-23 10:58 の承認提示文に「未検証反映への override を含む」旨と REQUEST_CHANGES 状態・反映内容を明示した上で、ユーザーが ExitPlanMode で plan を承認（人間の明示 override）
+
+## Progress Log
+
+Format for each phase entry (**strict, required by pre-commit-gate.sh**):
+
+```
+### YYYY-MM-DD HH:MM - PHASE_NAME
+- [completed action]
+- Phase completed
+```
+
+Phase-specific content:
+- RED: `Test code created, N tests failing`
+- GREEN: `Implementation complete, all tests passing`
+- REFACTOR: `refactor (checklist) + Verification Gate passed`
+- REVIEW: `review(code) score:NN verdict:PASS/WARN/BLOCK`
+- COMMIT: `Committed: [hash]`
+
+### 2026-07-23 11:04 - Plan Review (pre-approval)
+- codex_session_id: 019f8879-bbcc-7120-b707-867068837504
+- review_attempts:
+  - {started: 2026-07-22 15:18, completed: 2026-07-22 15:2x, verdict: REQUEST_CHANGES}
+  - {started: 2026-07-22 15:32, completed: 2026-07-22 15:3x, verdict: REQUEST_CHANGES (Finding 1/2 解消確認、Finding 3 タイミングのみ)}
+- findings 要約: Claude design review（blocking_score 35、baseline 誤記2件+INFO2件、全反映）/ Codex attempt 1（REQUEST_CHANGES 3件、全反映）/ Codex attempt 2（REQUEST_CHANGES 1件残、Finding 3 検証タイミング、Codex 提示スニペットで反映済み）
+- unresolved_blocks: attempt-2 の Finding 3 タイミング指摘は Codex 提示スニペットで反映済みだが、反映後の最終版は再レビュー回数上限（1回）により Codex 未検証。承認は「未検証反映」への人間 override を含む
+- plan_presented: 2026-07-23 10:58
+- reviewed_plan_hash: 7f898a7c60fb7af5293f0fa534264351591c6e5b9126c701fdc380850f9e2650
+- verdict: BLOCK-overridden
+- override: 2026-07-23 10:58 の承認提示文に「未検証反映への override を含む」旨と REQUEST_CHANGES 状態・反映内容を明示した上で、ユーザーが ExitPlanMode で plan を承認（人間の明示 override）
+- Phase completed
+
+### 2026-07-23 11:04 - KICKOFF
+- Cycle doc created
+- Scope definition ready
+- Phase completed
+
+### 2026-07-23 11:09 - Design Review Gate + Post-Transfer Verification (architect)
+- Design Review Gate: PASS（score 15/100）。Scope 具体的（R1+R3 のみ）、Files to Change 8件（<=10）、YAGNI違反なし。Architecture: skills/commit/SKILL.md 91行・Step 4 が L60-66（実測一致）、skills/cycle-retrospective/SKILL.md 40行（実測一致）、reference.md の override区間 L69-87（実測一致）・固定文字列区間 L89-99（実測一致）・no-lesson区間は実測L43-56（plan記載L43-55、±1行差はセクション境界カウントの丸め、実害なし）。tests/test-commit-cycle-doc-trailer.sh 未存在確認（実装前として正しい）。STATUS.md:12 Test Scripts=113、test-codify-insight.sh TC-19 113 pin 実在確認。rules/git-conventions.md 除外の根拠（always層凍結76行）を実測検証: rules/git-conventions.md(29)+git-safety.md(22)+security.md(25)=76 ちょうど（test-rules-path-scoping.sh TC-07 契約と一致）— 追記が交換条件を要するという plan 記述は正確
+- Post-Transfer Verification: 転記欠落なし。Plan Review Record（codex_session_id/hash/verdict/unresolved_blocks/override）、Files to Change 全8件、Test List 7件（frontmatter test_count:7 と一致）、Verification（EXPECTED_CYCLE_DOC タイミング注記含む）、DISCOVERED 3件、全て plan と Cycle doc で一致
+- 観察事項（scope 実質変更ではない、非 BLOCK）: Cycle doc L37 の「scope 同梱注記」（docs/cycles/20260721_1503_rules-load-trigger-reclassification.md 同梱）は plan 本文に存在しない sync-plan 追加記述。git status 実測で該当ファイルは M（Block 0 codify-insight が 11:03 に Codify Decisions 追記した既存差分）と確認。同パターンは 20260717_1126 および 20260721_1503 で前例あり（両cycle とも「scope 実質変更ではなく Block 0 副作用の透明化メモ」と裁定、再承認不要、REVIEW フェーズでの scope 裁定を推奨）。本cycle も同じ裁定を踏襲し、再承認不要と判断。REVIEW フェーズでの前例踏襲裁定を推奨
+- 総合判定: PASS。orchestrate は Block 2a (RED) へ進行可
+- Phase completed
+
+### 2026-07-23 11:34 - RED
+- Test code created, 5 tests failing (7 tests total, 2 regression PASS)
+- 新規テストファイル tests/test-commit-cycle-doc-trailer.sh を作成（TC-T1〜TC-T5 + 回帰 TC-R1/TC-R2）
+- 全 TC で fence-aware な見出し区間先行抽出 helper（section_lines / section_count）→ 区間内 grep -cF を実装。whole-file grep 不使用。ERE メタ文字は見出し引数に渡さない（fixed-string prefix）
+- `-` 始まりパターン（`- **回答**:` 等）は grep -cF -- で option 誤認を回避
+- TC-R1/TC-R2 は既存スイート未実行。固定文字列 3 件（Extraction skipped by override / Extraction failed after N retries / No reusable lesson this cycle）の区間内存在検査として実装（recursive runner 回避）
+- 実行結果: PASS 2 / FAIL 5 / rc=1（新規 TC-T1〜TC-T5 が期待どおり FAIL、回帰 TC-R1/TC-R2 は PASS）
+- Phase completed
+
+### 2026-07-23 11:42 - GREEN
+- Implementation complete, all tests passing
+- skills/commit/SKILL.md Step 4 に `Cycle-Doc:` トレーラー付与指示を 2 行追加（93 行、≤100 厳守）
+- skills/commit/reference.md: 「良いコミットメッセージ」例に `Cycle-Doc:` 行を Co-Authored-By 直上（同一トレーラーブロック）へ追加 + `### Cycle-Doc トレーラー仕様` サブセクションを新設（値=repo-relative パス、主サイクル 1 件、commit スキル以外の経路には付与しない）
+- skills/cycle-retrospective/reference.md: 抽出アルゴリズムに第 4 設問（想起漏れ）追加、出力テンプレートに `### 想起漏れ` 固定 2 行スキーマ + 回答許容値（該当なし / docs/cycles/…）規定、no-lesson 経路と override-proceed 経路の両方に `### 想起漏れ` 必須を追記（既存固定文字列 3 件は不変）
+- skills/cycle-retrospective/SKILL.md: Extraction に想起漏れ設問 1 行 + Output に「全正常終了経路で記録」1 行（42 行、≤100）
+- docs/STATUS.md: Test Scripts 113→114 / tests/test-codify-insight.sh TC-19: regex + echo + fail msg を 114 へ、bump 履歴コメント 1 行追記
+- CHANGELOG.md: [Unreleased] + Added を新設し本機能 2 点を記載
+- 検証: bash tests/test-commit-cycle-doc-trailer.sh 7/7 PASS rc=0。回帰 test-cycle-retrospective / test-commit-auto-learn / test-phase-gate / test-codify-insight 全 rc=0。動的比較 test-orchestrate-a2b / test-v2-release / test-pre-commit-gate 全 rc=0。wc -l 両 SKILL.md ≤100（93 / 42）
+- Phase completed
+
+---
+
+## Next Steps
+
+1. [Done] KICKOFF
+2. [Done] RED
+3. [Done] GREEN
+4. [Done] REFACTOR
+5. [Next] REVIEW <- Current
+6. [ ] COMMIT
+7. [ ] DONE
+
+### 2026-07-23 11:50 - REFACTOR
+
+- チェックリスト 7 項目適用: 改善対象ゼロ（変更は md 仕様記述 + count 同期のみ。tests/ は REFACTOR 禁止事項により対象外。トレーラー仕様表の表/補足文の軽微重複は情報保存を優先し許容）
+- Verification Gate: bash -n lint OK + full suite 114/114 rc=0 全 PASS（baseline 113/113 + 新規 1、regression ゼロ。scratchpad/refactor-suite2.txt）
+- Phase completed
+
+### 2026-07-23 12:04 - REVIEW
+
+**Competitive review 構成**: Claude panel 4 名（HIGH tier、risk-classifier score 95）+ Codex（resume 019f8879、3 ラウンド）。Claude blocking_score: security 5 / design 5 / maintainability 25 / correctness 45（全て PASS 帯）。Codex: BLOCK → BLOCK → **PASS**（最終確認済み）。
+
+**Findings Judgment（3-category triage、計 13 件）**:
+
+accept-apply（適用済み 8 件、全て REFACTOR 完了後の review-fix として本エントリで SSOT 同期）:
+1. [Codex BLOCK-1] reference.md の機械集計契約 grep -A2 → -A3（見出し直後の空行で回答行に届かない実バグ）+ 回答行の行全体一致仕様を明記
+2. [Codex WARN-2] TC-T3 に回収契約 oracle（b2）と回答行アンカー regex 検査（b3）を追加
+3. [Codex WARN-3] Cycle doc Next Steps を REVIEW 現在位置へ同期
+4. [Codex re-check BLOCK] 集計契約を「最後の ^## Retrospective$ セクション先行抽出 → 区間内 grep -A3」の二段へ修正（whole-file grep は cycle doc 内の plan 転記テンプレートを誤取得する）。TC-T3 b2 を fenced decoy + 実 Retrospective の fixture oracle に変更（実セクションの回答ちょうど 1 件を検証）。Codex 最終確認 PASS
+5. [maintainability WARN-2] tests/test-codify-insight.sh の変数名 has_scripts113 → has_scripts114（8 回の bump で維持された rename 慣行の回復）
+6. [correctness important] 集計コマンド例の `<cycle_doc>` リテラルが bash リダイレクト衝突で構文エラー（oracle 実測）→ `"$cycle_doc"` 変数表記 + プレースホルダ注記へ修正
+7. [correctness optional] TC-T3(c) の override 検査を `### proceed (続行)` 区間限定（term_level=3）へ精密化 + `### abort (中止)` の negative pin 追加（abort はファイル非変更契約）
+8. [correctness info] 本エントリ自体が post-REFACTOR の review-fix 差分（reference.md 154→163 行、テスト 223→268 行）の SSOT 記録（doc-mutations 即時同期）
+
+accept-defer（follow-up、#185 へ統合コメント予定 3 件）:
+- [maintainability WARN-1] section 抽出 helper の 4 番目の重複実装（test-patterns rule「section_grep 再利用」と矛盾。fence-aware + term_level 拡張を共有 helper へ集約する統合を #185 テスト強度強化と同時に実施）
+- [maintainability INFO] TC-T3 の 11 条件集約（将来分割候補）
+- [design INFO] override-proceed 経路の fenced テンプレート例欠如（非対称の解消）
+
+reject（2 件、理由付き）:
+- [security INFO] set -e 欠落: 22/92 本と同型の既存 idiom（PASS/FAIL カウンタ設計で意図的）。suite 全体一貫性監査は #185 スコープ
+- [design INFO] STATUS.md Last updated 未同期: COMMIT フェーズの Step 3（STATUS 更新）で同時解消されるため個別対応不要
+
+**検証**: 修正後 tests/test-commit-cycle-doc-trailer.sh 7/7 rc=0、回帰 test-cycle-retrospective / test-commit-auto-learn / test-phase-gate / test-codify-insight 全 rc=0。design reviewer の指示違反 full suite 実行（タイムアウト中断）による孤児プロセスは ps sweep で 0 件確認（前 cycle insight の適用）
+- Phase completed
+
+### 2026-07-23 12:04 - DISCOVERED 起票
+
+- REVIEW accept-defer 3 件（helper 統合 / TC-T3 分割候補 / override 経路テンプレート例）→ issue #185 へ統合コメント
+- R2（spec 時強制想起本体）→ 既存 issue #187 で追跡継続（新規起票なし）
+- Phase completed
+
+## Retrospective
+
+抽出時刻: 2026-07-23 12:05
+抽出方法: Cycle doc 全体（plan review 3 attempt / pre-red-gate BLOCK 2 回 / code review 3 ラウンド 13 findings）からの失敗→最終解→insight 抽出
+
+### Insight 1: 機械可読契約（集計コマンド・スキーマ）は散文で書かず、「実行可能な形のコマンド + fixture oracle TC」を最初から対にする
+- **Failure**: R4 機械集計契約を散文 + 概形コマンドで書いた結果、4 つの穴が review 3 ラウンドかけて逐次発覚 — (1) grep -A2 が見出し直後の空行で回答行に届かない (2) whole-file grep が cycle doc 内の plan 転記テンプレートを誤取得 (3) `<cycle_doc>` プレースホルダが bash リダイレクトと衝突し copy-paste 実行で構文エラー (4) テスト側も同じ whole-file 検査で誤取得を検出不能
+- **Final fix**: 「最後の ^## Retrospective$ セクション先行抽出 → 区間内 grep -A3」の二段契約を実行可能な変数表記で文書化し、fenced decoy + 実セクションを含む fixture に対して documented pipeline を実行する oracle TC で pin
+- **Insight**: **doc に機械可読契約（回収コマンド・schema regex）を書く時は、(a) そのまま実行可能な形（変数表記、プレースホルダ非使用）で書き (b) 実データ形状（転記・fence・空行・decoy）を再現した fixture に対する oracle TC を同時に作る。散文契約は「もっともらしいが動かないコマンド」を許してしまう**。cycle 20260717_1605 #1（見出し区間先行抽出）の生産側原則を消費側（集計コマンド）へ拡張
+- **一般化**: rules/test-patterns.md 追記候補（#185 の契約強化と同時実装が効率的）
+
+### Insight 2: Plan Review Record の記述形式は pre-red-gate の grep 契約（入れ子 {started: ...} / override 実証跡）に合わせて書く
+- **Failure**: plan の review_attempts を `{date: ..., started: ...}` 形式で書き、override を「承認時に記録」プレースホルダにした結果、pre-red-gate が 2 回 BLOCK（`^  - {started:` 不一致 / `- override: [^ ]` の実証跡要求）。転記層での形式修正 + 承認イベント実証跡の追記で解消
+- **Final fix**: started 先頭の入れ子形式へ統一（date は started 値に内包）+ override 行に ExitPlanMode 承認の具体的実証跡を記録
+- **Insight**: **Plan Review Record を書く時点で scripts/gates/pre-red-gate.sh の契約（入れ子 {started: 形式、BLOCK-overridden には override 実証跡必須）を確認する。gate の grep contract は書式の自由度を持たない — 記録形式は下流の決定論ゲートが規定する**
+- **一般化**: skills/spec/reference.md の Plan File Template に review_attempts の厳密形式と override 要件を明記する追記候補
+
+### 想起漏れ
+
+- **設問**: 今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか
+- **回答**: docs/cycles/20260717_1605_approval-reorder-cycle2.md, docs/cycles/20260717_1126_approval-reorder.md
+
+### 2026-07-23 12:06 - COMMIT
+
+- pre-commit-gate（明示指定）rc=0 PASS
+- EXPECTED_CYCLE_DOC を commit 前に捕捉: docs/cycles/20260723_1103_cycle-doc-trailer-and-recall-miss-question.md（/tmp/dev-crew-verify-20260723_1103/expected-cycle-doc.txt）
+- STATUS.md: Done 72→73 + Completed 行 + Last updated 2026-07-23（design review INFO 同時解消）。Test Scripts 114 は GREEN で同期済み
+- 本コミットが Cycle-Doc トレーラーの初回実運用（commit スキル経由）。commit 後に git interpret-trailers で完全一致 + count=1 を検証する
+- commit 同梱: skills 4 + tests 2 + docs/STATUS.md + CHANGELOG.md + 本 cycle doc + docs/cycles/20260721_1503（Block 0 codify 出力、architect/REVIEW で scope 裁定済み）
+- Phase completed

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -61,6 +61,8 @@ Progress Log追記(`### {date} - COMMIT\n- {summary}\n- Phase completed`) + fron
 
 Type: feat / fix / refactor / test。Cycle doc の issue 参照を含める。詳細: [reference.md](reference.md#commit-message)
 
+コミットメッセージ末尾のトレーラーブロックに `Cycle-Doc: <Cycle Doc Gate で解決した active cycle doc パス>` を必ず含める（repo-relative パス 1 件、`Co-Authored-By:` と同じトレーラーブロック内）。詳細: [reference.md](reference.md#commit-message)
+
 ```bash
 git add <files> && git commit -m "..."
 ```

--- a/skills/commit/reference.md
+++ b/skills/commit/reference.md
@@ -28,8 +28,21 @@ Closes #123
 
 🤖 Generated with Claude Code
 
+Cycle-Doc: docs/cycles/20250115_1000_login-implementation.md
 Co-Authored-By: Claude <noreply@anthropic.com>
 ```
+
+### Cycle-Doc トレーラー仕様
+
+commit スキルが作る feature コミットには、末尾トレーラーブロックに `Cycle-Doc:` 行を付与する。配置は issue 参照行（Closes/Refs）の後、`Co-Authored-By:` と同じトレーラーブロック内。
+
+| 項目 | 規定 |
+|------|------|
+| 値 | repo-relative パス（例: `docs/cycles/20250115_1000_login-implementation.md`） |
+| 件数 | 主サイクル 1 件のみ。複数の cycle doc を同梱するコミットでも Cycle Doc Gate が選択した主サイクル 1 件だけを記す |
+| 付与対象 | commit スキル経由のコミットのみ。commit スキル以外の経路（release-skill・手動コミット）ではトレーラーを付与しない（誤リンク防止） |
+
+値は Cycle Doc Gate（SKILL.md の解決ロジック、updated 最新の non-DONE）が選んだ active cycle doc パス。複数 cycle が同時 IN_PROGRESS の場合の値は Gate の選択に従う。
 
 ## Error Handling
 

--- a/skills/cycle-retrospective/SKILL.md
+++ b/skills/cycle-retrospective/SKILL.md
@@ -22,6 +22,7 @@ allowed-tools: Read, Edit, AskUserQuestion
 
 - Cycle doc 全体を読む (plan / phase summaries / review verdicts / test failures / retry log / DISCOVERED)
 - Failure → Final fix → Insight ペアを抽出 (詳細手順: reference.md)
+- 想起漏れ設問を評価: 今回の手戻りは過去のどの cycle doc を最初に読んでいれば防げたか（該当なし可、reference.md の `### 想起漏れ` スキーマで記録）
 - **抽出 0 件 (no reusable lesson)** — 抽出は成功したが再利用可能な知見が見つからないケース (Codex P2-2 対応): 通常 exit path、Retrospective に `No reusable lesson this cycle` を記録して retro_status: resolved に遷移 (user intervention 不要、AskUserQuestion も実行しない)
 - **抽出エラー (LLM error / parse error)** — LLM 実行自体が失敗したケース: retry N=2 → 全失敗時は AskUserQuestion で override (proceed / abort)。no-lesson path と混同しない
 
@@ -30,6 +31,7 @@ allowed-tools: Read, Edit, AskUserQuestion
 state-ownership.md の cycle-retrospective 行に従う:
 
 - **Body**: `## Retrospective` を Cycle doc EOF (`## Next Steps` の後) に append (APPEND-ONLY 遵守、middle-insert 禁止、既存内容は一切変更しない)
+- **想起漏れ記録**: 全正常終了経路（通常テンプレート / no-lesson / override-proceed）で `### 想起漏れ` を記録する。abort（ファイル非変更）のみ対象外
 - **frontmatter**: `retro_status` (none → captured / none → resolved) と `updated` のみ更新
   - `captured`: 有効な insight を追記した場合
   - `resolved`: no-lesson / override-proceed (`Extraction skipped by override` または `Extraction failed after N retries`) の場合

--- a/skills/cycle-retrospective/reference.md
+++ b/skills/cycle-retrospective/reference.md
@@ -9,6 +9,7 @@
 1. **失敗の言語化**: 最初に試みた実装・アプローチと、それがどう失敗したかを具体的に記述する
 2. **最終解の言語化**: 最終的に成功した実装・アプローチを 1-2 文で記述する
 3. **事前知識化**: 「次回この課題に取り組む自分に何を伝えるか」を指示形 1-3 文で記述する
+4. **想起漏れの言語化**: 今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか（該当なし可）。回答は `## Retrospective` 内の `### 想起漏れ` に固定 2 行スキーマで記録する（下記出力テンプレート参照）
 
 ### 抽出ソース
 
@@ -38,7 +39,24 @@ Cycle doc の以下セクションをスキャン:
 - **Failure**: ...
 - **Final fix**: ...
 - **Insight**: ...
+
+### 想起漏れ
+
+- **設問**: 今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか
+- **回答**: 該当なし
 ```
+
+`### 想起漏れ` は固定 2 行スキーマ（設問行 + 回答行）。回答行は行全体が `- **回答**: 該当なし` または `- **回答**: docs/cycles/<filename>.md`（複数時は `docs/cycles/a.md, docs/cycles/b.md` のカンマ区切り）に一致すること。他の表現・自由文で置き換えてはならない。手戻りゼロの cycle でも沈黙せず `該当なし` を明示記録する。
+
+集計手順（10 サイクル計測の機械集計契約）: cycle doc 本文には plan 転記・例示の fenced テンプレートが含まれ得るため、whole-file grep は誤取得する。**最後の** `^## Retrospective$` セクション（EOF append 契約により実 Retrospective は常に最後）を先に抽出してから区間内を検査する:
+
+```bash
+# $cycle_doc は対象 cycle doc のパスを入れた変数（そのまま実行可能な形）
+awk '/^## Retrospective$/{buf=""; found=1} found{buf=buf $0 ORS} END{printf "%s", buf}' "$cycle_doc" \
+  | grep -A3 '^### 想起漏れ$' | grep '^- \*\*回答\*\*:'
+```
+
+出力は回答行ちょうど 1 行であること（`grep -A3` は見出し直後の空行を含むため。-A2 では回答行に届かない）。
 
 ### No-lesson 処理 (抽出成功 + 0 件、Codex P2-2 対応)
 
@@ -48,11 +66,17 @@ Cycle doc の以下セクションをスキャン:
 ## Retrospective
 
 No reusable lesson this cycle
+
+### 想起漏れ
+
+- **設問**: 今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか
+- **回答**: 該当なし
 ```
 
 - retro_status: `resolved` に遷移
 - **AskUserQuestion は実行しない** (user intervention 不要)
 - Retry / override path とは別 (そちらは LLM エラー時のみ)
+- no-lesson 経路でも `### 想起漏れ`（回答 `該当なし`）を必須で併記する（全正常終了経路で記録）
 
 ## Retry Policy (LLM エラー時のみ、Codex P2-2 対応)
 
@@ -74,6 +98,7 @@ LLM エラー時の動作:
 
 - Cycle doc に `## Retrospective` を append する
 - 内容: `Extraction skipped by override` または `Extraction failed after N retries`
+- 併せて `### 想起漏れ`（回答 `該当なし`）を必須で記録する（全正常終了経路で記録。abort のみ対象外）
 - retro_status を `resolved` に遷移させる
 - 通常の exit 0 で終了
 

--- a/tests/test-codify-insight.sh
+++ b/tests/test-codify-insight.sh
@@ -383,27 +383,28 @@ if [ "$TC18_PASS" = "true" ]; then
   pass "TC-18: All 4 files mention codify-insight"
 fi
 
-# TC-19: docs/STATUS.md contains "Skills | 28" AND "Test Scripts | 113", README.md contains "28 skills"
+# TC-19: docs/STATUS.md contains "Skills | 28" AND "Test Scripts | 114", README.md contains "28 skills"
 # Updated 2026-05-25: Test Scripts 110 → 112 (TC01+TC02 added)
 # Updated 2026-06-25: Test Scripts 112 → 113 (test-rules-path-scoping.sh added)
 # Updated 2026-07-02: Skills 32→29, Test Scripts 113→112 (3 skills + 1 test deleted)
 # Updated 2026-07-03: Skills 29→28 (parallel deleted)
 # Updated 2026-07-13: Test Scripts 112→113 (test-review-policy.sh added)
+# Updated 2026-07-23: 113→114 (test-commit-cycle-doc-trailer.sh added)
 echo ""
-echo "TC-19: STATUS.md Skills=28 + Test Scripts=113, README.md 28 skills"
+echo "TC-19: STATUS.md Skills=28 + Test Scripts=114, README.md 28 skills"
 if [ ! -f "$STATUS_MD" ]; then
   fail "TC-19: docs/STATUS.md does not exist"
 else
   has_skills28=$(grep -qE "Skills[[:space:]]*\|[[:space:]]*28" "$STATUS_MD" && echo "yes" || echo "no")
-  has_scripts113=$(grep -qE "Test Scripts[[:space:]]*\|[[:space:]]*113" "$STATUS_MD" && echo "yes" || echo "no")
+  has_scripts114=$(grep -qE "Test Scripts[[:space:]]*\|[[:space:]]*114" "$STATUS_MD" && echo "yes" || echo "no")
   has_readme28=$(grep -qE "28 skills" "$README_MD" 2>/dev/null && echo "yes" || echo "no")
-  if [ "$has_skills28" = "yes" ] && [ "$has_scripts113" = "yes" ] && [ "$has_readme28" = "yes" ]; then
-    pass "TC-19: STATUS.md Skills=28 + Test Scripts=113, README.md 28 skills"
+  if [ "$has_skills28" = "yes" ] && [ "$has_scripts114" = "yes" ] && [ "$has_readme28" = "yes" ]; then
+    pass "TC-19: STATUS.md Skills=28 + Test Scripts=114, README.md 28 skills"
   else
     skills_current=$(grep -oE "Skills[[:space:]]*\|[[:space:]]*[0-9]+" "$STATUS_MD" | grep -oE "[0-9]+$" | head -1 || echo "not found")
     scripts_current=$(grep -oE "Test Scripts[[:space:]]*\|[[:space:]]*[0-9]+" "$STATUS_MD" | grep -oE "[0-9]+$" | head -1 || echo "not found")
     readme_current=$(grep -oE "[0-9]+ skills" "$README_MD" 2>/dev/null | head -1 || echo "not found")
-    fail "TC-19: STATUS.md Skills=$skills_current (need 28), Test Scripts=$scripts_current (need 113), README=$readme_current (need '28 skills')"
+    fail "TC-19: STATUS.md Skills=$skills_current (need 28), Test Scripts=$scripts_current (need 114), README=$readme_current (need '28 skills')"
   fi
 fi
 

--- a/tests/test-commit-cycle-doc-trailer.sh
+++ b/tests/test-commit-cycle-doc-trailer.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+# test-commit-cycle-doc-trailer.sh - Cycle-Doc trailer (commit) + recall-miss question (cycle-retrospective)
+#
+# All TCs extract the target H2/H3 section region first (fence-aware), then grep
+# within the region. Whole-file grep is forbidden: the target docs embed markdown
+# code fences whose lines begin with "## " (e.g. "## Retrospective"), which a naive
+# whole-file scan would mis-detect as headings.
+
+set -uo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf "  \033[32mPASS\033[0m %s\n" "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf "  \033[31mFAIL\033[0m %s\n" "$1"; }
+
+COMMIT_SKILL="$BASE_DIR/skills/commit/SKILL.md"
+COMMIT_REF="$BASE_DIR/skills/commit/reference.md"
+RETRO_SKILL="$BASE_DIR/skills/cycle-retrospective/SKILL.md"
+RETRO_REF="$BASE_DIR/skills/cycle-retrospective/reference.md"
+
+# section_lines <file> <start_marker> <term_level>
+#   start_marker: full heading incl leading hashes, fixed-string prefix (no ERE meta).
+#   term_level:   terminate at the next heading whose level (# count) <= term_level.
+#   Fence-aware: lines inside ``` code fences are emitted as body and never treated
+#   as headings (so a fenced "## Retrospective" does not terminate the region).
+section_lines() {
+  awk -v sm="$2" -v tl="$3" '
+    /^```/ { fence = !fence; if (in_sec) print; next }
+    !in_sec && !fence && index($0, sm) == 1 { in_sec = 1; next }
+    in_sec && !fence && /^#+ / {
+      n = 0; while (substr($0, n + 1, 1) == "#") n++;
+      if (n <= tl) { in_sec = 0; next }
+    }
+    in_sec { print }
+  ' "$1"
+}
+
+# section_count <file> <start_marker> <term_level> <fixed_pattern> → prints match count
+# `--` guards patterns that begin with '-' (e.g. "- **回答**:") from option parsing.
+section_count() {
+  section_lines "$1" "$2" "$3" | grep -cF -- "$4" || true
+}
+
+echo "=== Cycle-Doc trailer + recall-miss question Tests ==="
+
+# --- TC-T1: commit/SKILL.md Step 4 has Cycle-Doc trailer instruction + whole file <= 100 lines ---
+echo ""
+echo "TC-T1: skills/commit/SKILL.md Step 4 section has 'Cycle-Doc' trailer instruction + <= 100 lines"
+if [ ! -f "$COMMIT_SKILL" ]; then
+  fail "TC-T1: skills/commit/SKILL.md does not exist"
+else
+  count_trailer=$(section_count "$COMMIT_SKILL" "### Step 4" 3 "Cycle-Doc")
+  lines=$(wc -l < "$COMMIT_SKILL" | tr -d ' ')
+  if [ "$count_trailer" -ge 1 ] && [ "$lines" -le 100 ]; then
+    pass "TC-T1: Step 4 has Cycle-Doc trailer instruction + SKILL.md is $lines lines (<= 100)"
+  elif [ "$count_trailer" -lt 1 ]; then
+    fail "TC-T1: Step 4 section missing 'Cycle-Doc' trailer instruction"
+  else
+    fail "TC-T1: skills/commit/SKILL.md exceeds 100 lines ($lines lines)"
+  fi
+fi
+
+# --- TC-T2: commit/reference.md コミットメッセージ詳細 has trailer example + two clauses ---
+echo ""
+echo "TC-T2: skills/commit/reference.md コミットメッセージ詳細 has 'Cycle-Doc:' + 'commit スキル以外の経路' + '主サイクル 1 件'"
+if [ ! -f "$COMMIT_REF" ]; then
+  fail "TC-T2: skills/commit/reference.md does not exist"
+else
+  count_example=$(section_count "$COMMIT_REF" "## コミットメッセージ詳細" 2 "Cycle-Doc:")
+  count_scope=$(section_count "$COMMIT_REF" "## コミットメッセージ詳細" 2 "commit スキル以外の経路")
+  count_primary=$(section_count "$COMMIT_REF" "## コミットメッセージ詳細" 2 "主サイクル 1 件")
+  if [ "$count_example" -ge 1 ] && [ "$count_scope" -ge 1 ] && [ "$count_primary" -ge 1 ]; then
+    pass "TC-T2: コミットメッセージ詳細 has Cycle-Doc: example + non-skill-path clause + single-primary clause"
+  elif [ "$count_example" -lt 1 ]; then
+    fail "TC-T2: コミットメッセージ詳細 section missing 'Cycle-Doc:' trailer line in example"
+  elif [ "$count_scope" -lt 1 ]; then
+    fail "TC-T2: コミットメッセージ詳細 section missing 'commit スキル以外の経路' clause"
+  else
+    fail "TC-T2: コミットメッセージ詳細 section missing '主サイクル 1 件' clause"
+  fi
+fi
+
+# --- TC-T3: cycle-retrospective/reference.md recall-miss question, schema, no-lesson + override paths ---
+echo ""
+echo "TC-T3: skills/cycle-retrospective/reference.md recall-miss question + schema + no-lesson/override paths"
+if [ ! -f "$RETRO_REF" ]; then
+  fail "TC-T3: skills/cycle-retrospective/reference.md does not exist"
+else
+  # (a) recall-miss question in the extraction-algorithm section
+  count_question=$(section_count "$RETRO_REF" "## 抽出アルゴリズム" 2 "どの cycle doc を最初に読んでいれば防げたか")
+  # (b) fixed 2-line schema + answer-format regulation in the output-template section
+  count_schema_q=$(section_count "$RETRO_REF" "## 出力テンプレート" 2 "- **設問**: 今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか")
+  count_schema_a=$(section_count "$RETRO_REF" "## 出力テンプレート" 2 "- **回答**:")
+  count_answer_none=$(section_count "$RETRO_REF" "## 出力テンプレート" 2 "該当なし")
+  count_answer_path=$(section_count "$RETRO_REF" "## 出力テンプレート" 2 "docs/cycles/")
+  # (b2) collection contract: doc must specify last-Retrospective-section extraction
+  # (whole-file grep would pick up transcribed plan templates inside real cycle docs),
+  # and the documented pipeline must extract exactly the real answer from a fixture
+  # containing a fenced decoy template plus a real trailing Retrospective section.
+  count_awk_last=$(section_count "$RETRO_REF" "## 出力テンプレート" 2 "awk '/^## Retrospective\$/")
+  count_a3=$(section_count "$RETRO_REF" "## 出力テンプレート" 2 "grep -A3 '^### 想起漏れ\$'")
+  fixture=$(mktemp)
+  cat > "$fixture" << 'ORACLE_FIXTURE'
+# fixture doc
+
+## Plan Transcription
+
+```markdown
+### 想起漏れ
+
+- **設問**: 今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか
+- **回答**: 該当なし
+```
+
+## Retrospective
+
+### Insight 1
+
+- **Failure**: x
+
+### 想起漏れ
+
+- **設問**: 今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか
+- **回答**: docs/cycles/real.md
+ORACLE_FIXTURE
+  a3_output=$(awk '/^## Retrospective$/{buf=""; found=1} found{buf=buf $0 ORS} END{printf "%s", buf}' "$fixture" \
+    | grep -A3 '^### 想起漏れ$' 2>/dev/null || true)
+  a3_oracle_count=$(echo "$a3_output" | grep -cF -- "- **回答**:" || true)
+  a3_oracle_value=$(echo "$a3_output" | grep -cF -- "- **回答**: docs/cycles/real.md" || true)
+  rm -f "$fixture"
+  a3_oracle=0
+  if [ "${a3_oracle_count:-0}" -eq 1 ] && [ "${a3_oracle_value:-0}" -eq 1 ]; then
+    a3_oracle=1
+  fi
+  # (b3) every answer line in the doc (all templates: normal / no-lesson / override)
+  # must match the anchored allowed pattern — whole-file scope is intentional here
+  answer_lines_total=$(grep -cE '^- \*\*回答\*\*:' "$RETRO_REF" || true)
+  answer_lines_valid=$(grep -cE '^- \*\*回答\*\*: (該当なし|docs/cycles/[^ ]+\.md(, docs/cycles/[^ ]+\.md)*)$' "$RETRO_REF" || true)
+  # (c) both no-lesson section and override section require ### 想起漏れ
+  count_nolesson=$(section_count "$RETRO_REF" "### No-lesson 処理" 2 "想起漏れ")
+  count_override=$(section_count "$RETRO_REF" "### proceed (続行)" 3 "想起漏れ")
+  # abort must NOT write anything (file-untouched contract) — negative pin
+  count_abort_neg=$(section_count "$RETRO_REF" "### abort (中止)" 3 "想起漏れ")
+  if [ "$count_question" -ge 1 ] && \
+     [ "$count_schema_q" -ge 1 ] && [ "$count_schema_a" -ge 1 ] && \
+     [ "$count_answer_none" -ge 1 ] && [ "$count_answer_path" -ge 1 ] && \
+     [ "${count_awk_last:-0}" -ge 1 ] && [ "${count_a3:-0}" -ge 1 ] && [ "${a3_oracle:-0}" -ge 1 ] && \
+     [ "${answer_lines_total:-0}" -ge 1 ] && [ "$answer_lines_total" -eq "$answer_lines_valid" ] && \
+     [ "$count_nolesson" -ge 1 ] && [ "$count_override" -ge 1 ] && [ "${count_abort_neg:-0}" -eq 0 ]; then
+    pass "TC-T3: recall-miss question + 2-line schema + no-lesson/override paths all present"
+  elif [ "$count_question" -lt 1 ]; then
+    fail "TC-T3: 抽出アルゴリズム section missing recall-miss question 'どの cycle doc を最初に読んでいれば防げたか'"
+  elif [ "$count_schema_q" -lt 1 ]; then
+    fail "TC-T3: 出力テンプレート section missing schema 設問 line literal"
+  elif [ "$count_schema_a" -lt 1 ]; then
+    fail "TC-T3: 出力テンプレート section missing schema '- **回答**:' line"
+  elif [ "$count_answer_none" -lt 1 ] || [ "$count_answer_path" -lt 1 ]; then
+    fail "TC-T3: 出力テンプレート section missing answer-format values ('該当なし' / 'docs/cycles/')"
+  elif [ "${count_awk_last:-0}" -lt 1 ] || [ "${count_a3:-0}" -lt 1 ] || [ "${a3_oracle:-0}" -lt 1 ]; then
+    fail "TC-T3: collection contract broken (last-section awk spec / anchored grep -A3 spec missing, or oracle did not extract exactly the real answer)"
+  elif [ "${answer_lines_total:-0}" -lt 1 ] || [ "$answer_lines_total" -ne "$answer_lines_valid" ]; then
+    fail "TC-T3: answer line(s) violate anchored format (total=$answer_lines_total valid=$answer_lines_valid)"
+  elif [ "$count_nolesson" -lt 1 ]; then
+    fail "TC-T3: No-lesson 処理 section missing '想起漏れ' record requirement"
+  elif [ "$count_override" -lt 1 ]; then
+    fail "TC-T3: proceed (続行) subsection missing '想起漏れ' record requirement"
+  else
+    fail "TC-T3: abort (中止) subsection must NOT mention '想起漏れ' (abort is file-untouched)"
+  fi
+fi
+
+# --- TC-T4: cycle-retrospective/SKILL.md Extraction/Output mention question + all-normal-exit; 3 fixed strings intact ---
+echo ""
+echo "TC-T4: skills/cycle-retrospective/SKILL.md Extraction/Output has recall-miss + 全正常終了経路 + 3 fixed strings unchanged"
+if [ ! -f "$RETRO_SKILL" ]; then
+  fail "TC-T4: skills/cycle-retrospective/SKILL.md does not exist"
+else
+  count_ext_question=$(section_count "$RETRO_SKILL" "### Extraction" 3 "想起漏れ")
+  count_out_allexit=$(section_count "$RETRO_SKILL" "### Output" 3 "全正常終了経路")
+  count_fixed_nolesson=$(section_count "$RETRO_SKILL" "### Extraction" 3 "No reusable lesson this cycle")
+  count_fixed_skipped=$(section_count "$RETRO_SKILL" "### Output" 3 "Extraction skipped by override")
+  count_fixed_retries=$(section_count "$RETRO_SKILL" "### Output" 3 "Extraction failed after N retries")
+  if [ "$count_ext_question" -ge 1 ] && [ "$count_out_allexit" -ge 1 ] && \
+     [ "$count_fixed_nolesson" -ge 1 ] && [ "$count_fixed_skipped" -ge 1 ] && [ "$count_fixed_retries" -ge 1 ]; then
+    pass "TC-T4: Extraction/Output mention recall-miss + all-normal-exit; 3 fixed strings intact"
+  elif [ "$count_ext_question" -lt 1 ]; then
+    fail "TC-T4: Extraction section missing '想起漏れ' recall-miss mention"
+  elif [ "$count_out_allexit" -lt 1 ]; then
+    fail "TC-T4: Output section missing '全正常終了経路' record instruction"
+  else
+    fail "TC-T4: a fixed string was altered/removed (nolesson=$count_fixed_nolesson skipped=$count_fixed_skipped retries=$count_fixed_retries)"
+  fi
+fi
+
+# --- TC-T5: order contract — Cycle-Doc: after <type>: line, adjacent to Co-Authored-By trailer block ---
+echo ""
+echo "TC-T5: skills/commit/reference.md example — 'Cycle-Doc:' after '<type>:' line, near 'Co-Authored-By:'"
+if [ ! -f "$COMMIT_REF" ]; then
+  fail "TC-T5: skills/commit/reference.md does not exist"
+else
+  example=$(section_lines "$COMMIT_REF" "### 良いコミットメッセージ" 3)
+  type_ln=$(printf '%s\n' "$example" | grep -nF "feat:" | head -1 | cut -d: -f1)
+  cyc_ln=$(printf '%s\n' "$example" | grep -nF "Cycle-Doc:" | head -1 | cut -d: -f1)
+  co_ln=$(printf '%s\n' "$example" | grep -nF "Co-Authored-By:" | head -1 | cut -d: -f1)
+  if [ -z "$cyc_ln" ]; then
+    fail "TC-T5: example has no 'Cycle-Doc:' trailer line"
+  elif [ -z "$type_ln" ] || [ -z "$co_ln" ]; then
+    fail "TC-T5: example missing '<type>:' (feat:) or 'Co-Authored-By:' anchor"
+  else
+    diff=$((cyc_ln - co_ln))
+    [ "$diff" -lt 0 ] && diff=$((-diff))
+    if [ "$type_ln" -lt "$cyc_ln" ] && [ "$diff" -le 3 ]; then
+      pass "TC-T5: Cycle-Doc: (line $cyc_ln) is after type (line $type_ln) and within trailer block (Co-Authored-By line $co_ln)"
+    elif [ "$type_ln" -ge "$cyc_ln" ]; then
+      fail "TC-T5: 'Cycle-Doc:' (line $cyc_ln) must appear after '<type>:' line (line $type_ln)"
+    else
+      fail "TC-T5: 'Cycle-Doc:' (line $cyc_ln) not adjacent to Co-Authored-By trailer block (line $co_ln, distance $diff > 3)"
+    fi
+  fi
+fi
+
+# --- TC-R1 (regression): cycle-retrospective/reference.md 固定文字列 Contract keeps all 3 fixed strings ---
+echo ""
+echo "TC-R1: skills/cycle-retrospective/reference.md 固定文字列 Contract keeps 3 fixed strings (test-cycle-retrospective non-破壊)"
+if [ ! -f "$RETRO_REF" ]; then
+  fail "TC-R1: skills/cycle-retrospective/reference.md does not exist"
+else
+  r1_skipped=$(section_count "$RETRO_REF" "## 固定文字列 Contract" 2 "Extraction skipped by override")
+  r1_retries=$(section_count "$RETRO_REF" "## 固定文字列 Contract" 2 "Extraction failed after N retries")
+  r1_nolesson=$(section_count "$RETRO_REF" "## 固定文字列 Contract" 2 "No reusable lesson this cycle")
+  if [ "$r1_skipped" -ge 1 ] && [ "$r1_retries" -ge 1 ] && [ "$r1_nolesson" -ge 1 ]; then
+    pass "TC-R1: 固定文字列 Contract retains all 3 fixed strings"
+  else
+    fail "TC-R1: 固定文字列 Contract missing a fixed string (skipped=$r1_skipped retries=$r1_retries nolesson=$r1_nolesson)"
+  fi
+fi
+
+# --- TC-R2 (regression): cycle-retrospective/SKILL.md Workflow keeps all 3 fixed strings ---
+echo ""
+echo "TC-R2: skills/cycle-retrospective/SKILL.md Workflow keeps 3 fixed strings (commit/phase-gate non-破壊 proxy)"
+if [ ! -f "$RETRO_SKILL" ]; then
+  fail "TC-R2: skills/cycle-retrospective/SKILL.md does not exist"
+else
+  r2_skipped=$(section_count "$RETRO_SKILL" "## Workflow" 2 "Extraction skipped by override")
+  r2_retries=$(section_count "$RETRO_SKILL" "## Workflow" 2 "Extraction failed after N retries")
+  r2_nolesson=$(section_count "$RETRO_SKILL" "## Workflow" 2 "No reusable lesson this cycle")
+  if [ "$r2_skipped" -ge 1 ] && [ "$r2_retries" -ge 1 ] && [ "$r2_nolesson" -ge 1 ]; then
+    pass "TC-R2: Workflow retains all 3 fixed strings"
+  else
+    fail "TC-R2: Workflow missing a fixed string (skipped=$r2_skipped retries=$r2_retries nolesson=$r2_nolesson)"
+  fi
+fi
+
+# Summary
+echo ""
+echo "=== Summary ==="
+echo "PASS: $PASS / FAIL: $FAIL / TOTAL: $((PASS + FAIL))"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- **Cycle-Doc トレーラー**: commit スキルがコミットメッセージのトレーラーブロックに主サイクル 1 件の `Cycle-Doc:` を自動付与（#187 の来歴基盤。commit スキル以外の経路では付与しない誤リンク防止を明文化）
- **想起漏れ計測設問**: cycle-retrospective に「今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか」を追加。固定 2 行スキーマで全正常終了経路に必須、回収は「最後の Retrospective セクション先行抽出 → grep -A3」の二段契約（fixture oracle で pin）
- tests/test-commit-cycle-doc-trailer.sh 新規 7TC（fence-aware 区間抽出）、Test Scripts 113→114 同期

## Verification
- full suite 114/114 rc=0（baseline 113/113 + 新規 1、REFACTOR Verification Gate）
- **本 PR のコミット自体がトレーラー初回実運用**: `git interpret-trailers --parse` で count=1・commit 前捕捉の期待値と完全一致（TRAILER MATCH）
- 想起漏れも本 cycle の retrospective で初適用: 回答 = 20260717_1605, 20260717_1126（二段回収 pipeline の self-apply 実測成功）
- Codex plan review 2 attempt + code review 3 ラウンド + Claude 4 panel の findings 計 13 件 triage 済み（accept-apply 8 / accept-defer 3 → #185 / reject 2）

Refs #187 #185
Cycle doc: docs/cycles/20260723_1103_cycle-doc-trailer-and-recall-miss-question.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)