### PR TITLE
chore: release v2.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "dev-crew",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "source": "./",
       "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-crew",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "AI development team environment. TDD workflow, security audit, pattern learning, and phase-boundary compaction.",
   "author": {
     "name": "morodomi"

--- a/.claude/dev-crew.json
+++ b/.claude/dev-crew.json
@@ -1,5 +1,5 @@
 {
-  "dev_crew_version": "2.14.0",
+  "dev_crew_version": "2.15.0",
   "review_policy": {
     "reviewer_model": "self",
     "escalate_high_to": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.15.0] - 2026-07-27
 
 ### Added
 - spec に強制想起（Forced Recall、Step 7.2）を追加（#187）: Files to Change 確定後・Step 8 の前に `scripts/recall-candidates.sh` を実行し、変更予定ファイルに関連する過去 cycle doc を決定論的に提示する。データソースは既存のもののみ（`git log --name-only` の共変更 + Cycle-Doc トレーラーの確定リンク優先）で、ハブファイルは IDF 相当で寄与を減衰。上位候補を助言者形式 3 点セット（何が起きたか / 当時の前提 / 今回も同じ前提か）で plan の `## Recall` に記録し、sync-plan が Cycle doc へ転記する。正本変更ゼロ・冪等・常駐プロセスなし


### PR DESCRIPTION
Version bump to 2.15.0

- 強制想起 3 部作（Cycle-Doc トレーラー / 想起漏れ計測設問 / spec Step 7.2 Forced Recall）
- codified rules batch 19 件
- dev_crew_version 同期（Version Gate 整合維持）
- CHANGELOG [Unreleased] → [2.15.0]

🤖 Generated with [Claude Code](https://claude.com/claude-code)