### PR TITLE
feat: spec 時強制想起 — 関連 cycle doc の自動提示（#187 R2 本体）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- spec に強制想起（Forced Recall、Step 7.2）を追加（#187）: Files to Change 確定後・Step 8 の前に `scripts/recall-candidates.sh` を実行し、変更予定ファイルに関連する過去 cycle doc を決定論的に提示する。データソースは既存のもののみ（`git log --name-only` の共変更 + Cycle-Doc トレーラーの確定リンク優先）で、ハブファイルは IDF 相当で寄与を減衰。上位候補を助言者形式 3 点セット（何が起きたか / 当時の前提 / 今回も同じ前提か）で plan の `## Recall` に記録し、sync-plan が Cycle doc へ転記する。正本変更ゼロ・冪等・常駐プロセスなし
 - コミットメッセージに `Cycle-Doc: <path>` トレーラーを付与（commit スキル）: feature コミットと cycle doc を機械可読なリンクで結ぶ。値は Cycle Doc Gate が解決した主サイクル 1 件の repo-relative パス。commit スキル以外の経路（release-skill・手動コミット）には付与しない
 - cycle-retrospective に想起漏れ設問を追加: 「今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか」を全正常終了経路で `### 想起漏れ` 固定 2 行スキーマ（回答 `該当なし` or `docs/cycles/<file>.md`）に記録し、機械集計可能にする
 

--- a/agents/sync-plan.md
+++ b/agents/sync-plan.md
@@ -62,6 +62,7 @@ planファイルから以下をCycle docに転記:
 | Risk Interview | BLOCK時のインタビュー回答 |
 | Context & Dependencies | 依存関係・参照ドキュメント |
 | Implementation Notes | Goal, Background, Design Approach |
+| Recall | ## Recall（関連過去サイクル・助言者形式） |
 
 ### Step 3: Transfer Test List
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,11 +5,11 @@
 | Metric | Value |
 |--------|-------|
 | In-Progress Cycles | 0 |
-| Done (unarchived) | 73 |
+| Done (unarchived) | 74 |
 | Archived Cycles | 37 |
 | Skills | 28 |
 | Agents | 41 |
-| Test Scripts | 114 |
+| Test Scripts | 115 |
 
 Last updated: 2026-07-23
 
@@ -17,6 +17,7 @@ Last updated: 2026-07-23
 
 | Date | Cycle | Type |
 |------|-------|------|
+| 2026-07-23 | 20260723_1328: spec-forced-recall (強制想起本体 #187 R2。spec Step 7.2 + scripts/recall-candidates.sh — トレーラー優先・共変更・unique ペアハブ減衰・archive 二段解決。Test Scripts 114→115) | feat |
 | 2026-07-23 | 20260723_1103: cycle-doc-trailer-and-recall-miss-question (強制想起 #187 先行実装。commit スキルに Cycle-Doc トレーラー自動付与 + cycle-retrospective に想起漏れ設問・固定 2 行スキーマ・二段回収契約。Test Scripts 113→114) | feat |
 | 2026-07-21 | 20260721_1503: rules-load-trigger-reclassification (rules ロード契機 4 分類。7 workflow rules を cycle-scoped 化し常時ロード 449→103 行 77% 減。フェーズ入口 Read 契約 pin TC-05〜11、codify tier 仕様。#185/#186/#187 起票) | feat |
 | 2026-07-17 | 20260717_1605: approval-reorder-cycle2 (narrative doc + onboard 配布テンプレートを新順序へ。onboard L521 security 修正、CHANGELOG [Unreleased]+Breaking、#179 close) | docs |

--- a/docs/cycles/20260723_1103_cycle-doc-trailer-and-recall-miss-question.md
+++ b/docs/cycles/20260723_1103_cycle-doc-trailer-and-recall-miss-question.md
@@ -5,12 +5,12 @@ phase: DONE
 complexity: simple
 test_count: 7
 risk_level: low
-retro_status: captured
+retro_status: resolved
 codex_session_id: "019f8879-bbcc-7120-b707-867068837504"
 codex_mode: no
 plan_file: /Users/morodomi/.claude/plans/hashed-tickling-honey.md
 created: 2026-07-23 11:04
-updated: 2026-07-23 12:06
+updated: 2026-07-23 13:28
 ---
 
 # v2.15 強制想起 先行 cycle: Cycle-Doc トレーラー + 想起漏れ計測設問
@@ -330,3 +330,19 @@ reject（2 件、理由付き）:
 - 本コミットが Cycle-Doc トレーラーの初回実運用（commit スキル経由）。commit 後に git interpret-trailers で完全一致 + count=1 を検証する
 - commit 同梱: skills 4 + tests 2 + docs/STATUS.md + CHANGELOG.md + 本 cycle doc + docs/cycles/20260721_1503（Block 0 codify 出力、architect/REVIEW で scope 裁定済み）
 - Phase completed
+
+## Codify Decisions
+
+### Insight 1
+- **Decision**: codified
+- **Destination**: rule
+- **Tier**: file-scoped
+- **Paths**: tests/**
+- **Reason**: 「機械可読契約は実行可能コマンド + fixture oracle の対で書く」は cycle 20260717_1605 #1（見出し区間先行抽出）の消費側拡張で、契約-oracle 系の再発。rules/test-patterns.md（file-scoped 既存）へ追記（follow-up 実装、#185 のテスト強度強化と同時が効率的）
+- **Decided**: 2026-07-23 13:28
+
+### Insight 2
+- **Decision**: codified
+- **Destination**: inline-update
+- **Reason**: Plan Review Record の厳密形式（入れ子 {started: ...} / override 実証跡必須）を skills/spec/reference.md の Plan File Template に明記する 1-2 行の直接更新。次に spec を使う cycle の手戻りを即防ぐ
+- **Decided**: 2026-07-23 13:28

--- a/docs/cycles/20260723_1328_spec-forced-recall.md
+++ b/docs/cycles/20260723_1328_spec-forced-recall.md
@@ -1,0 +1,338 @@
+---
+feature: spec-forced-recall
+cycle: 20260723_1328
+phase: DONE
+complexity: standard
+test_count: 16
+risk_level: medium
+retro_status: captured
+codex_session_id: "019f8d37-91ba-7551-a0af-70ca0aa356d4"
+codex_mode: no
+plan_file: /Users/morodomi/.claude/plans/hashed-tickling-honey.md
+created: 2026-07-23 13:29
+updated: 2026-07-23 15:37
+---
+
+# spec-time forced recall of related cycle docs
+
+## Scope Definition
+
+### In Scope
+- [ ] scripts/recall-candidates.sh を新規作成し、共変更 + トレーラー優先の決定論的候補生成を実装する
+- [ ] skills/spec/SKILL.md に Step 7.2: Forced Recall を追加（L83/L95 圧縮で 2 行捻出、<100 行維持）
+- [ ] skills/spec/reference.md + reference.ja.md に `## Forced Recall {#forced-recall}` セクションと Plan File Template への `## Recall` ブロックを追加
+- [ ] agents/sync-plan.md の転記テーブルに Recall 行を追加
+- [ ] skills/spec/templates/cycle.md に転記先 `## Recall` セクションを追加
+- [ ] tests/test-recall-candidates.sh を新規作成（fixture git repo による script 契約 + doc 契約）
+- [ ] docs/STATUS.md の Test Scripts 114→115 同期
+- [ ] tests/test-codify-insight.sh TC-19 の 114→115 同期（regex + echo + `has_scripts114`→`has_scripts115` rename + bump 履歴コメント）
+- [ ] CHANGELOG.md [Unreleased] Added 追記
+
+### Out of Scope
+- R4 集計スクリプト（想起採否の機械集計） (Reason: 計測期間終了時に実装予定、本 cycle は data 蓄積の基盤のみ)
+- Plan File Template への `## Files to Change` ブロック正式化 (Reason: 現行慣行 [agent-prompts rule の全量列挙] で機能中。R4 計測で入力欠落 miss が出たら再評価)
+- rules 降格棚卸し（cycle-scoped → 想起層） (Reason: R4 完了後に実施、v2.14 からの継続 DISCOVERED)
+
+### Files to Change（全量 10 件。追加・削除禁止 — architect の ≤10 制約ちょうど、余白ゼロ。GREEN/REFACTOR で collateral fix が発生した場合は scope +1 の即時 SSOT 記録 + REVIEW 裁定で処理する — design review WARN の事前明記）
+- scripts/recall-candidates.sh (new)
+- skills/spec/SKILL.md (edit)
+- skills/spec/reference.md (edit)
+- skills/spec/reference.ja.md (edit)
+- agents/sync-plan.md (edit)
+- skills/spec/templates/cycle.md (edit)
+- tests/test-recall-candidates.sh (new)
+- docs/STATUS.md (edit)
+- tests/test-codify-insight.sh (edit)
+- CHANGELOG.md (edit)
+
+**scope 同梱注記**: docs/cycles/20260723_1103_cycle-doc-trailer-and-recall-miss-question.md — orchestrate Block 0 codify gate 出力（retro_status: resolved + Codify Decisions 追記、2026-07-23 13:28）。本 cycle commit に同梱する（内容編集はしない）。
+
+## Environment
+
+### Scope
+- Layer: Plugin 全体（doc/bash プロジェクトのため Backend/Frontend 区分は非該当）
+- Plugin: bash + markdown（テストは tests/test-*.sh）
+- Risk: 30 (WARN — spec ワークフローへのステップ追加 + 新規 script。security/external/DB 該当なし)
+
+### Runtime
+- Language: bash 3.2.57, git 2.49.0
+
+### Dependencies (key packages)
+- なし（shell テストのみ）
+
+### Risk Interview (BLOCK only)
+- 該当なし（Risk 30 = WARN。BLOCK ではないため Risk Interview 不要）
+
+## Context & Dependencies
+
+### Reference Documents
+- docs/cycles/20260723_1103_cycle-doc-trailer-and-recall-miss-question.md - R1 トレーラー + R3 想起漏れ設問の先行 cycle（PR #190）。本 cycle はその上に spec-time forced recall 本体を構築する
+- 要求仕様書（2026-07-17、issue #187） - データソース制約（既存のみ・frontmatter 拡張なし・SQLite/embeddings なし）、助言者形式原則、提示件数・除外なしの原則の出典
+- rules/integration-verification.md - real-path invocation 契約（本 cycle の Verification section の設計根拠）
+- rules/multi-file-consistency.md - 順序検証・deterministic gate の設計根拠（recall-candidates.sh の awk 集計・hash 境界設計）
+- rules/doc-mutations.md - hash 境界（`## Recall` を Plan Review Record より前に配置する順序制約の根拠）
+
+### Dependent Features
+- spec skill (Step 8: Codex plan review): Forced Recall はこの直前（Step 7.2）に発火し、想起結果が plan review の検査対象になる
+- sync-plan agent: `## Recall` の転記テーブル行追加を必要とする
+- pre-red-gate.sh: hash 境界の正準アルゴリズムが `## Recall` の配置位置を規定する
+
+### Related Issues/PRs
+- Issue #187: R2 ロードマップ（ユーザー決定 2026-07-22）に従う本体実装
+
+## Test List
+
+### TODO
+(none — all items transitioned to WIP in RED)
+
+注記: fixture git repo は mktemp -d + trap EXIT + `git -C` init + GIT_AUTHOR_*/GIT_COMMITTER_* 環境固定（決定論）で構築する。前例なし（新規パターン導入、`grep -rln "git init" tests/ scripts/` 0 件）。doc 契約（TC-D1〜D3）は見出し区間先行抽出で検査し、whole-file grep は禁止。
+
+### WIP
+(none — all 16 transitioned to DONE in GREEN)
+
+### DISCOVERED
+- R4 集計スクリプト（10 サイクル分の Recall 採否 + 想起漏れ回答の機械集計）: 計測期間終了時に実装。データは本 cycle の `## Recall`（plan→cycle doc 転記、hash 保護）+ 想起漏れ回答（二段回収契約済み）で蓄積される
+- Plan File Template への `## Files to Change` ブロック正式化（探索で指摘された gap — recall の入力アンカーが慣行依存）: 現行慣行（agent-prompts rule による全量列挙）で機能しているため見送り。R4 計測で入力欠落 miss が出たら再評価
+- rules 降格棚卸し（cycle-scoped → 想起層）: R4 完了後（v2.14 からの継続）
+
+### DONE
+- [x] TC-S1（トレーラー優先）
+- [x] TC-S2（共変更 fallback）
+- [x] TC-S3（ハブ減衰）
+- [x] TC-S4（recency tie-break）
+- [x] TC-S5（0 件 + exit code）
+- [x] TC-S6（現存しない doc の除外報告）
+- [x] TC-S7（冪等）
+- [x] TC-S8（上位 N 制限 + TSV 形式）
+- [x] TC-S9（正本変更ゼロ）
+- [x] TC-S10（archive 解決）
+- [x] TC-S11（ペア重複排除）
+- [x] TC-D1（spec 統合）
+- [x] TC-D2（reference 両言語）
+- [x] TC-D3（転記配線）
+- [x] TC-R1（回帰: post-approve-ordering proxy）
+- [x] TC-R2（回帰: ja Template proxy）
+
+## Implementation Notes
+
+### Goal
+spec フェーズの固定点に「変更予定ファイルに関連する過去 cycle doc の自動提示」を注入する。pull 型検索（問い合わせ待ち）を廃し、ワークフロー固定点で必ず発火させる構造にすることで、想起を記憶力の問題から構造の問題に変える。
+
+### Background
+強制想起（issue #187、要求仕様書 2026-07-17）の本体。先行 cycle（20260723_1103、PR #190）で R1 トレーラーと R3 想起漏れ設問が稼働済み。本 cycle はその上に spec-time forced recall 本体を構築する。
+
+設計の中心（要求仕様書 + 事前議論で確定済み）:
+- データソースは既存のもののみ: `git log --name-only`（共変更）+ Cycle-Doc トレーラー（R1、確定リンク優先）+ 既存 cycle doc。frontmatter 拡張・SQLite・embeddings は使わない
+- ハブファイル重み付けは必須（2026-07-21 実測: STATUS.md は 49 cycle doc、orchestrate SKILL は 33 に共変更リンク vs 葉ファイル 4-6。重み付けなしでは「常に直近 5 サイクル」に縮退する）
+- 発火点は spec の Files to Change 確定後・Step 8（Codex plan review）前。想起結果が plan に入ることで「当時の前提が今回も成立するか」自体が plan review の検査対象になる
+- 提示は助言者形式 3 点セット（何が起きたか / 当時の前提 / 今回も同じ前提か）、上位 5 件程度・新しい順優先・該当なしも 1 行明示（沈黙しない）
+- 提示結果は plan の独立セクションに記録 — R4 の行動基準「参照が plan 本文に残存」の計測はこれを grep する
+- 正本（cycle doc・コード）変更ゼロ / 常駐プロセスなし / 冪等
+
+#### Ambiguity Resolution（事前議論で確定済み）
+- 候補生成は決定論 script（テスト可能）、助言者形式 3 点セットの要約のみ LLM（spec 実行時に上位候補の cycle doc を読む）
+- ハブ重み付けの方式: ファイル F の寄与 = 1 / (F に共変更リンクする cycle doc 数)（IDF 相当。除外でなく重み — 仕様原則「導出構造は miss 実測まで追加しない」「古いものも除外しない」と整合）
+- トレーラーリンクは共変更推定より高優先（確定来歴）。過去 348 コミット（トレーラーなし）は共変更推定でカバー
+- spec SKILL.md は 99 行のため、ステップ追加は圧縮とセット（圧縮対象は探索で確定）
+
+#### Baseline 実測（2026-07-23、Explore agents 2 体）
+- spec SKILL.md = 99 行。TC-R4（tests/test-post-approve-ordering.sh:154-170）が Step 8 見出し存在 + `<100` 行を厳密 pin → ステップ追加は圧縮とセットが必須。圧縮対象確定: L83（Step 7.1 の憲法 doc 列挙 → reference.md#constitution-check に既存、重複） + L95（Step 8 の resume フラグ注記 → reference.md:13 と verbatim 重複、既存アンカーあり）で計 ~2 行捻出
+- hash 境界の確認: 正準 hash = `## Plan Review Record` 行より前の全内容（scripts/gates/pre-red-gate.sh:274-284）。`## Recall` を Record より前（Plan File Template の TDD Context 後、reference.md:536-538 間）に置けば hash 領域内 = 承認後改変から保護され R4 計測が信頼できる。必然の順序制約: Recall は Step 8 実行前に書き終える（Step 8 後の追記は reviewed_plan_hash を無効化し pre-red-gate BLOCK）
+- sync-plan は固定転記テーブル（agents/sync-plan.md:56-64）— `## Recall` は自動転記されない。テーブル行追加 + templates/cycle.md へ転記先セクション追加が必要
+- reference.ja.md（519 行）は準ミラー — Step 8 / Plan File Template を含み lockstep 更新必須（tests/test-spec-onboard-improvements.sh TC-02 が ja の Template を pin）
+- fixture git repo のテスト前例ゼロ（`grep -rln "git init" tests/ scripts/` 0 件）→ 新規パターン導入: mktemp + `git -C "$TMPREPO" init` + GIT_AUTHOR_*/GIT_COMMITTER_* 環境固定（決定論）。script は `git -C "$ROOT"` 経由設計にする（root 注入でテスト可能に。前例: tests/test-doc-consistency.sh:156 の rc 明示捕捉付き `git -C`）
+- trailer 抽出構文の動作実証（git 2.49.0）: `git log --format='%H%x09%(trailers:key=Cycle-Doc,valueonly)'` が single-pass・TSV 直行・トレーラー不在は空文字列。現在トレーラー付きコミット 1 件（0446aac）を実測確認
+- 性能実測: 354 コミット・73 cycle docs で full-history name-only スキャン 0.229s → spec 所要時間への影響は無視可能（受入 7-3 充足）
+- SIGPIPE 契約（pre-red-gate.sh:57-63）: `git log | grep -q` 禁止。変数捕捉 + herestring or `git log | awk`（awk は最後まで読む）に統一。bash 3.2: declare -A / mapfile 禁止 → 集計は awk 連想配列（SUBSEP 複合キー、前例 scripts/tfidf-summary.sh:85-131。sqrt/log も awk で可）
+- count 逆向き契約（grep literal）: docs/STATUS.md:12 `| Test Scripts | 114 |` + tests/test-codify-insight.sh TC-19（`has_scripts114` regex）の 2 箇所を 114→115 同期。scripts/ のファイル数 pin は存在しない（test-plugin-structure は下限のみ）→ 新規 script 追加は非破壊
+- 関連スイート baseline: 直近 full suite 114/114 rc=0（cycle 20260723_1103 REFACTOR Gate 実測）
+
+### Design Approach
+
+1. **scripts/recall-candidates.sh（新規・決定論）**
+   - 引数: `recall-candidates.sh <project_root> <file>...`（root 注入でテスト可能）。`-n <N>` で上位件数（既定 5）
+   - 規約: `#!/bin/bash` + `set -euo pipefail`、エラー様式 `ERROR:`/stderr、exit 0=正常（0 件でも正常）、1=引数/環境エラー（scripts/ 既存規約準拠）
+   - ロジック（awk 1 パス集計、SUBSEP 複合キー）:
+     - (a) `git -C "$ROOT" log --format='C%x09%H%x09%(trailers:key=Cycle-Doc,valueonly)' --name-only` を単一実行で走査
+     - (b) コミットにトレーラーあり → そのコミットの cycle doc リンクはトレーラー値のみ（確定来歴、共変更 doc は無視）。従サイクルのリンク喪失は仕様と整合済み（cycle 20260723_1103 で確定した「主サイクル 1 件のみ」トレーラー仕様の継承であり新規逸脱ではない — design review INFO で結論確定）
+     - (c) トレーラーなし → 同一コミット内の docs/cycles/*.md を共変更リンクとする
+     - (d) 入力ファイル F ごとの寄与 = 1 / (F のリンク先 distinct cycle doc 数)（ハブ減衰。IDF 相当、除外はしない）を候補 doc に合算。実効性は実データで検証済み（design review 実測: docs/STATUS.md は 74 コミット・57 distinct doc にリンク、内訳 count=1×31 / count=2×25 / count=3×1 — 単一ハブ入力でも count>1 の doc が直近サイクルより上位に出るため recency 縮退は起きない）
+     - (e) 順位: score 降順 → 同点は新しい cycle（ファイル名の YYYYMMDD_HHMM 降順）
+     - (f) 履歴上のリンク先 `docs/cycles/<basename>.md` は `docs/cycles/<basename>.md` → `docs/cycles/archive/<basename>.md` の順で現在パスに解決する（archive には 37 doc が現存・可読 — Codex Finding 1。仕様「古いものも除外しない」の遵守）。両方に存在しない場合のみ除外し、除外件数を stderr に 1 行報告（no silent caps）。出力パスは解決後の現在パス
+     - (f2) スコアリングは unique (入力ファイル F, cycle doc) ペア集合の上で行う（Codex Finding 2）: 同一ペアが複数コミットに出現しても寄与は 1 回のみ。分母（F のリンク先 distinct doc 数）もペア集合から算出 — 頻繁編集 doc の過大評価を防ぐ
+     - (g) 出力: TSV `score\t<resolved-cycle-doc-path>`（archive 解決後の現在パス）上位 N 件。0 件時は stdout 空 + exit 0（提示側が「関連なし」を記録）
+2. **spec への統合（Step 7.2、hash 順序制約準拠）**
+   - SKILL.md: L83/L95 圧縮で 2 行捻出し、Step 7.1 の直後に Step 5.5 型 2-3 行の Step 7.2: Forced Recall を追加:「Files to Change 確定後・Step 8 の前に `scripts/recall-candidates.sh . <files...>` を実行し、上位候補を助言者形式で plan の `## Recall` に記録する。詳細: reference.md#forced-recall」。TC-R4 の `<100` を維持
+   - reference.md + reference.ja.md: `## Forced Recall {#forced-recall}` セクション新設 — script 実行方法、上位候補の cycle doc の読み方（Retrospective / Codify Decisions / DISCOVERED 中心）、助言者形式 3 点セットの記録形式（各候補につき `### docs/cycles/<file>` + `- **何が起きたか**` / `- **当時の前提**` / `- **今回も同じ前提か**` の 3 行）、0 件時は「関連する過去サイクルなし」1 行、命令形で書かない（助言者原則 — 過剰保守化の防止）。Plan File Template（en:514-557 / ja:455-501 の両方）の TDD Context 後・Plan Review Record 前に `## Recall` ブロックを追加
+3. **plan → Cycle doc 転記**: agents/sync-plan.md の転記テーブル（L58-64）に `| Recall | ## Recall（関連過去サイクル・助言者形式） |` 行を追加。skills/spec/templates/cycle.md に転記先 `## Recall` セクションを追加（test-frontmatter-retro-status TC-02 の negative pin は `## Retrospective` placeholder のみが対象で非抵触 — RED で確認）
+4. **テスト（tests/test-recall-candidates.sh 新規）**: fixture git repo（mktemp -d + trap EXIT + `git -C` init + GIT_AUTHOR_*/GIT_COMMITTER_* 固定）による script 契約 + doc 契約（上記 Test List 参照）
+
+## Verification
+
+Real-path invocation を最低 1 件含めること (rules/integration-verification.md)。
+
+```bash
+# 契約テスト（本 cycle の主対象）
+bash tests/test-recall-candidates.sh
+bash tests/test-post-approve-ordering.sh
+bash tests/test-spec-onboard-improvements.sh
+bash tests/test-pre-red-gate.sh
+bash tests/test-codify-insight.sh
+# real-path invocation（integration-verification 準拠）: 実履歴への実行。
+# 既知の確定リンク: skills/commit/reference.md はトレーラー付きコミット 0446aac で
+# docs/cycles/20260723_1103_...md とリンク済み → 1 位に来ることを実測
+bash scripts/recall-candidates.sh . skills/commit/reference.md | head -5
+bash scripts/recall-candidates.sh . skills/commit/reference.md | head -1 | grep -c "20260723_1103"
+# ハブ減衰の実挙動: docs/STATUS.md（49 doc リンクのハブ）単独入力で直近 5 cycle への縮退が
+# 起きないこと（上位に低頻度リンクの doc が混ざる）を目視確認し evidence 保存
+bash scripts/recall-candidates.sh . docs/STATUS.md | head -5
+# 正本変更ゼロの実 repo 検証: script 実行前後で working tree が不変
+git status --porcelain > /tmp/recall-before.txt && bash scripts/recall-candidates.sh . skills/commit/reference.md > /dev/null && git status --porcelain > /tmp/recall-after.txt && diff /tmp/recall-before.txt /tmp/recall-after.txt && echo "TREE UNCHANGED"
+# full suite（Block 0 baseline は隔離 snapshot 上で実測。fail counter で集約 — 最終 exit が失敗を伝搬）
+fails=0; for f in tests/test-*.sh; do bash "$f" >/dev/null 2>&1; rc=$?; echo "$f rc=$rc"; [ "$rc" -ne 0 ] && fails=$((fails+1)); done; echo "FAILS=$fails"; [ "$fails" -eq 0 ]
+```
+
+Evidence: (orchestrate が自動記入)
+
+## Progress Log
+
+### 2026-07-23 13:29 - Plan Review (pre-approval)
+- codex_session_id: 019f8d37-91ba-7551-a0af-70ca0aa356d4
+- review_attempts:
+  - {started: 2026-07-23 13:24, completed: 2026-07-23 13:25, verdict: BLOCK}
+  - {started: 2026-07-23 13:25, completed: 2026-07-23 13:26, verdict: PASS}
+- findings 要約: Claude design review（Step 7、blocking_score 30）: WARN 2（scope 10/10 余白ゼロの明記 / 正本変更ゼロの直接テスト欠如 → TC-S9 + Verification 追加）+ INFO 2（トレーラー従サイクル整合の結論明記 / ハブ減衰の実データ検証記録）→ 全反映。Codex attempt 1 (BLOCK 3件): (1)[High] archive 済み 37 doc の誤除外 — 仕様「古いもの除外なし」と矛盾 → 二段パス解決 + TC-S10 (2)[Medium] (F,doc) ペア重複排除の未定義 → unique ペア集合上のスコアリング + TC-S11 (3)[Low] full suite loop の exit 伝搬 → fail counter 集約。全反映。Codex attempt 2: PASS（3 件解消確認。非ブロッキング表記 1 点 — 出力形式の resolved-path 表記 — も反映済み）
+- unresolved_blocks: なし（attempt 2 で PASS。表記修正は非ブロッキング指摘の反映であり設計・テスト契約の変更なし）
+- plan_presented: 2026-07-23 13:26
+- reviewed_plan_hash: b54cd78c0466055b4abe06545dac7b0a4cdcfe92f76fc08ecf5c591b267a8e88
+- verdict: PASS
+- Phase completed
+
+### 2026-07-23 13:29 - KICKOFF
+- Cycle doc created
+- Scope definition ready
+- Phase completed
+
+### 2026-07-23 13:34 - Architect (Design Review Gate + Post-Transfer Verification)
+- Design Review Gate: score ~12/100 → **PASS**. Scope 10/10 Files to Change with explicit 余白ゼロ + collateral-fix contingency note; Design Approach (a)-(g) specific and internally consistent; Test List 16 items (TC-S1-S11 + TC-D1-D3 + TC-R1-R2) covers normal/boundary/exception categories in verifiable Given/When/Then form; Risk 30/WARN → risk_level: medium is consistent with change content (new script + workflow step, no security/external/DB)
+- 実ファイル突合結果:
+  - (a) scripts/recall-candidates.sh・tests/test-recall-candidates.sh とも未存在 — 確認済み（RED 未着手のため期待通り）
+  - (b) skills/spec/SKILL.md = 99 行を実測確認。L83（憲法ドキュメント列挙、reference.md:587-597 `#constitution-check` と重複）・L95（resume flag 前置注記、reference.md:13 と重複）を実測確認 — 圧縮対象の主張は正確
+  - (c) agents/sync-plan.md 転記テーブル（L58-64）に Recall 行は未存在 — 確認済み（未着手のため期待通り）
+  - (d) docs/STATUS.md:12 = `| Test Scripts | 114 |`、tests/test-codify-insight.sh:399 `has_scripts114` regex を実測確認 — count 契約の主張は正確
+  - (e) docs/cycles/archive/ に 37 doc 現存・可読（サンプル 3 件 wc -l 実施、非空）。docs/cycles/ と archive/ の basename 重複は 0 件 — 二段パス解決の前提（曖昧衝突なし）は成立
+  - (f) Files to Change 10/10（architect ≤10 制約ちょうど）、余白ゼロ注記・collateral fix 対応（scope +1 即時記録 + REVIEW 裁定）が事前明記済み — 整合
+- Post-Transfer Verification（plan ↔ Cycle doc 突合）:
+  - Plan Review Record: codex_session_id / verdict PASS / reviewed_plan_hash / review_attempts（BLOCK→PASS 2 attempts）/ unresolved_blocks なし — 全フィールド転記一致を確認。reviewed_plan_hash は正準アルゴリズム（`awk '$0=="## Plan Review Record"{exit}{print}' <plan> | shasum -a 256`）で再計算し `b54cd78c...` と完全一致（実測、hash 領域整合性は健全）
+  - Files to Change 10 件・余白ゼロ注記・scope 同梱注記: plan と Cycle doc で完全一致（verbatim）
+  - Test List 16 件（TC-S1〜S11, TC-D1〜D3, TC-R1〜R2）: 全項目 verbatim 一致、test_count: 16 と整合
+  - Verification section: bash ブロック内容 verbatim 一致（Cycle doc 側に "Real-path invocation を最低 1 件含めること" の定型注記が先頭に付加されているのみ、テンプレート由来で非問題）
+  - DISCOVERED 3 項目: plan と Cycle doc で完全一致
+  - 設計方針 (a)-(g): plan Design Approach と Cycle doc Implementation Notes で完全一致
+  - 転記欠落: なし / scope 実質変更: なし
+  - 観察のみ（DISCOVERED 追記不要、記録のみ）: 「scope 同梱注記」（docs/cycles/20260723_1103_....md を本 cycle commit に同梱）は plan 本文に verbatim ソースがなく、sync-plan が Block 0 の運用文脈（同 doc の retro_status: resolved・Codify Decisions 追記・git status M を実測確認済み、事実関係は正確）から補記したものと判断。設計・テスト契約・Files to Change に変更を及ぼさないため「観察のみ」に分類し、再承認は不要と判断
+- 判定: **PASS**（BLOCK 0 件、scope 実質変更 0 件）。plan ファイルは未編集（読み取りのみ）。orchestrate は Block 2a（RED）へ進行可
+- Phase completed
+
+### 2026-07-23 13:50 - RED
+- Test code created, 14 tests failing (RED)。tests/test-recall-candidates.sh 新規作成（16 TC）
+- 内訳: TC-S1〜S11（script 契約、fixture git repo）+ TC-D1〜D3（doc 契約、見出し区間先行抽出）は新挙動未実装のため FAIL（14 件）。TC-R1/R2（回帰非破壊 proxy、既存 pin 存在検査）は既存契約が健在のため PASS（2 件）— cycle 20260723_1103 の TC-R1/R2 代替と同型
+- fixture: mktemp -d + trap EXIT cleanup + `git -C "$REPO" -c init.defaultBranch=main init` + GIT_AUTHOR_*/GIT_COMMITTER_* 固定 export（決定論）。トレーラー付き/なし・ハブ/葉・archive 移動・重複ペア・除外・該当なしの各シナリオを合成コミットで構築
+- script 契約は先頭に `[ -f "$SCRIPT" ]` 存在 guard を置き、scripts/recall-candidates.sh 未存在の現在は「script does not exist」で FAIL
+- 契約 literal: TSV `score\t<resolved-cycle-doc-path>`、既定上位 5、archive 二段解決、unique (F,doc) ペア、stderr 除外報告、exit 0=正常。bash 3.2 互換・SIGPIPE 契約遵守（script 出力は変数捕捉、`bash subject | grep` 直結なし）
+- oracle 検証: 設計 (a)-(g) の参照実装を fixture に適用し、f1→a1 のみ / f3H+f3L→l3 先頭(score 1) > hub docs(0.333) / f4→new4 先頭(tie recency) / f11→d11 score 1(dedup) / f8→6 候補(script が 5 に cap) / f10→archive パス / f6→stderr 除外・stdout 空 を確認済み（GREEN の実装ターゲット確定）
+- 実行結果: `bash tests/test-recall-candidates.sh` → PASS 2 / FAIL 14 / TOTAL 16、rc=1（RED 確認）。他テストは baseline 並行実行中のため未実行（読み取り並列・実行直列）
+- Phase completed
+
+### 2026-07-23 14:18 - GREEN
+- Implementation complete, all 16 tests passing。scripts/recall-candidates.sh 新規実装 + doc 配線 9 ファイル編集
+- scripts/recall-candidates.sh: `set -euo pipefail`、`<project_root> <file>... [-n N]`。git log（Cycle-Doc トレーラー inline + --name-only）を Q 優先行と結合し awk 単一パス集計（`split("",arr)` clear で bash 3.2 互換、SIGPIPE 契約遵守: git log | awk 直結・grep -q 直結なし）。トレーラー優先 / 共変更 fallback / unique (F,doc) ペア寄与 1/distinct / archive 二段パス解決 + stderr 除外報告 / score 降順→basename 降順 tie-break は `sort -k1,1nr -k2,2r` + `awk 'NR<=n'`（head 不使用で SIGPIPE 回避）
+- doc 配線: SKILL.md Step 7.2 追加（L83/L95 圧縮 + 4項目リスト inline 化で 99→97 行、<100 維持・Step 8/--sandbox read-only pin 保持）/ reference.md + reference.ja.md に `## Forced Recall {#forced-recall}` + Template `## Recall`（Plan Review Record より前）/ sync-plan.md 転記行 / templates/cycle.md `## Recall`（Retrospective placeholder 不追加）
+- count 同期: docs/STATUS.md 114→115 + test-codify-insight.sh TC-19（has_scripts114→has_scripts115 rename + bump 履歴 1 行）。test-orchestrate-a2b TC-15（動的 count 契約）で 115=実数 115 を確認
+- 検証: bash tests/test-recall-candidates.sh 16/16 PASS rc=0。回帰 test-post-approve-ordering / test-spec-onboard-improvements / test-pre-red-gate / test-codify-insight / test-post-approve-action / test-spec-upstream / test-orchestrate-a2b / test-v2-release 全 rc=0。wc -l SKILL.md=97。real-path: `recall-candidates.sh . skills/commit/reference.md | head -1` → 20260723_1103 が 1 位（tie 内 recency 首位）。read-only: 実行前後で git status --porcelain 不変
+- 逆向き契約 sweep: `grep -rln "114" tests/` の残存は test-codify-insight.sh の bump 履歴コメントのみ（live assertion なし）
+- Phase completed
+
+---
+
+## Next Steps
+
+1. [Done] KICKOFF <- Current
+2. [Next] RED
+3. [ ] GREEN
+4. [ ] REFACTOR
+5. [ ] REVIEW
+6. [ ] COMMIT
+7. [ ] DONE
+
+### 2026-07-23 14:29 - REFACTOR
+
+- チェックリスト 7 項目適用: 改善対象ゼロ（scripts/recall-candidates.sh は SIGPIPE 契約・bash 3.2・awk 1 パス集計・二段解決の規約準拠を実読確認。tests/ は REFACTOR 禁止事項により対象外）
+- Verification Gate: bash -n lint OK（script + test）+ full suite 115/115 FAILS=0（baseline 114/114 + 新規 1、regression ゼロ）
+- baseline 補足: 隔離 snapshot の初回実測で 4 件 FAIL → 単一根本原因（snapshot に Holdings 親 docs/test_architecture.md 未複製 → test-paradigm-selection FAIL → 他 3 件は再帰 cascade）を切り分け、親 docs 補完後に 114/114 FAILS=0 確定（隔離 snapshot の親構造複製 insight の再確認事例）
+- Phase completed
+
+### 2026-07-23 15:36 - REVIEW
+
+**Competitive review 構成**: Claude panel 4 名（HIGH tier、risk-classifier score 105）+ Codex（resume 019f8d37）。blocking_score: security 5 / maintainability 8 / correctness 28 / design 78。Codex verdict: BLOCK 1 + WARN 1 + INFO 1。
+
+**Findings Judgment（3-category triage、計 13 件）**:
+
+accept-apply（適用済み 5 件）:
+1. [Codex BLOCK / design BLOCK-2 関連] 単一ハブ入力の recency 縮退が設計ノート (d) と reference 両言語の契約文言に矛盾 → **仕様の許容挙動として文書化**（reference.md / reference.ja.md の該当文言を「減衰は入力ファイル間の相対重み。単一ハブのみは同点→新しい順（許容挙動、miss 計測で拡張判断）」へ修正、byte-identical lockstep）+ TC-S3 に lone-hub characterization（同点 + 新しい順）を追加 pin
+2. [design BLOCK-1] Step 7.2 の発火位置矛盾（Files to Change 確定前に配置）→ SKILL.md 内で設計フロー行の後・Step 8 直前へ移設し「設計で Files to Change が確定した直後」と明記（97 行維持、TC-D1/TC-R4 PASS）
+3. [Codex WARN] TC-S9 が script 失敗時も vacuous PASS → `RECALL_RC == 0` を判定条件に追加
+4. [correctness WARN] basename 衝突時の誤帰属（cycles/ と archive/ に同名の別 doc）の暗黙不変条件 → script ヘッダに「basename は両 dir 横断で一意を維持」の invariant を明文化（oracle で再現確認済み・現リポジトリ衝突 0 件実測）
+5. [design INFO] GREEN の SKILL.md 圧縮手段逸脱（4 項目リスト 1 行化）→ Codex INFO の裁定通り「plan 記載の 2 箇所では物理行が捻出できず、意味欠落なしの追加圧縮は妥当」として承認記録
+
+**scope 実質変更の再承認（doc-mutations 3 分岐、design BLOCK-2 の監査ギャップ解消）**:
+- 対象: plan 設計ノート (d) の「単一ハブ入力でも縮退しない」実データ主張は、Codex plan review Finding 2 が要求した unique (F,doc) ペア契約の帰結として**成立しない**（設計ノートの検証が per-commit 集計前提だった）。plan review PASS の根拠の一部が反転したため scope 実質変更として扱う
+- **AskUserQuestion による再承認済み（2026-07-23）**: 「縮退を許容仕様化」を選択。追加スコアリング信号は仕様書 §4 の「miss 実測まで追加しない」原則に従い R4 計測後に判断
+- Verification の「縮退が起きないことを目視確認」項目は本裁定により**期待値が反転**: 実測 evidence（/tmp/dev-crew-verify-20260723_1328/product-verification.log の hub query 出力 = 全同点 0.017544・新しい順）は許容仕様の実挙動記録として保存
+
+accept-defer（follow-up、#185 コメント予定 3 件）:
+- [correctness INFO] 重複トレーラーの 2 件目 silent drop / core.quotePath 対象ファイル名の silent miss / rename 追跡なし — いずれも本番経路（ASCII 命名・commit スキル単一トレーラー契約）では発火しない低確率エッジ。診断出力の追加は #185 のテスト強度強化と同時に判断
+- [maintainability INFO] awk 配列命名ケース不揃い / section helper の 5 実装目（#185 統合対象に追加）
+- basename 衝突の runtime guard（ヘッダ文書化より強い防御）
+
+reject（1 件、理由付き）:
+- [design WARN 再承認要求のうち「REVIEW 記録欠落」] → reject ではなく本エントリで解消（design review は REVIEW エントリ作成前の中間状態を観察したもの。監査証跡は本エントリ + 再承認記録で完備）
+
+**検証**: 修正後 tests/test-recall-candidates.sh 16/16 rc=0、test-post-approve-ordering / test-spec-onboard-improvements rc=0。security 実測: パス走査は basename-before-concat で構造的に不可能（模範例評価）。correctness oracle 実測: merge commit 経路・sort tie-break・float 決定論（30 回 byte-identical）は全て正しい
+- Phase completed
+
+### 2026-07-23 15:36 - DISCOVERED 起票
+
+- REVIEW accept-defer 4 群（recall エッジ診断 / basename runtime guard / helper 統合 5 実装目 / awk 命名）→ issue #185 へ統合コメント
+- R4 集計スクリプト・rules 降格棚卸し → 既存 issue #187 で追跡継続（plan DISCOVERED 通り）
+- Phase completed
+
+## Retrospective
+
+抽出時刻: 2026-07-23 15:37
+抽出方法: Cycle doc 全体（plan review BLOCK→PASS / baseline 誤 FAIL 切り分け / code review 13 findings・再承認 1 件）からの失敗→最終解→insight 抽出
+
+### Insight 1: 設計時の実データ検証は「最終契約の式」で再実行しないと無効になる。中間設計での実測は契約変更で silently 失効する
+- **Failure**: 設計ノート (d) の「単一ハブでも縮退しない」は per-commit 集計前提の実データ検証だった。その後 Codex plan review Finding 2 が unique (F,doc) ペア契約を導入し、検証済み主張が**式の変更で失効**したのに、主張のテキストは plan にそのまま残存 → 実装後に design reviewer が矛盾を検出し、scope 実質変更の再承認（AskUserQuestion）まで発展
+- **Final fix**: 縮退を許容仕様として再承認 + reference 両言語の契約文言修正 + lone-hub characterization TC で実挙動を pin
+- **Insight**: **plan 内の実測ベース主張には「どの式・どの契約バージョンで測ったか」を併記し、レビューで式が変わったら依存する主張を再実測してから残す。式の変更（ペア重複排除等）は、その式で検証済みだった全主張の失効チェックをセットで行う**
+- **一般化**: rules/plan-discipline.md 追記候補（実測主張の前提式併記 + 式変更時の失効 sweep）
+
+### Insight 2: ワークフロー step の挿入位置は「前提が成立する時点」を doc の実行順で検証する。見出し番号の隣接ではなく前提の充足順で置く
+- **Failure**: Step 7.2 を「Step 7.1 の直後」という見出し隣接で配置した結果、前提（Files to Change 確定）が成立する設計フローより前に置かれ、doc の実行順に読むと前提未成立で発火する構造矛盾。plan review（Codex PASS）も探索エージェントの配置推奨も見逃し、design reviewer が実行順トレースで検出
+- **Final fix**: 設計フロー行の後・Step 8 直前へ移設し、発火条件を「設計で Files to Change が確定した直後」と自己記述化
+- **Insight**: **手順 doc へ step を挿入する時は、番号や見出しの隣接ではなく「その step の前提条件が直前までに成立しているか」を doc を頭から実行するトレースで検証する。前提条件は step 自身の文中に書く（位置に依存させない）**
+- **一般化**: rules/multi-file-consistency.md の順序検証原則（行番号比較）の適用対象を「workflow doc の前提充足順」へ拡張する追記候補
+
+### 想起漏れ
+
+- **設問**: 今回の手戻りは、過去のどの cycle doc を最初に読んでいれば防げたか
+- **回答**: 該当なし
+
+### 2026-07-23 15:37 - COMMIT
+
+- pre-commit-gate（明示指定）rc=0 PASS
+- EXPECTED_CYCLE_DOC 捕捉済み（commit 前）: docs/cycles/20260723_1328_spec-forced-recall.md
+- STATUS.md: Done 73→74 + Completed 行（Test Scripts 115 は GREEN 同期済み、Last updated 2026-07-23 前 cycle 同期済み）
+- commit 同梱: scripts 1 + skills/spec 4 + agents/sync-plan.md + tests 2 + docs/STATUS.md + CHANGELOG.md + 本 cycle doc + docs/cycles/20260723_1103（Block 0 codify 出力、REVIEW 裁定済み）
+- Phase completed

--- a/scripts/recall-candidates.sh
+++ b/scripts/recall-candidates.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# recall-candidates.sh - Deterministic recall of related cycle docs for a change set.
+#
+# Usage: bash scripts/recall-candidates.sh <project_root> <file>... [-n N]
+# Output: TSV `score<TAB>docs/cycles/<resolved-path>` for the top N candidates
+#         (default 5), score-descending, newer-basename first on ties.
+#         Zero candidates -> empty stdout + exit 0.
+# Exit:   0 = normal (including 0 candidates); 1 = argument/environment error.
+#
+# Data sources are existing history only: git co-change (--name-only) plus the
+# Cycle-Doc commit trailer (confirmed provenance overrides co-change). No frontmatter
+# extension, no SQLite, no embeddings. The working tree is never mutated (read-only).
+#
+# Invariant (implicit, currently holds with zero collisions): cycle doc basenames are
+# unique across docs/cycles/ and docs/cycles/archive/. Aggregation is basename-keyed,
+# so a same-basename pair of DISTINCT docs in both dirs would be conflated (the live
+# path wins at resolve time). Keep basenames unique when archiving.
+#
+# Scoring: for the unique set of (input file F, cycle doc) pairs, each pair contributes
+# 1 / (distinct docs linked to F) to its doc's score. This IDF-style hub decay keeps a
+# hub file (linked to many docs) from collapsing the ranking onto the most-recent cycles.
+# A pair repeated across commits contributes once.
+#
+# git log stream shape (single pass, bash 3.2 / SIGPIPE safe — piped into awk which
+# reads to EOF, never `| grep -q`):
+#   C<TAB><hash><TAB><Cycle-Doc trailer value or empty>   commit header
+#   <changed path>                                        one per --name-only file
+# Query files are primed into the same stream as `Q<TAB><path>` lines so no awk -v
+# newline escaping is needed.
+
+set -euo pipefail
+
+usage() {
+  echo "ERROR: usage: recall-candidates.sh <project_root> <file>... [-n N]" >&2
+  exit 1
+}
+
+TOP_N=5
+ROOT=""
+FILES=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n)
+      shift
+      [ $# -gt 0 ] || usage
+      TOP_N="$1"
+      ;;
+    *)
+      if [ -z "$ROOT" ]; then
+        ROOT="$1"
+      else
+        # Strip a leading ./ so query paths match git --name-only output.
+        FILES+=("${1#./}")
+      fi
+      ;;
+  esac
+  shift
+done
+
+[ -n "$ROOT" ] || usage
+[ "${#FILES[@]}" -ge 1 ] || usage
+[ -d "$ROOT" ] || { echo "ERROR: not a directory: $ROOT" >&2; exit 1; }
+case "$TOP_N" in
+  ''|*[!0-9]*) echo "ERROR: -n requires a positive integer" >&2; exit 1 ;;
+esac
+[ "$TOP_N" -ge 1 ] || { echo "ERROR: -n requires a positive integer" >&2; exit 1; }
+
+# Single-pass aggregation: emit `score<TAB>doc-basename` for every candidate doc.
+raw=$(
+  {
+    printf 'Q\t%s\n' "${FILES[@]}"
+    git -C "$ROOT" log --format='C%x09%H%x09%(trailers:key=Cycle-Doc,valueonly)' --name-only
+  } | awk -F'\t' '
+    function basename(p) { sub(/.*\//, "", p); return p }
+
+    function flush(   f, d) {
+      if (!have) return
+      split("", docs)
+      if (trailer != "") {
+        docs[basename(trailer)] = 1
+      } else {
+        for (f in changed)
+          if (f ~ /^docs\/cycles\/.*\.md$/) docs[basename(f)] = 1
+      }
+      for (f in changed)
+        if (f in QUERY)
+          for (d in docs) pair[f SUBSEP d] = 1
+      split("", changed)
+      have = 0
+      trailer = ""
+    }
+
+    BEGIN { have = 0; trailer = "" }
+
+    $1 == "Q" && NF >= 2 { QUERY[$2] = 1; next }
+    $1 == "C" && NF >= 3 { flush(); have = 1; trailer = $3; next }
+    $0 == "" { next }
+    { changed[$0] = 1 }
+
+    END {
+      flush()
+      for (p in pair) { split(p, a, SUBSEP); fcount[a[1]]++ }
+      for (p in pair) { split(p, a, SUBSEP); score[a[2]] += 1.0 / fcount[a[1]] }
+      for (d in score) printf "%.6f\t%s\n", score[d], d
+    }
+  '
+)
+
+# Resolve each candidate basename to its current path (docs/cycles/, then archive/).
+# Docs absent from both are excluded and reported once on stderr (no silent caps).
+excluded=0
+resolved=""
+while IFS=$'\t' read -r score b; do
+  [ -n "${score:-}" ] || continue
+  if [ -f "$ROOT/docs/cycles/$b" ]; then
+    p="docs/cycles/$b"
+  elif [ -f "$ROOT/docs/cycles/archive/$b" ]; then
+    p="docs/cycles/archive/$b"
+  else
+    excluded=$((excluded + 1))
+    continue
+  fi
+  resolved+="${score}"$'\t'"${b}"$'\t'"${p}"$'\n'
+done <<< "$raw"
+
+[ "$excluded" -eq 0 ] || echo "excluded $excluded cycle doc(s) absent from current tree" >&2
+
+if [ -n "$resolved" ]; then
+  printf '%s' "$resolved" \
+    | sort -t "$(printf '\t')" -k1,1nr -k2,2r \
+    | awk -F'\t' -v n="$TOP_N" 'NR <= n { print $1 "\t" $3 }'
+fi
+
+exit 0

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -80,19 +80,17 @@ planファイルにTDDコンテキストを記録。テンプレート: [referen
 
 ### Step 7: Continue in Plan Mode
 
-**Step 7.1: Upstream & Constitution Check** — 上流ドキュメント (`ROADMAP.md` 等) と憲法ドキュメント (`CONSTITUTION.md`, `AGENTS.md`, `CLAUDE.md`, `README.md` のいずれか存在するもの) を読み、設計方針との整合性を確認。差異があれば plan の `## Upstream References` に理由を記録。詳細: [reference.md](reference.md#constitution-check)
+**Step 7.1: Upstream & Constitution Check** — 上流ドキュメント (`ROADMAP.md` 等) と憲法ドキュメントを読み、設計方針との整合性を確認。差異があれば plan の `## Upstream References` に記録。詳細: [reference.md](reference.md#constitution-check)
 
-specの記録後、plan mode内で以下を続行（specスキルの範囲外）:
-1. **探索**: コードベース調査（最低5ファイル読む）
-2. **設計**: アーキテクチャ決定、設計方針
-3. **Test List**: Given/When/Then形式
-4. **QAチェック**: カバレッジ・粒度・セキュリティ・独立性
+specの記録後、plan mode内で続行（specスキル範囲外）: 探索（最低5ファイル）→ 設計 → Test List（Given/When/Then）→ QAチェック（カバレッジ・粒度・セキュリティ・独立性）
+
+**Step 7.2: Forced Recall** — 設計で Files to Change が確定した直後（Step 8 の前）に `bash scripts/recall-candidates.sh . <変更予定ファイル...>` を実行し、上位候補を助言者形式で plan の `## Recall` に記録（0 件時は「関連する過去サイクルなし」）。詳細: [reference.md](reference.md#forced-recall)
 
 → review --plan → Step 8（承認前 Codex plan review）→ approve（ExitPlanMode）→ 自動orchestrate（sync-plan→RED→GREEN→...）
 
 ### Step 8: Pre-Approval Plan Review (Codex)
 
-Step 7 後・ExitPlanMode（承認）前: `codex exec --sandbox read-only "review plan <plan path>"` → findings を draft plan へ直接反映 → 最終版を1回だけ再レビュー（`codex exec --sandbox read-only resume <session-id> "..."` — フラグは resume より前置、後置は rc=2 実測済み）→ `## Plan Review Record` を plan に記録。未解消 BLOCK は人間の明示 override が承認提示文で必須。Codex 不在時は skip し Record に `codex_unavailable` を記録。詳細: [reference.md](reference.md#step-8-pre-approval-plan-review)
+Step 7 後・ExitPlanMode（承認）前: `codex exec --sandbox read-only "review plan <plan path>"` → findings を draft plan へ直接反映 → 最終版を1回だけ再レビュー（resume、フラグ前置。詳細は reference）→ `## Plan Review Record` を plan に記録。未解消 BLOCK は人間の明示 override が承認提示文で必須。Codex 不在時は skip し Record に `codex_unavailable` を記録。詳細: [reference.md](reference.md#step-8-pre-approval-plan-review)
 
 ## Reference
 

--- a/skills/spec/reference.ja.md
+++ b/skills/spec/reference.ja.md
@@ -476,6 +476,15 @@ planファイルに記録するTDDコンテキストのテンプレート:
 ### Ambiguity Resolution (該当時)
 - [カテゴリ]: [解決内容]
 
+## Recall
+
+（Step 7.2 の `scripts/recall-candidates.sh` 上位候補を助言者形式で記録。候補が無ければ「関連する過去サイクルなし」の 1 行）
+
+### docs/cycles/<file>
+- **何が起きたか**: 当時の状況・結果
+- **当時の前提**: その判断が依存した前提
+- **今回も同じ前提か**: Yes/No と理由
+
 ## Plan Review Record
 
 - codex_session_id: [uuid or "" if extraction_failed]
@@ -497,6 +506,41 @@ approve後、compact + accept edits on に遷移したら `/orchestrate` のみ�
 ```
 
 この後、plan mode内で探索・設計・Test List定義・QAチェック・Step 8（承認前レビュー）を続行する。
+
+## Forced Recall {#forced-recall}
+
+Step 7.2 で実行する強制想起。Files to Change に挙げた変更予定ファイルに関連する過去 cycle doc を決定論的に提示し、「当時の前提が今回も成立するか」を plan review の検査対象に載せる。pull 型検索（問い合わせ待ち）ではなく、ワークフロー固定点で必ず発火させる。
+
+### 実行
+
+```bash
+bash scripts/recall-candidates.sh . <変更予定ファイル...>
+```
+
+データソースは既存のもののみ: `git log --name-only`（共変更）+ Cycle-Doc トレーラー（確定リンク優先）。ハブファイル（多数の cycle doc に共変更リンクするファイル）は寄与を IDF 相当で減衰させる — 減衰は**入力ファイル間の相対重み**として働くため、通常の入力（Files to Change の複数ファイル）では葉ファイル由来の候補がハブ由来より優先され、直近サイクルへの縮退を防ぐ。単一のハブファイルのみを入力した場合は全候補が同点となり新しい順の提示になる（仕様上の許容挙動。miss が計測されたら拡張判断の対象）。出力は `score<TAB>docs/cycles/<path>` の上位候補（既定 5 件、score 降順・新しい順 tie-break）。0 件なら stdout 空 + exit 0。
+
+### 上位候補の読み方
+
+各候補 cycle doc の **Retrospective / Codify Decisions / DISCOVERED** を中心に読み、当時何を学び・何を保留したかを掴む。
+
+### 記録形式（助言者形式）
+
+上位候補を plan の `## Recall` に記録する。候補が無ければ次の 1 行のみ:
+
+```
+関連する過去サイクルなし
+```
+
+候補がある場合、各 doc につき 3 点セットで記録する:
+
+```
+### docs/cycles/<file>
+- **何が起きたか**: 当時の状況・結果の要約
+- **当時の前提**: その判断が依存した前提
+- **今回も同じ前提か**: Yes/No と理由
+```
+
+**助言者原則**: 過去の失敗を「今後も禁止」として書かない。想起は今回の判断材料であって恒久ルールへの昇格ではない（過剰保守化の防止）。
 
 ## プロジェクト固有のカスタマイズ
 

--- a/skills/spec/reference.md
+++ b/skills/spec/reference.md
@@ -535,6 +535,15 @@ planファイルに記録するTDDコンテキストのテンプレート:
 ### Ambiguity Resolution (if any)
 - [category]: [resolution]
 
+## Recall
+
+（Step 7.2 の `scripts/recall-candidates.sh` 上位候補を助言者形式で記録。候補が無ければ「関連する過去サイクルなし」の 1 行）
+
+### docs/cycles/<file>
+- **何が起きたか**: 当時の状況・結果
+- **当時の前提**: その判断が依存した前提
+- **今回も同じ前提か**: Yes/No と理由
+
 ## Plan Review Record
 
 - codex_session_id: [uuid or "" if extraction_failed]
@@ -557,6 +566,41 @@ Edit/Write は直接行わず、必ず /orchestrate に委譲する（プロン�
 ```
 
 この後、plan mode内で探索・設計・Test List定義・QAチェック・Step 8（承認前レビュー）を続行する。
+
+## Forced Recall {#forced-recall}
+
+Step 7.2 で実行する強制想起。Files to Change に挙げた変更予定ファイルに関連する過去 cycle doc を決定論的に提示し、「当時の前提が今回も成立するか」を plan review の検査対象に載せる。pull 型検索（問い合わせ待ち）ではなく、ワークフロー固定点で必ず発火させる。
+
+### 実行
+
+```bash
+bash scripts/recall-candidates.sh . <変更予定ファイル...>
+```
+
+データソースは既存のもののみ: `git log --name-only`（共変更）+ Cycle-Doc トレーラー（確定リンク優先）。ハブファイル（多数の cycle doc に共変更リンクするファイル）は寄与を IDF 相当で減衰させる — 減衰は**入力ファイル間の相対重み**として働くため、通常の入力（Files to Change の複数ファイル）では葉ファイル由来の候補がハブ由来より優先され、直近サイクルへの縮退を防ぐ。単一のハブファイルのみを入力した場合は全候補が同点となり新しい順の提示になる（仕様上の許容挙動。miss が計測されたら拡張判断の対象）。出力は `score<TAB>docs/cycles/<path>` の上位候補（既定 5 件、score 降順・新しい順 tie-break）。0 件なら stdout 空 + exit 0。
+
+### 上位候補の読み方
+
+各候補 cycle doc の **Retrospective / Codify Decisions / DISCOVERED** を中心に読み、当時何を学び・何を保留したかを掴む。
+
+### 記録形式（助言者形式）
+
+上位候補を plan の `## Recall` に記録する。候補が無ければ次の 1 行のみ:
+
+```
+関連する過去サイクルなし
+```
+
+候補がある場合、各 doc につき 3 点セットで記録する:
+
+```
+### docs/cycles/<file>
+- **何が起きたか**: 当時の状況・結果の要約
+- **当時の前提**: その判断が依存した前提
+- **今回も同じ前提か**: Yes/No と理由
+```
+
+**助言者原則**: 過去の失敗を「今後も禁止」として書かない。想起は今回の判断材料であって恒久ルールへの昇格ではない（過剰保守化の防止）。
 
 ## Upstream Consistency Check {#upstream-check}
 

--- a/skills/spec/templates/cycle.md
+++ b/skills/spec/templates/cycle.md
@@ -64,6 +64,10 @@ updated: YYYY-MM-DD HH:MM
 ### Related Issues/PRs
 - Issue #[number]: [title]
 
+## Recall
+
+（spec Step 7.2 の recall-candidates.sh 上位候補を助言者形式で転記。候補なしは「関連する過去サイクルなし」の 1 行）
+
 ## Test List
 
 ### TODO

--- a/tests/test-codify-insight.sh
+++ b/tests/test-codify-insight.sh
@@ -383,28 +383,29 @@ if [ "$TC18_PASS" = "true" ]; then
   pass "TC-18: All 4 files mention codify-insight"
 fi
 
-# TC-19: docs/STATUS.md contains "Skills | 28" AND "Test Scripts | 114", README.md contains "28 skills"
+# TC-19: docs/STATUS.md contains "Skills | 28" AND "Test Scripts | 115", README.md contains "28 skills"
 # Updated 2026-05-25: Test Scripts 110 → 112 (TC01+TC02 added)
 # Updated 2026-06-25: Test Scripts 112 → 113 (test-rules-path-scoping.sh added)
 # Updated 2026-07-02: Skills 32→29, Test Scripts 113→112 (3 skills + 1 test deleted)
 # Updated 2026-07-03: Skills 29→28 (parallel deleted)
 # Updated 2026-07-13: Test Scripts 112→113 (test-review-policy.sh added)
 # Updated 2026-07-23: 113→114 (test-commit-cycle-doc-trailer.sh added)
+# Updated 2026-07-23: 114→115 (test-recall-candidates.sh added)
 echo ""
-echo "TC-19: STATUS.md Skills=28 + Test Scripts=114, README.md 28 skills"
+echo "TC-19: STATUS.md Skills=28 + Test Scripts=115, README.md 28 skills"
 if [ ! -f "$STATUS_MD" ]; then
   fail "TC-19: docs/STATUS.md does not exist"
 else
   has_skills28=$(grep -qE "Skills[[:space:]]*\|[[:space:]]*28" "$STATUS_MD" && echo "yes" || echo "no")
-  has_scripts114=$(grep -qE "Test Scripts[[:space:]]*\|[[:space:]]*114" "$STATUS_MD" && echo "yes" || echo "no")
+  has_scripts115=$(grep -qE "Test Scripts[[:space:]]*\|[[:space:]]*115" "$STATUS_MD" && echo "yes" || echo "no")
   has_readme28=$(grep -qE "28 skills" "$README_MD" 2>/dev/null && echo "yes" || echo "no")
-  if [ "$has_skills28" = "yes" ] && [ "$has_scripts114" = "yes" ] && [ "$has_readme28" = "yes" ]; then
-    pass "TC-19: STATUS.md Skills=28 + Test Scripts=114, README.md 28 skills"
+  if [ "$has_skills28" = "yes" ] && [ "$has_scripts115" = "yes" ] && [ "$has_readme28" = "yes" ]; then
+    pass "TC-19: STATUS.md Skills=28 + Test Scripts=115, README.md 28 skills"
   else
     skills_current=$(grep -oE "Skills[[:space:]]*\|[[:space:]]*[0-9]+" "$STATUS_MD" | grep -oE "[0-9]+$" | head -1 || echo "not found")
     scripts_current=$(grep -oE "Test Scripts[[:space:]]*\|[[:space:]]*[0-9]+" "$STATUS_MD" | grep -oE "[0-9]+$" | head -1 || echo "not found")
     readme_current=$(grep -oE "[0-9]+ skills" "$README_MD" 2>/dev/null | head -1 || echo "not found")
-    fail "TC-19: STATUS.md Skills=$skills_current (need 28), Test Scripts=$scripts_current (need 114), README=$readme_current (need '28 skills')"
+    fail "TC-19: STATUS.md Skills=$skills_current (need 28), Test Scripts=$scripts_current (need 115), README=$readme_current (need '28 skills')"
   fi
 fi
 

--- a/tests/test-recall-candidates.sh
+++ b/tests/test-recall-candidates.sh
@@ -1,0 +1,450 @@
+#!/bin/bash
+# test-recall-candidates.sh - recall-candidates.sh script contract + spec forced-recall doc wiring
+#
+# TC-S1..S11 exercise scripts/recall-candidates.sh against a deterministic fixture git
+# repo (mktemp -d + trap EXIT cleanup + fixed GIT_AUTHOR_*/GIT_COMMITTER_* env). The script
+# does not exist during RED, so every TC-S fails at the leading existence guard.
+#
+# TC-D1..D3 verify the spec workflow / reference / transcription wiring. Doc contracts
+# extract the target heading region first (fence-aware), then grep within: whole-file grep
+# would mis-detect fenced "## " lines (template bodies) as headings.
+
+set -uo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$BASE_DIR/scripts/recall-candidates.sh"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf "  \033[32mPASS\033[0m %s\n" "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf "  \033[31mFAIL\033[0m %s\n" "$1"; }
+
+# section_lines <file> <start_marker> <term_level>
+#   start_marker: full heading incl leading hashes, fixed-string prefix (no ERE meta).
+#   term_level:   terminate at the next heading whose level (# count) <= term_level.
+#   Fence-aware: lines inside ``` code fences are emitted as body and never treated as
+#   headings (so a fenced "## Recall" inside a template does not terminate the region).
+section_lines() {
+  awk -v sm="$2" -v tl="$3" '
+    /^```/ { fence = !fence; if (in_sec) print; next }
+    !in_sec && !fence && index($0, sm) == 1 { in_sec = 1; next }
+    in_sec && !fence && /^#+ / {
+      n = 0; while (substr($0, n + 1, 1) == "#") n++;
+      if (n <= tl) { in_sec = 0; next }
+    }
+    in_sec { print }
+  ' "$1"
+}
+
+# --- Deterministic fixture git repo -----------------------------------------
+# Distinct input file names per scenario keep each file's link set (and hub-decay
+# denominator) predictable within a single shared repo. Commit dates are fixed and
+# irrelevant to ranking: recency tie-break reads the YYYYMMDD_HHMM in doc basenames.
+REPO=""
+build_fixture() {
+  REPO=$(mktemp -d)
+  export GIT_AUTHOR_NAME=fixture GIT_AUTHOR_EMAIL=fixture@example.com
+  export GIT_AUTHOR_DATE="2026-01-01T00:00:00 +0000"
+  export GIT_COMMITTER_NAME=fixture GIT_COMMITTER_EMAIL=fixture@example.com
+  export GIT_COMMITTER_DATE="2026-01-01T00:00:00 +0000"
+  git -C "$REPO" -c init.defaultBranch=main init -q
+  mkdir -p "$REPO/docs/cycles/archive"
+
+  # TC-S1: trailer overrides co-change. a1 is the confirmed (trailer) link; b1 is a
+  # co-changed decoy in the same commit and must be ignored because a trailer is present.
+  printf 'a\n' > "$REPO/docs/cycles/20260110_1000_a1.md"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "seed a1 doc"
+  printf 'x\n' > "$REPO/f1.txt"
+  printf 'b\n' > "$REPO/docs/cycles/20260110_1100_b1.md"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "$(printf 'change f1 with trailer\n\nCycle-Doc: docs/cycles/20260110_1000_a1.md')"
+
+  # TC-S2: trailer-less co-change fallback.
+  printf 'y\n' > "$REPO/f2.txt"
+  printf 'c\n' > "$REPO/docs/cycles/20260112_1000_c2.md"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "co-change f2 c2"
+
+  # TC-S3: hub decay. f3H links 3 distinct docs (each contributes 1/3); f3L links 1
+  # (contributes 1/1) so the leaf-derived doc must outrank the hub-derived docs.
+  printf 'h\n' > "$REPO/f3H.txt"
+  printf '1\n' > "$REPO/docs/cycles/20260113_1000_h3a.md"
+  printf '2\n' > "$REPO/docs/cycles/20260113_1100_h3b.md"
+  printf '3\n' > "$REPO/docs/cycles/20260113_1200_h3c.md"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "hub f3H links 3 docs"
+  printf 'l\n' > "$REPO/f3L.txt"
+  printf '4\n' > "$REPO/docs/cycles/20260113_1300_l3.md"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "leaf f3L links 1 doc"
+
+  # TC-S4: recency tie-break. f4 links two docs (each 1/2, tied); newer basename wins.
+  printf 'g\n' > "$REPO/f4.txt"
+  printf 'o\n' > "$REPO/docs/cycles/20260101_1000_old4.md"
+  printf 'n\n' > "$REPO/docs/cycles/20260201_1000_new4.md"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "f4 links old4 new4 tie"
+
+  # TC-S5: file that links to no cycle doc -> empty output, exit 0.
+  printf 'lonely\n' > "$REPO/f5.txt"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "f5 solo no doc"
+
+  # TC-S6: historical link to a doc that no longer exists anywhere -> excluded + reported.
+  printf 'z\n' > "$REPO/f6.txt"
+  printf 'zz\n' > "$REPO/docs/cycles/20260116_1000_z6.md"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "f6 links z6"
+  git -C "$REPO" rm -q docs/cycles/20260116_1000_z6.md
+  git -C "$REPO" commit -qm "delete z6 doc"
+
+  # TC-S8: six candidate docs (all tied) -> default run caps at 5 lines, TSV format.
+  printf 'e\n' > "$REPO/f8.txt"
+  printf '1\n' > "$REPO/docs/cycles/20260301_1000_d81.md"
+  printf '2\n' > "$REPO/docs/cycles/20260302_1000_d82.md"
+  printf '3\n' > "$REPO/docs/cycles/20260303_1000_d83.md"
+  printf '4\n' > "$REPO/docs/cycles/20260304_1000_d84.md"
+  printf '5\n' > "$REPO/docs/cycles/20260305_1000_d85.md"
+  printf '6\n' > "$REPO/docs/cycles/20260306_1000_d86.md"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "f8 links 6 docs"
+
+  # TC-S10: doc moved to archive/ after the linking commit -> resolves to current path.
+  printf 'w\n' > "$REPO/f10.txt"
+  printf 'old\n' > "$REPO/docs/cycles/20260117_1000_old10.md"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "seed f10 old10"
+  git -C "$REPO" mv docs/cycles/20260117_1000_old10.md docs/cycles/archive/20260117_1000_old10.md
+  git -C "$REPO" commit -qm "archive old10"
+
+  # TC-S11: same (file, doc) pair touched by 3 commits -> unique-pair contribution once.
+  printf 'p1\n' > "$REPO/f11.txt"; printf 'd1\n' > "$REPO/docs/cycles/20260118_1000_d11.md"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "f11 d11 first"
+  printf 'p2\n' > "$REPO/f11.txt"; printf 'd2\n' > "$REPO/docs/cycles/20260118_1000_d11.md"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "f11 d11 second"
+  printf 'p3\n' > "$REPO/f11.txt"; printf 'd3\n' > "$REPO/docs/cycles/20260118_1000_d11.md"
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "f11 d11 third"
+}
+
+# run_recall <input files...> : captures RECALL_OUT / RECALL_ERR / RECALL_RC
+run_recall() {
+  local ef
+  ef=$(mktemp)
+  RECALL_OUT=$(bash "$SCRIPT" "$REPO" "$@" 2>"$ef"); RECALL_RC=$?
+  RECALL_ERR=$(cat "$ef"); rm -f "$ef"
+}
+
+build_fixture
+trap 'rm -rf "$REPO"' EXIT
+
+echo "=== recall-candidates.sh + spec forced-recall Tests ==="
+
+# --- TC-S1: trailer priority over co-change ---
+echo ""
+echo "TC-S1: trailer-linked doc wins; co-changed decoy in the same commit is ignored"
+if [ ! -f "$SCRIPT" ]; then
+  fail "TC-S1: scripts/recall-candidates.sh does not exist"
+else
+  run_recall f1.txt
+  has_a1=$(printf '%s\n' "$RECALL_OUT" | grep -cF "20260110_1000_a1.md" || true)
+  has_b1=$(printf '%s\n' "$RECALL_OUT" | grep -cF "20260110_1100_b1.md" || true)
+  if [ "$RECALL_RC" -eq 0 ] && [ "$has_a1" -ge 1 ] && [ "$has_b1" -eq 0 ]; then
+    pass "TC-S1: a1 (trailer) linked, b1 (co-change) suppressed"
+  else
+    fail "TC-S1: expected a1 present + b1 absent (rc=$RECALL_RC a1=$has_a1 b1=$has_b1)"
+  fi
+fi
+
+# --- TC-S2: co-change fallback (no trailer) ---
+echo ""
+echo "TC-S2: trailer-less commit links the co-changed cycle doc"
+if [ ! -f "$SCRIPT" ]; then
+  fail "TC-S2: scripts/recall-candidates.sh does not exist"
+else
+  run_recall f2.txt
+  has_c2=$(printf '%s\n' "$RECALL_OUT" | grep -cF "20260112_1000_c2.md" || true)
+  if [ "$RECALL_RC" -eq 0 ] && [ "$has_c2" -ge 1 ]; then
+    pass "TC-S2: c2 linked via co-change fallback"
+  else
+    fail "TC-S2: expected c2 present (rc=$RECALL_RC c2=$has_c2)"
+  fi
+fi
+
+# --- TC-S3: hub decay (IDF-style weighting) ---
+echo ""
+echo "TC-S3: leaf-derived doc (1/1) outranks hub-derived docs (1/3)"
+if [ ! -f "$SCRIPT" ]; then
+  fail "TC-S3: scripts/recall-candidates.sh does not exist"
+else
+  run_recall f3H.txt f3L.txt
+  first=$(printf '%s\n' "$RECALL_OUT" | head -1)
+  is_leaf=$(printf '%s\n' "$first" | grep -cF "20260113_1300_l3.md" || true)
+  # Characterization: a single pure-hub query yields all-tied scores presented
+  # newest-first — the documented, accepted behavior (decay is a relative weight
+  # across input files; it cannot differentiate a lone hub's own candidates).
+  run_recall f3H.txt
+  hub_first=$(printf '%s\n' "$RECALL_OUT" | head -1)
+  hub_is_newest=$(printf '%s\n' "$hub_first" | grep -cF "20260113_1200_h3c.md" || true)
+  hub_scores=$(printf '%s\n' "$RECALL_OUT" | cut -f1 | sort -u | grep -c . || true)
+  if [ "$RECALL_RC" -eq 0 ] && [ "$is_leaf" -ge 1 ] && [ "$hub_is_newest" -ge 1 ] && [ "$hub_scores" -eq 1 ]; then
+    pass "TC-S3: leaf doc l3 ranked first (hub decay) + lone-hub query ties newest-first (documented)"
+  elif [ "$is_leaf" -lt 1 ]; then
+    fail "TC-S3: expected l3 first (first=[$first])"
+  else
+    fail "TC-S3: lone-hub characterization mismatch (first=[$hub_first] distinct_scores=$hub_scores)"
+  fi
+fi
+
+# --- TC-S4: recency tie-break on equal score ---
+echo ""
+echo "TC-S4: equal-score docs tie-break by newer basename date"
+if [ ! -f "$SCRIPT" ]; then
+  fail "TC-S4: scripts/recall-candidates.sh does not exist"
+else
+  run_recall f4.txt
+  first=$(printf '%s\n' "$RECALL_OUT" | head -1)
+  is_new=$(printf '%s\n' "$first" | grep -cF "20260201_1000_new4.md" || true)
+  if [ "$RECALL_RC" -eq 0 ] && [ "$is_new" -ge 1 ]; then
+    pass "TC-S4: newer doc new4 ranked first on tie"
+  else
+    fail "TC-S4: expected new4 first (rc=$RECALL_RC first=[$first])"
+  fi
+fi
+
+# --- TC-S5: zero candidates + exit 0 ---
+echo ""
+echo "TC-S5: file linking to no cycle doc yields empty stdout + exit 0"
+if [ ! -f "$SCRIPT" ]; then
+  fail "TC-S5: scripts/recall-candidates.sh does not exist"
+else
+  run_recall f5.txt
+  if [ "$RECALL_RC" -eq 0 ] && [ -z "$RECALL_OUT" ]; then
+    pass "TC-S5: empty stdout, rc=0"
+  else
+    fail "TC-S5: expected empty stdout + rc 0 (rc=$RECALL_RC out=[$RECALL_OUT])"
+  fi
+fi
+
+# --- TC-S6: excluded non-existent doc reported on stderr ---
+echo ""
+echo "TC-S6: doc absent from current tree excluded from stdout + reported on stderr"
+if [ ! -f "$SCRIPT" ]; then
+  fail "TC-S6: scripts/recall-candidates.sh does not exist"
+else
+  run_recall f6.txt
+  has_z6=$(printf '%s\n' "$RECALL_OUT" | grep -cF "z6" || true)
+  err_lines=$(printf '%s\n' "$RECALL_ERR" | grep -c . || true)
+  if [ "$RECALL_RC" -eq 0 ] && [ "$has_z6" -eq 0 ] && [ "$err_lines" -ge 1 ]; then
+    pass "TC-S6: z6 excluded from stdout, exclusion reported on stderr"
+  else
+    fail "TC-S6: expected z6 absent + stderr report (rc=$RECALL_RC z6=$has_z6 err_lines=$err_lines)"
+  fi
+fi
+
+# --- TC-S7: idempotent (byte-identical output) ---
+echo ""
+echo "TC-S7: repeated run on identical input produces byte-identical output"
+if [ ! -f "$SCRIPT" ]; then
+  fail "TC-S7: scripts/recall-candidates.sh does not exist"
+else
+  run_recall f8.txt; out1="$RECALL_OUT"; rc1="$RECALL_RC"
+  run_recall f8.txt; out2="$RECALL_OUT"; rc2="$RECALL_RC"
+  if [ "$rc1" -eq 0 ] && [ "$rc2" -eq 0 ] && [ "$out1" = "$out2" ]; then
+    pass "TC-S7: output stable across runs"
+  else
+    fail "TC-S7: expected identical output (rc1=$rc1 rc2=$rc2 equal=$([ "$out1" = "$out2" ] && echo yes || echo no))"
+  fi
+fi
+
+# --- TC-S8: top-N cap (default 5) + TSV format ---
+echo ""
+echo "TC-S8: six candidates capped to 5 lines, each 'score<TAB>docs/cycles/...'"
+if [ ! -f "$SCRIPT" ]; then
+  fail "TC-S8: scripts/recall-candidates.sh does not exist"
+else
+  run_recall f8.txt
+  nlines=$(printf '%s\n' "$RECALL_OUT" | grep -c . || true)
+  badlines=$(printf '%s\n' "$RECALL_OUT" | awk -F'\t' '$0!=""{ if ($1 !~ /^[0-9]+(\.[0-9]+)?$/ || $2 !~ /^docs\/cycles\//) bad++ } END{print bad+0}')
+  if [ "$RECALL_RC" -eq 0 ] && [ "$nlines" -eq 5 ] && [ "$badlines" -eq 0 ]; then
+    pass "TC-S8: 5 lines, all well-formed TSV"
+  else
+    fail "TC-S8: expected 5 well-formed lines (rc=$RECALL_RC nlines=$nlines badlines=$badlines)"
+  fi
+fi
+
+# --- TC-S9: read-only (working tree + status unchanged) ---
+echo ""
+echo "TC-S9: script leaves working tree and git status unchanged (canonical acceptance pin)"
+if [ ! -f "$SCRIPT" ]; then
+  fail "TC-S9: scripts/recall-candidates.sh does not exist"
+else
+  before_status=$(git -C "$REPO" status --porcelain)
+  before_manifest=$( (cd "$REPO" && find . -type f -not -path './.git/*' | sort | xargs shasum 2>/dev/null | shasum) )
+  run_recall f1.txt
+  s9_rc=$RECALL_RC
+  after_status=$(git -C "$REPO" status --porcelain)
+  after_manifest=$( (cd "$REPO" && find . -type f -not -path './.git/*' | sort | xargs shasum 2>/dev/null | shasum) )
+  if [ "$s9_rc" -eq 0 ] && [ "$before_status" = "$after_status" ] && [ "$before_manifest" = "$after_manifest" ]; then
+    pass "TC-S9: script succeeded (rc=0) and tree + status identical before/after"
+  elif [ "$s9_rc" -ne 0 ]; then
+    fail "TC-S9: script run failed (rc=$s9_rc) — unchanged tree is vacuous without a successful run"
+  else
+    fail "TC-S9: working tree or status mutated by script run"
+  fi
+fi
+
+# --- TC-S10: archive two-stage path resolution ---
+echo ""
+echo "TC-S10: doc moved under docs/cycles/archive/ resolves to its current path (not excluded)"
+if [ ! -f "$SCRIPT" ]; then
+  fail "TC-S10: scripts/recall-candidates.sh does not exist"
+else
+  run_recall f10.txt
+  has_arch=$(printf '%s\n' "$RECALL_OUT" | grep -cF "docs/cycles/archive/20260117_1000_old10.md" || true)
+  if [ "$RECALL_RC" -eq 0 ] && [ "$has_arch" -ge 1 ]; then
+    pass "TC-S10: archive path resolved and present in output"
+  else
+    fail "TC-S10: expected archive path present (rc=$RECALL_RC arch=$has_arch out=[$RECALL_OUT])"
+  fi
+fi
+
+# --- TC-S11: unique (file, doc) pair dedup ---
+echo ""
+echo "TC-S11: same pair across 3 commits contributes once (score not tripled)"
+if [ ! -f "$SCRIPT" ]; then
+  fail "TC-S11: scripts/recall-candidates.sh does not exist"
+else
+  run_recall f11.txt
+  occ=$(printf '%s\n' "$RECALL_OUT" | grep -cF "20260118_1000_d11.md" || true)
+  d11_line=$(printf '%s\n' "$RECALL_OUT" | grep -F "20260118_1000_d11.md" | head -1)
+  d11_score=$(printf '%s\n' "$d11_line" | cut -f1)
+  score_is_one=$(awk -v s="$d11_score" 'BEGIN{ if (s==1) print 1; else print 0 }')
+  if [ "$RECALL_RC" -eq 0 ] && [ "$occ" -eq 1 ] && [ "$score_is_one" -eq 1 ]; then
+    pass "TC-S11: d11 appears once with unique-pair score 1 (not 3)"
+  else
+    fail "TC-S11: expected single occurrence + score 1 (rc=$RECALL_RC occ=$occ score=[$d11_score])"
+  fi
+fi
+
+# --- TC-D1: spec/SKILL.md Step 7.2 wiring + under 100 lines ---
+echo ""
+echo "TC-D1: skills/spec/SKILL.md Step 7 region references recall-candidates.sh + '## Recall'; file < 100 lines"
+SPEC_SKILL="$BASE_DIR/skills/spec/SKILL.md"
+if [ ! -f "$SPEC_SKILL" ]; then
+  fail "TC-D1: skills/spec/SKILL.md does not exist"
+else
+  # Region: from the Step 7 heading up to (excluding) the Step 8 heading — robust to
+  # whether Step 7.2 is a bold sub-item or a nested ### heading.
+  step7_region=$(awk '/^### Step 7/{f=1} /^### Step 8/{f=0} f' "$SPEC_SKILL")
+  has_script=$(printf '%s\n' "$step7_region" | grep -cF "recall-candidates.sh" || true)
+  has_recall=$(printf '%s\n' "$step7_region" | grep -cF "## Recall" || true)
+  d1_lines=$(wc -l < "$SPEC_SKILL" | tr -d ' ')
+  if [ "$has_script" -ge 1 ] && [ "$has_recall" -ge 1 ] && [ "$d1_lines" -lt 100 ]; then
+    pass "TC-D1: Step 7 wires recall-candidates.sh + ## Recall; SKILL.md is $d1_lines lines"
+  elif [ "$has_script" -lt 1 ]; then
+    fail "TC-D1: Step 7 region missing 'recall-candidates.sh' reference"
+  elif [ "$has_recall" -lt 1 ]; then
+    fail "TC-D1: Step 7 region missing '## Recall' recording instruction"
+  else
+    fail "TC-D1: SKILL.md must stay under 100 lines (is $d1_lines)"
+  fi
+fi
+
+# --- TC-D2: reference.md + reference.ja.md forced-recall section + template ordering ---
+echo ""
+echo "TC-D2: both reference files carry #forced-recall advisory triad + no-match line + Template '## Recall' before Plan Review Record"
+d2_ok=1
+d2_msg=""
+for f in reference.md reference.ja.md; do
+  ref="$BASE_DIR/skills/spec/$f"
+  if [ ! -f "$ref" ]; then
+    d2_ok=0; d2_msg="$d2_msg $f:missing"; continue
+  fi
+  fr=$(section_lines "$ref" "## Forced Recall" 2)
+  c_what=$(printf '%s\n' "$fr" | grep -cF "何が起きたか" || true)
+  c_assume=$(printf '%s\n' "$fr" | grep -cF "当時の前提" || true)
+  c_same=$(printf '%s\n' "$fr" | grep -cF "今回も同じ前提か" || true)
+  c_none=$(printf '%s\n' "$fr" | grep -cF "関連する過去サイクルなし" || true)
+  tmpl=$(section_lines "$ref" "## Plan File Template" 2)
+  recall_ln=$(printf '%s\n' "$tmpl" | grep -nF "## Recall" | head -1 | cut -d: -f1)
+  prr_ln=$(printf '%s\n' "$tmpl" | grep -nF "## Plan Review Record" | head -1 | cut -d: -f1)
+  order_ok=0
+  if [ -n "$recall_ln" ] && [ -n "$prr_ln" ] && [ "$recall_ln" -lt "$prr_ln" ]; then
+    order_ok=1
+  fi
+  if [ "$c_what" -ge 1 ] && [ "$c_assume" -ge 1 ] && [ "$c_same" -ge 1 ] && [ "$c_none" -ge 1 ] && [ "$order_ok" -eq 1 ]; then
+    :
+  else
+    d2_ok=0
+    d2_msg="$d2_msg $f(what=$c_what assume=$c_assume same=$c_same none=$c_none order=$order_ok)"
+  fi
+done
+if [ "$d2_ok" -eq 1 ]; then
+  pass "TC-D2: forced-recall triad + no-match line + Template ordering present in both languages"
+else
+  fail "TC-D2: reference contract incomplete:$d2_msg"
+fi
+
+# --- TC-D3: sync-plan transcription row + cycle template section (negative Retrospective) ---
+echo ""
+echo "TC-D3: sync-plan.md transcription table has a '## Recall' row; cycle.md has '## Recall' + no '## Retrospective'"
+SYNC="$BASE_DIR/agents/sync-plan.md"
+CYCLE_TMPL="$BASE_DIR/skills/spec/templates/cycle.md"
+d3_ok=1
+d3_msg=""
+if [ ! -f "$SYNC" ]; then
+  d3_ok=0; d3_msg="$d3_msg sync-plan:missing"
+else
+  step2=$(section_lines "$SYNC" "### Step 2" 3)
+  sync_row=$(printf '%s\n' "$step2" | grep -cF "## Recall" || true)
+  [ "$sync_row" -ge 1 ] || { d3_ok=0; d3_msg="$d3_msg no-recall-row($sync_row)"; }
+fi
+if [ ! -f "$CYCLE_TMPL" ]; then
+  d3_ok=0; d3_msg="$d3_msg cycle-tmpl:missing"
+else
+  tmpl_recall=$(grep -cF "## Recall" "$CYCLE_TMPL" || true)
+  tmpl_retro=$(grep -cF "## Retrospective" "$CYCLE_TMPL" || true)
+  [ "$tmpl_recall" -ge 1 ] || { d3_ok=0; d3_msg="$d3_msg no-recall-section($tmpl_recall)"; }
+  [ "$tmpl_retro" -eq 0 ] || { d3_ok=0; d3_msg="$d3_msg retrospective-present($tmpl_retro)"; }
+fi
+if [ "$d3_ok" -eq 1 ]; then
+  pass "TC-D3: transcription row + cycle template ## Recall present; ## Retrospective absent"
+else
+  fail "TC-D3: transcription/template wiring incomplete:$d3_msg"
+fi
+
+# --- TC-R1 (regression): test-post-approve-ordering non-破壊 proxy ---
+# The spec edits (Step 7.2 + L83/L95 compression) must not break TC-R4's contract:
+# SKILL.md keeps its Step 8 heading + --sandbox read-only clause and stays under 100 lines.
+echo ""
+echo "TC-R1 (regression): skills/spec/SKILL.md keeps '### Step 8' + '--sandbox read-only' + < 100 lines"
+if [ ! -f "$SPEC_SKILL" ]; then
+  fail "TC-R1: skills/spec/SKILL.md does not exist"
+else
+  r1_step8=$(grep -c "^### Step 8" "$SPEC_SKILL" || true)
+  r1_sandbox=$(grep -cF -- "--sandbox read-only" "$SPEC_SKILL" || true)
+  r1_lines=$(wc -l < "$SPEC_SKILL" | tr -d ' ')
+  if [ "$r1_step8" -ge 1 ] && [ "$r1_sandbox" -ge 1 ] && [ "$r1_lines" -lt 100 ]; then
+    pass "TC-R1: Step 8 + --sandbox read-only intact; SKILL.md $r1_lines lines"
+  else
+    fail "TC-R1: post-approve-ordering pins broken (step8=$r1_step8 sandbox=$r1_sandbox lines=$r1_lines)"
+  fi
+fi
+
+# --- TC-R2 (regression): ja Plan File Template + hash boundary non-破壊 proxy ---
+# The reference.ja.md edits (Forced Recall + template ## Recall) must not disturb the
+# pinned template structure (## TDD Context / ## Plan Review Record boundary / ## Post-Approve Action).
+echo ""
+echo "TC-R2 (regression): reference.ja.md Plan File Template retains TDD Context + Plan Review Record boundary + Post-Approve Action"
+REF_JA="$BASE_DIR/skills/spec/reference.ja.md"
+if [ ! -f "$REF_JA" ]; then
+  fail "TC-R2: skills/spec/reference.ja.md does not exist"
+else
+  ja_tmpl=$(section_lines "$REF_JA" "## Plan File Template" 2)
+  r2_ctx=$(printf '%s\n' "$ja_tmpl" | grep -cF "## TDD Context" || true)
+  r2_prr=$(printf '%s\n' "$ja_tmpl" | grep -cF "## Plan Review Record" || true)
+  r2_post=$(printf '%s\n' "$ja_tmpl" | grep -cF "## Post-Approve Action" || true)
+  if [ "$r2_ctx" -ge 1 ] && [ "$r2_prr" -ge 1 ] && [ "$r2_post" -ge 1 ]; then
+    pass "TC-R2: ja template structure + Plan Review Record boundary intact"
+  else
+    fail "TC-R2: ja template pins broken (ctx=$r2_ctx prr=$r2_prr post=$r2_post)"
+  fi
+fi
+
+# Summary
+echo ""
+echo "=== Summary ==="
+echo "PASS: $PASS / FAIL: $FAIL / TOTAL: $((PASS + FAIL))"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- **spec Step 7.2 Forced Recall**: Files to Change 確定直後に `scripts/recall-candidates.sh`（新規・決定論）が関連 cycle doc 上位 5 件を算出し、助言者形式 3 点セットで plan の `## Recall` に記録（hash 領域内 = 承認後改変から保護、R4 計測の信頼基盤）。pull 型検索を廃しワークフロー固定点で必ず発火
- スコアリング: Cycle-Doc トレーラー優先 / 共変更 fallback / unique (F,doc) ペア上のハブ減衰（1/count）/ archive 二段パス解決（37 doc を除外しない）/ 正本変更ゼロ（TC-S9 で pin）
- 配線: reference 両言語（byte-identical lockstep）+ Plan File Template + sync-plan 転記テーブル + cycle template。Test Scripts 114→115
- 初の fixture git repo テストパターン導入（mktemp + git -C init + 環境固定、16TC）

## Review / 再承認
- Plan review: Codex BLOCK 3 件（archive 誤除外 / ペア重複排除 / exit 伝搬）反映 → attempt 2 **PASS**
- Code review: 13 findings triage（accept-apply 5 / defer 4 群 → #185 / reject 1）。design BLOCK 2 件を解消 — Step 7.2 の発火位置矛盾（実行順トレースで検出→移設）、単一ハブ縮退の設計主張反転（**AskUserQuestion 再承認で許容仕様化**、両言語文書化 + characterization TC）
- 最終: recall テスト 16/16、full suite 115/115、real-path 実測（トレーラー確定リンクが 1 位・TREE UNCHANGED）

Refs #187 #185
Cycle doc: docs/cycles/20260723_1328_spec-forced-recall.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)